### PR TITLE
fix: build files getting too large for git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+          # built binary files are too large for the default buffer
+          git config --global http.postBuffer 157286400
           git add Cargo.toml
           git add Cargo.lock
           git commit -m "Bump crate version to ${{ steps.version.outputs.new_version }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "uniffi",
 ]
@@ -6108,11 +6108,11 @@ dependencies = [
 
 [[package]]
 name = "walletkit"
-version = "0.0.7"
+version = "0.0.6"
 
 [[package]]
 name = "walletkit-core"
-version = "0.0.7"
+version = "0.0.6"
 dependencies = [
  "alloy",
  "alloy-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["uniffi-bindgen","walletkit-core", "walletkit"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.7"
+version = "0.0.6"
 license = "MIT"
 edition = "2021"
 authors = ["World Contributors"]


### PR DESCRIPTION
See workflow failure example, https://github.com/worldcoin/walletkit/actions/runs/12282935208/job/34275360624