### PR TITLE
proof generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6114,6 +6114,7 @@ dependencies = [
  "alloy-core",
  "hex",
  "mockito",
+ "regex",
  "reqwest 0.12.9",
  "ruint",
  "semaphore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +997,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
+dependencies = [
+ "brotli",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1060,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
@@ -1177,6 +1221,27 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1436,6 +1501,16 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static 1.5.0",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "combine"
@@ -2457,6 +2532,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2749,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2678,9 +2772,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3306,6 +3402,30 @@ dependencies = [
  "thiserror 1.0.69",
  "widestring",
  "windows",
+]
+
+[[package]]
+name = "mockito"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -4030,6 +4150,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,7 +4216,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
@@ -4102,7 +4234,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -4119,11 +4251,14 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4147,6 +4282,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4788,6 +4924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,7 +5147,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5013,6 +5166,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5236,6 +5399,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5949,8 +6113,11 @@ dependencies = [
  "alloy",
  "alloy-core",
  "hex",
+ "mockito",
+ "reqwest 0.12.9",
  "ruint",
  "semaphore",
+ "serde",
  "serde_json",
  "strum",
  "thiserror 2.0.3",

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "aarch",
     "clippy",
     "foundryup",
+    "merkle",
     "ruint",
     "Uniffi",
     "WalletKit",

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -23,8 +23,10 @@ name = "walletkit_core"
 [dependencies]
 alloy-core = { version = "0.8.12", default-features = false, features = ["sol-types"] }
 hex = "0.4.3"
+reqwest = { version = "0.12.9", features = ["json", "brotli"] }
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 semaphore = { git = "https://github.com/worldcoin/semaphore-rs", rev = "f266248", features = ["depth_30"] }
+serde = "1.0.215"
 serde_json = "1.0.133"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "2.0.3"
@@ -32,4 +34,5 @@ uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 alloy = { version = "0.6.4", default-features = false, features = ["json", "contract", "node-bindings"] }
+mockito = "1.6.1"
 tokio = "1.41.1"

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -35,4 +35,5 @@ uniffi = { workspace = true, features = ["build"] }
 [dev-dependencies]
 alloy = { version = "0.6.4", default-features = false, features = ["json", "contract", "node-bindings"] }
 mockito = "1.6.1"
+regex = "1.11.1"
 tokio = "1.41.1"

--- a/walletkit-core/src/credential_type.rs
+++ b/walletkit-core/src/credential_type.rs
@@ -1,5 +1,7 @@
 use strum::EnumString;
 
+use crate::Environment;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Object, EnumString, Hash)]
 #[strum(serialize_all = "snake_case")]
 pub enum CredentialType {
@@ -26,6 +28,33 @@ impl CredentialType {
             Self::Device => b"phone_credential",
             Self::Passport => b"passport",
             Self::SecurePassport => b"secure_passport",
+        }
+    }
+
+    /// Returns the host name for the relevant sign up sequencer to use. The sign up sequencer is used to fetch Merkle inclusion proofs.
+    ///
+    /// [Reference](https://github.com/worldcoin/signup-sequencer)
+    ///
+    /// # Future
+    /// - Support custom sign up sequencer hosts
+    #[must_use]
+    pub fn get_sign_up_sequencer_host(&self, environment: &Environment) -> &str {
+        if environment == &Environment::Staging {
+            match self {
+                Self::Orb => "signup-orb-ethereum.stage-crypto.worldcoin.org",
+                Self::Device => "signup-phone-ethereum.stage-crypto.worldcoin.org",
+                Self::Passport => "signup-document.stage-crypto.worldcoin.org",
+                Self::SecurePassport => {
+                    "signup-document-secure.stage-crypto.worldcoin.org"
+                }
+            }
+        } else {
+            match self {
+                Self::Orb => "signup-orb-ethereum.crypto.worldcoin.org",
+                Self::Device => "signup-phone-ethereum.crypto.worldcoin.org",
+                Self::Passport => "signup-document.crypto.worldcoin.org",
+                Self::SecurePassport => "signup-document-secure.crypto.worldcoin.org",
+            }
         }
     }
 }

--- a/walletkit-core/src/credential_type.rs
+++ b/walletkit-core/src/credential_type.rs
@@ -41,19 +41,23 @@ impl CredentialType {
     pub fn get_sign_up_sequencer_host(&self, environment: &Environment) -> &str {
         if environment == &Environment::Staging {
             match self {
-                Self::Orb => "signup-orb-ethereum.stage-crypto.worldcoin.org",
-                Self::Device => "signup-phone-ethereum.stage-crypto.worldcoin.org",
-                Self::Passport => "signup-document.stage-crypto.worldcoin.org",
+                Self::Orb => "https://signup-orb-ethereum.stage-crypto.worldcoin.org",
+                Self::Device => {
+                    "https://signup-phone-ethereum.stage-crypto.worldcoin.org"
+                }
+                Self::Passport => "https://signup-document.stage-crypto.worldcoin.org",
                 Self::SecurePassport => {
-                    "signup-document-secure.stage-crypto.worldcoin.org"
+                    "https://signup-document-secure.stage-crypto.worldcoin.org"
                 }
             }
         } else {
             match self {
-                Self::Orb => "signup-orb-ethereum.crypto.worldcoin.org",
-                Self::Device => "signup-phone-ethereum.crypto.worldcoin.org",
-                Self::Passport => "signup-document.crypto.worldcoin.org",
-                Self::SecurePassport => "signup-document-secure.crypto.worldcoin.org",
+                Self::Orb => "https://signup-orb-ethereum.crypto.worldcoin.org",
+                Self::Device => "https://signup-phone-ethereum.crypto.worldcoin.org",
+                Self::Passport => "https://signup-document.crypto.worldcoin.org",
+                Self::SecurePassport => {
+                    "https://signup-document-secure.crypto.worldcoin.org"
+                }
             }
         }
     }

--- a/walletkit-core/src/credential_type.rs
+++ b/walletkit-core/src/credential_type.rs
@@ -38,9 +38,9 @@ impl CredentialType {
     /// # Future
     /// - Support custom sign up sequencer hosts
     #[must_use]
-    pub fn get_sign_up_sequencer_host(&self, environment: &Environment) -> &str {
-        if environment == &Environment::Staging {
-            match self {
+    pub const fn get_sign_up_sequencer_host(&self, environment: &Environment) -> &str {
+        match environment {
+            Environment::Production => match self {
                 Self::Orb => "https://signup-orb-ethereum.stage-crypto.worldcoin.org",
                 Self::Device => {
                     "https://signup-phone-ethereum.stage-crypto.worldcoin.org"
@@ -49,16 +49,15 @@ impl CredentialType {
                 Self::SecurePassport => {
                     "https://signup-document-secure.stage-crypto.worldcoin.org"
                 }
-            }
-        } else {
-            match self {
+            },
+            Environment::Staging => match self {
                 Self::Orb => "https://signup-orb-ethereum.crypto.worldcoin.org",
                 Self::Device => "https://signup-phone-ethereum.crypto.worldcoin.org",
                 Self::Passport => "https://signup-document.crypto.worldcoin.org",
                 Self::SecurePassport => {
                     "https://signup-document-secure.crypto.worldcoin.org"
                 }
-            }
+            },
         }
     }
 }

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -3,6 +3,12 @@ use thiserror::Error;
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum Error {
-    #[error("fetching_inclusion_proof_failed")]
-    FetchingInclusionProofFailed,
+    #[error("invalid_input")]
+    InvalidInput,
+    #[error("invalid_number")] // Number is not a valid U256 integer
+    InvalidNumber,
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    ProofGeneration(#[from] semaphore::protocol::ProofError),
 }

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     InvalidInput,
     #[error("invalid_number")] // Number is not a valid U256 integer
     InvalidNumber,
+    #[error("serialization_error")]
+    SerializationError,
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
     #[error(transparent)]

--- a/walletkit-core/src/identity.rs
+++ b/walletkit-core/src/identity.rs
@@ -130,13 +130,34 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
     #[test]
-    fn test() {
-        // FIXME: incomplete test
+    fn test_proof_generation() {
+        // TODO: complete test
         let identity = Identity::new(b"not_a_real_secret", &Environment::Staging);
         let context = Context::new("app_id", None, None, Arc::new(CredentialType::Orb));
         let nullifier_hash = identity.generate_nullifier_hash(&context);
         println!("{}", nullifier_hash.to_hex_string());
+    }
+
+    #[test]
+    const fn test_proof_generation_for_alt_credential() {
+        // TODO: implement me
+    }
+
+    #[test]
+    const fn test_proof_generation_with_simple_signal() {
+        // TODO: implement me (string signal)
+    }
+
+    #[test]
+    const fn test_proof_generation_with_complex_signal() {
+        // TODO: implement me (e.g. ABI-encoded wallet address)
+    }
+
+    #[test]
+    const fn test_nullifier_hash_generation() {
+        // TODO: implement me
     }
 
     #[test]

--- a/walletkit-core/src/identity.rs
+++ b/walletkit-core/src/identity.rs
@@ -97,7 +97,7 @@ impl Identity {
         )
         .await?;
 
-        generate_proof_with_semaphore_identity(&identity, merkle_tree_proof, context)
+        generate_proof_with_semaphore_identity(&identity, &merkle_tree_proof, context)
     }
 }
 

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -1,9 +1,20 @@
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
 
+use strum::EnumString;
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Object, EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum Environment {
+    Staging,
+    Production,
+}
+
 pub mod credential_type;
 pub mod error;
 pub mod identity;
+mod merkle_tree;
 pub mod proof;
+mod request;
 pub mod u256;
 
 uniffi::setup_scaffolding!("walletkit_core");

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -1,0 +1,131 @@
+use ruint::aliases::U256;
+use semaphore::poseidon_tree::Proof;
+use serde::{Deserialize, Serialize};
+
+use crate::{error::Error, request::Request, u256::U256Wrapper};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SequencerBody {
+    identity_commitment: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InclusionProofResponse {
+    #[serde(deserialize_with = "deserialize_merkle_root")]
+    root: U256Wrapper,
+    proof: Proof,
+}
+
+fn deserialize_merkle_root<'de, D>(deserializer: D) -> Result<U256Wrapper, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let merkle_root = U256Wrapper::try_from_hex_string(&s).map_err(|e| {
+        serde::de::Error::custom(format!(
+            "merkle root received is not a valid number: {e}"
+        ))
+    })?;
+    Ok(merkle_root)
+}
+
+#[derive(Debug, uniffi::Object)]
+#[allow(clippy::module_name_repetitions)]
+pub struct MerkleTreeProof {
+    poseidon_proof: Proof,
+    pub merkle_root: U256Wrapper,
+}
+
+impl From<MerkleTreeProof> for Proof {
+    fn from(proof: MerkleTreeProof) -> Self {
+        proof.poseidon_proof
+    }
+}
+
+#[uniffi::export]
+impl MerkleTreeProof {
+    /// Retrieves a Merkle inclusion proof from the sign up sequencer for a given identity commitment.
+    /// Each credential/environment pair uses a different sign up sequencer.
+    ///
+    /// # Errors
+    /// Will throw an error if the request fails or parsing the response fails.
+    #[uniffi::constructor]
+    pub async fn from_identity_commitment(
+        identity_commitment: &U256Wrapper,
+        sequencer_host: &str,
+    ) -> Result<Self, Error> {
+        let url = format!("{sequencer_host}/inclusionProof");
+
+        // TODO: Cache inclusion proof for 10-15 mins
+        let body = SequencerBody {
+            identity_commitment: identity_commitment.to_hex_string(),
+        };
+
+        let request = Request::new();
+        let response = request
+            .post(url, body)
+            .await?
+            .json::<InclusionProofResponse>()
+            .await?;
+
+        Ok(Self {
+            poseidon_proof: response.proof,
+            merkle_root: response.root,
+        })
+    }
+
+    #[uniffi::constructor]
+    pub fn from_json_proof(json_proof: &str, merkle_root: &str) -> Result<Self, Error> {
+        let proof: Proof =
+            serde_json::from_str(json_proof).map_err(|_| Error::InvalidInput)?;
+
+        Ok(Self {
+            poseidon_proof: proof,
+            merkle_root: U256::from_str_radix(merkle_root, 16)
+                .map_err(|_| Error::InvalidInput)?
+                .into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{credential_type::CredentialType, identity::Identity, Environment};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_retrieve_merkle_proof_from_sequencer() {
+        let mut mock_server = mockito::Server::new_async().await;
+
+        mock_server
+            .mock("POST", "/inclusionProof")
+            .with_status(200)
+            .with_body(include_bytes!("../tests/fixtures/inclusion_proof.json"))
+            .create_async()
+            .await;
+
+        let identity = Identity::new(b"not_a_real_secret", &Environment::Staging);
+
+        let merkle_proof = MerkleTreeProof::from_identity_commitment(
+            &identity.get_identity_commitment(&CredentialType::Device),
+            &mock_server.url(),
+        )
+        .await
+        .unwrap();
+
+        drop(mock_server);
+
+        assert_eq!(
+            merkle_proof.merkle_root,
+            U256Wrapper::try_from_hex_string(
+                "0x2f3a95b6df9074a19bf46e2308d7f5696e9dca49e0d64ef49a1425bbf40e0c02"
+            )
+            .unwrap()
+        );
+
+        assert_eq!(merkle_proof.poseidon_proof.leaf_index(), 17_029_704);
+    }
+}

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -12,22 +12,8 @@ struct SequencerBody {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InclusionProofResponse {
-    #[serde(deserialize_with = "deserialize_merkle_root")]
     root: U256Wrapper,
     proof: Proof,
-}
-
-fn deserialize_merkle_root<'de, D>(deserializer: D) -> Result<U256Wrapper, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let merkle_root = U256Wrapper::try_from_hex_string(&s).map_err(|e| {
-        serde::de::Error::custom(format!(
-            "merkle root received is not a valid number: {e}"
-        ))
-    })?;
-    Ok(merkle_root)
 }
 
 #[derive(Debug, uniffi::Object)]
@@ -37,9 +23,11 @@ pub struct MerkleTreeProof {
     pub merkle_root: U256Wrapper,
 }
 
-impl From<MerkleTreeProof> for Proof {
-    fn from(proof: MerkleTreeProof) -> Self {
-        proof.poseidon_proof
+impl MerkleTreeProof {
+    /// Returns the Poseidon proof.
+    #[must_use]
+    pub const fn as_poseidon_proof(&self) -> &Proof {
+        &self.poseidon_proof
     }
 }
 

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -1,4 +1,3 @@
-use ruint::aliases::U256;
 use semaphore::poseidon_tree::Proof;
 use serde::{Deserialize, Serialize};
 
@@ -83,9 +82,8 @@ impl MerkleTreeProof {
 
         Ok(Self {
             poseidon_proof: proof,
-            merkle_root: U256::from_str_radix(merkle_root, 16)
-                .map_err(|_| Error::InvalidInput)?
-                .into(),
+            merkle_root: U256Wrapper::try_from_hex_string(merkle_root)
+                .map_err(|_| Error::InvalidInput)?,
         })
     }
 }

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -364,4 +364,21 @@ mod proof_tests {
         let re = Regex::new(packed_proof_pattern).unwrap();
         assert!(re.is_match(parsed_json["proof"].as_str().unwrap()));
     }
+
+    #[test]
+    const fn test_proof_generation_with_local_merkle_tree() {
+        // TODO: implement me
+    }
+
+    #[ignore = "To be run manually as it requires a call to the Sign up Sequencer"]
+    #[test]
+    fn test_proof_verification_with_sign_up_sequencer() {
+        todo!("implement me");
+    }
+
+    #[ignore = "To be run manually as it requires a call to the Developer Portal"]
+    #[test]
+    fn test_proof_verification_with_developer_portal() {
+        todo!("implement me");
+    }
 }

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -88,6 +88,12 @@ impl Context {
     }
 }
 
+/// Represents the complete output of a World ID Proof (i.e. a credential persentation). This output
+/// can be serialized to JSON and can be verified easily with the Developer Portal or Sign up Sequencer.
+///
+/// For on-chain verification, the `proof` (which is packed) should generally be deserialized into `uint256[8]`.
+///
+/// More information on: [On-Chain Verification](https://docs.world.org/world-id/id/on-chain)
 #[derive(Clone, PartialEq, Eq, Debug, uniffi::Object, Serialize)]
 pub struct Output {
     pub merkle_root: U256Wrapper,

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -33,8 +33,12 @@ impl Context {
     ///
     /// # Arguments
     ///
-    /// * `app_id` - The ID of the application requesting proofs. This can be obtained from the Developer Portal.
+    /// * `app_id` - The ID of the application requesting proofs.  This can be obtained from the [Developer Portal](https://developer.world.org).
     /// * `action` - Optional. Custom incognito action being requested.
+    /// * `signal` - Optional. The signal is included in the ZKP and is committed to in the proof. When verifying the proof, the
+    ///     same signal must be provided to ensure the proof is valid. The signal can be used to prevent replay attacks, MITM or other cases.
+    ///     More details available in the [docs](https://docs.world.org/world-id/further-reading/zero-knowledge-proofs).
+    /// * `credential_type` - The type of credential being requested.
     ///
     #[must_use]
     #[uniffi::constructor]
@@ -60,8 +64,7 @@ impl Context {
     ///
     /// # Arguments
     ///
-    /// * `app_id` - The ID of the application requesting proofs. This can be obtained from the Developer Portal.
-    /// * `action` - Optional. Custom incognito action being requested as raw bytes (*must be UTF-8*).
+    /// See `Context::new` for reference. The `action` and `signal` need to be provided as raw bytes.
     ///
     #[must_use]
     #[uniffi::constructor]
@@ -96,10 +99,17 @@ impl Context {
 /// More information on: [On-Chain Verification](https://docs.world.org/world-id/id/on-chain)
 #[derive(Clone, PartialEq, Eq, Debug, uniffi::Object, Serialize)]
 pub struct Output {
+    /// The root hash of the Merkle tree used to prove membership. This root hash should match published hashes in the World ID
+    ///     protocol contract in Ethereum mainnet. See [address book](https://docs.world.org/world-id/reference/address-book).
     pub merkle_root: U256Wrapper,
+    /// Represents the unique identifier for a specific context (app & action) and World ID. A World ID holder will always generate
+    /// the same `nullifier_hash` for the same context.
     pub nullifier_hash: U256Wrapper,
+    /// The raw zero-knowledge proof.
     #[serde(skip_serializing)]
     pub raw_proof: Proof,
+    /// The ABI-encoded zero-knowledge proof represented as a string. This is the format generally used with other libraries and
+    /// can be directly used with the Developer Portal for verification.
     pub proof: PackedProof,
 }
 

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -126,19 +126,18 @@ impl Output {
 /// Returns an error if proof generation fails
 pub fn generate_proof_with_semaphore_identity(
     identity: &identity::Identity,
-    merkle_tree_proof: MerkleTreeProof,
+    merkle_tree_proof: &MerkleTreeProof,
     context: &Context,
 ) -> Result<Output, Error> {
     let merkle_root = merkle_tree_proof.merkle_root; // clone the value
 
-    let merkle_proof = semaphore::poseidon_tree::Proof::from(merkle_tree_proof);
     let external_nullifier_hash = context.external_nullifier.into();
     let nullifier_hash =
         generate_nullifier_hash(identity, external_nullifier_hash).into();
 
     let proof = generate_proof(
         identity,
-        &merkle_proof,
+        merkle_tree_proof.as_poseidon_proof(),
         external_nullifier_hash,
         context.signal.into(),
     )?;
@@ -308,7 +307,7 @@ mod proof_tests {
         // Compute ZKP
         let zkp = generate_proof_with_semaphore_identity(
             &identity,
-            helper_load_merkle_proof(),
+            &helper_load_merkle_proof(),
             &context,
         )
         .unwrap();
@@ -353,7 +352,7 @@ mod proof_tests {
         // Compute ZKP
         let zkp = generate_proof_with_semaphore_identity(
             &identity,
-            helper_load_merkle_proof(),
+            &helper_load_merkle_proof(),
             &context,
         )
         .unwrap();

--- a/walletkit-core/src/request.rs
+++ b/walletkit-core/src/request.rs
@@ -2,16 +2,20 @@ use std::time::Duration;
 
 use serde::ser::Serialize;
 
+/// A simple wrapper on an HTTP client for making requests. Sets sensible defaults such as timeouts,
+/// user-agent & ensuring HTTPS.
 pub struct Request {
     client: reqwest::Client,
 }
 
 impl Request {
+    /// Initializes a new `Request` instance.
     pub(crate) fn new() -> Self {
         let client = reqwest::Client::new();
         Self { client }
     }
 
+    /// Makes a POST request to a given URL with a JSON body.
     pub(crate) async fn post<T>(
         &self,
         url: String,

--- a/walletkit-core/src/request.rs
+++ b/walletkit-core/src/request.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use serde::ser::Serialize;
+
+pub struct Request {
+    client: reqwest::Client,
+}
+
+impl Request {
+    pub(crate) fn new() -> Self {
+        let client = reqwest::Client::new();
+        Self { client }
+    }
+
+    pub(crate) async fn post<T>(
+        &self,
+        url: String,
+        body: T,
+    ) -> Result<reqwest::Response, reqwest::Error>
+    where
+        T: Serialize + Send + Sync,
+    {
+        #[cfg(not(test))]
+        assert!(url.starts_with("https"));
+
+        self.client
+            .post(&url)
+            .timeout(Duration::from_secs(3))
+            .header(
+                "User-Agent",
+                format!("walletkit-core/{}", env!("CARGO_PKG_VERSION")),
+            )
+            .json(&body)
+            .send()
+            .await
+    }
+}

--- a/walletkit-core/src/u256.rs
+++ b/walletkit-core/src/u256.rs
@@ -1,6 +1,8 @@
 use std::ops::Deref;
 
+use crate::error::Error;
 use ruint::aliases::U256;
+use serde::{Deserialize, Serialize};
 
 /// A wrapper around `U256` to represent a field element in the protocol. Wrapper enables FFI interoperability.
 ///
@@ -16,9 +18,24 @@ pub struct U256Wrapper(pub U256);
 
 #[uniffi::export]
 impl U256Wrapper {
+    /// Outputs a hex string representation of the `U256` value padded to 32 bytes (plus two bytes for the `0x` prefix).
     #[must_use]
     pub fn to_hex_string(&self) -> String {
-        format!("0x{}", hex::encode(self.0.to_be_bytes::<32>()))
+        format!("{:#066x}", self.0)
+    }
+
+    /// Attempts to parse a hex string as a `U256` value (wrapped).
+    ///
+    /// # Errors
+    /// Will return an `Error::InvalidNumber` if the input is not a valid hex-string-presented number up to 256 bits.
+    #[uniffi::constructor]
+    pub fn try_from_hex_string(hex_string: &str) -> Result<Self, Error> {
+        let hex_string = hex_string.trim().trim_start_matches("0x");
+
+        let number =
+            U256::from_str_radix(hex_string, 16).map_err(|_| Error::InvalidNumber)?;
+
+        Ok(Self(number))
     }
 }
 
@@ -45,6 +62,26 @@ impl Deref for U256Wrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+// JSON serializing for U256Wrapper
+impl Serialize for U256Wrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_hex_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for U256Wrapper {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::try_from_hex_string(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -83,6 +120,70 @@ mod tests {
             ))
             .to_hex_string(),
             "0x036b6384b5eca791c62761152d0c79bb0604c104a5fb6f4eb0703f3154bb3db0"
+        );
+    }
+
+    #[test]
+    fn test_from_hex_string_for_u256() {
+        assert_eq!(
+            U256Wrapper::try_from_hex_string(
+                "0x0000000000000000000000000000000000000000000000000000000000000001"
+            )
+            .unwrap(),
+            U256Wrapper(U256::from(1))
+        );
+        assert_eq!(
+            U256Wrapper::try_from_hex_string(
+                "0x000000000000000000000000000000000000000000000000000000000000002a"
+            )
+            .unwrap(),
+            U256Wrapper(U256::from(42))
+        );
+
+        assert_eq!(
+            U256Wrapper::try_from_hex_string(
+                "0x00000000000000000000000000000000000000000000000000000000000f423f"
+            )
+            .unwrap(),
+            U256Wrapper(uint!(999999_U256))
+        );
+
+        assert_eq!(
+            U256Wrapper::try_from_hex_string("0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6").unwrap(),
+            U256Wrapper(uint!(
+                80084422859880547211683076133703299733277748156566366325829078699459944778998_U256
+            ))
+        );
+
+        assert_eq!(
+            U256Wrapper::try_from_hex_string(
+                "0x036b6384b5eca791c62761152d0c79bb0604c104a5fb6f4eb0703f3154bb3db0"
+            )
+            .unwrap()
+            .0,
+            uint!(
+                0x036b6384b5eca791c62761152d0c79bb0604c104a5fb6f4eb0703f3154bb3db0_U256
+            )
+        );
+    }
+
+    #[test]
+    fn test_invalid_hex_string() {
+        assert!(U256Wrapper::try_from_hex_string("0xZZZZ").is_err());
+        assert!(U256Wrapper::try_from_hex_string("1g").is_err());
+        assert!(U256Wrapper::try_from_hex_string("not a hex string").is_err());
+    }
+
+    #[test]
+    fn test_json_serializing() {
+        let number = U256Wrapper(uint!(
+            0x036b6384b5eca791c62761152d0c79bb0604c104a5fb6f4eb0703f3154bb3db0_U256
+        ));
+
+        let json = serde_json::to_string(&number).unwrap();
+        assert_eq!(
+            json,
+            "\"0x036b6384b5eca791c62761152d0c79bb0604c104a5fb6f4eb0703f3154bb3db0\""
         );
     }
 }

--- a/walletkit-core/src/u256.rs
+++ b/walletkit-core/src/u256.rs
@@ -65,7 +65,6 @@ impl Deref for U256Wrapper {
     }
 }
 
-// JSON serializing for U256Wrapper
 impl Serialize for U256Wrapper {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/walletkit-core/tests/fixtures/inclusion_proof.json
+++ b/walletkit-core/tests/fixtures/inclusion_proof.json
@@ -1,0 +1,96 @@
+{
+  "status": "mined",
+  "root": "0x2f3a95b6df9074a19bf46e2308d7f5696e9dca49e0d64ef49a1425bbf40e0c02",
+  "proof": [
+    {
+      "Left": "0x32871aefcc49f9c68c228fc07c1e9c948aae38c510b99b93fe84f4692a1159e"
+    },
+    {
+      "Left": "0x14cece5d8b7610f54e34ab2bba11f9e6437ea377006b194eb7b4bed7f8af9aa0"
+    },
+    {
+      "Left": "0xe4d484bd2f786ea2da0f4b7a3e02e14bb53413308c4cc21b2796d4909a5aff6"
+    },
+    {
+      "Right": "0x20df04fc727746bf92e5c75a3353ff1de5d3165d13a810bb67d9e9abcc327bb3"
+    },
+    {
+      "Left": "0x187a87e4d4b8abca8deb18ca8a2e8c3b3d36b8613af8eb8ebb3dd0075507ceac"
+    },
+    {
+      "Left": "0x242cbbae351f1eed0a8d41dfc85eb708c170996066f0a2191209712fdf7f28f6"
+    },
+    {
+      "Right": "0x40866463fb04aa0e9677ec5d2e3a96254593c9e5dd8c92649f96e805ea5f003"
+    },
+    {
+      "Left": "0x78295e5a22b84e982cf601eb639597b8b0515a88cb5ac7fa8a4aabe3c87349d"
+    },
+    {
+      "Left": "0x2fa5e5f18f6027a6501bec864564472a616b2e274a41211a444cbe3a99f3cc61"
+    },
+    {
+      "Right": "0xa8fca5d93251a3e46c9bdc6c119e8ed1ecf125b5f383eb16d80ebb9bebf2c29"
+    },
+    {
+      "Left": "0x1b7201da72494f1e28717ad1a52eb469f95892f957713533de6175e5da190af2"
+    },
+    {
+      "Right": "0x29588f6783ba8e3161b752bf196917c4dba7fcdb7bf26e16ec1431e43caf4f7b"
+    },
+    {
+      "Right": "0xac6768a33a7d86ec72897d48197bfa075c580485122bff02162b516a1b4ddb6"
+    },
+    {
+      "Left": "0x14c54148a0940bb820957f5adf3fa1134ef5c4aaa113f4646458f270e0bfbfd0"
+    },
+    {
+      "Right": "0x14d4bcfe121be97d2e899610189abadb496d3993912324d76b89ba1237110f03"
+    },
+    {
+      "Right": "0x2667f065b4ecca4a33f295c2e6c515f982b7b8ec1398d5acdd9c894544a3ad31"
+    },
+    {
+      "Right": "0x1ec8877ca7755a7f37e0ecbee0456d318366c524713146bdef102181b3d026cc"
+    },
+    {
+      "Right": "0x87d47b57f282edc00cfde72ccd19d47cb250cfc191ca5b7f875fc1636aa3ad4"
+    },
+    {
+      "Left": "0xf57c5571e9a4eab49e2c8cf050dae948aef6ead647392273546249d1c1ff10f"
+    },
+    {
+      "Left": "0x1830ee67b5fb554ad5f63d4388800e1cfe78e310697d46e43c9ce36134f72cca"
+    },
+    {
+      "Left": "0x2134e76ac5d21aab186c2be1dd8f84ee880a1e46eaf712f9d371b6df22191f3e"
+    },
+    {
+      "Left": "0x19df90ec844ebc4ffeebd866f33859b0c051d8c958ee3aa88f8f8df3db91a5b1"
+    },
+    {
+      "Left": "0x18cca2a66b5c0787981e69aefd84852d74af0e93ef4912b4648c05f722efe52b"
+    },
+    {
+      "Left": "0x2388909415230d1b4d1304d2d54f473a628338f2efad83fadf05644549d2538d"
+    },
+    {
+      "Right": "0x16ec84443a1a7600f53c5cc4053be4cd4648c804746a9e438be2222cc9e1fc48"
+    },
+    {
+      "Left": "0x2ff6650540f629fd5711a0bc74fc0d28dcb230b9392583e5f8d59696dde6ae21"
+    },
+    {
+      "Left": "0x120c58f143d491e95902f7f5277778a2e0ad5168f6add75669932630ce611518"
+    },
+    {
+      "Left": "0x1f21feb70d3f21b07bf853d5e5db03071ec495a0a565a21da2d665d279483795"
+    },
+    {
+      "Left": "0x24be905fa71335e14c638cc0f66a8623a826e768068a9e968bb1a1dde18a72d2"
+    },
+    {
+      "Left": "0xf8666b62ed17491c50ceadead57d4cd597ef3821d65c328744c74e553dac26d"
+    }
+  ]
+}

--- a/walletkit-core/tests/solidity.rs
+++ b/walletkit-core/tests/solidity.rs
@@ -50,3 +50,8 @@ async fn test_advanced_external_nullifier_generation_on_chain() {
 
     assert_eq!(nullifier, *context.external_nullifier);
 }
+
+#[tokio::test]
+async fn test_proof_verification_on_chain() {
+    // TODO: implement this test
+}

--- a/walletkit-core/tests/solidity.rs
+++ b/walletkit-core/tests/solidity.rs
@@ -36,6 +36,7 @@ async fn test_advanced_external_nullifier_generation_on_chain() {
     let context = Context::new_from_bytes(
         &app_id,
         Some(custom_action),
+        None,
         Arc::new(CredentialType::Orb),
     );
 


### PR DESCRIPTION
- Adds base support for generating ZKPs under the protocol.
- Introduces a global `Environment` to identities to be able to distinguish between different sets.
- The default proof process generation also fetches the Merkle inclusion proof from the relevant sign up sequencer.
- Extends `U256Wrapper` to also parse hex strings