### PR TITLE
breaking change!: rename `Identity` to `WorldID`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ WalletKit is broken down into separate crates, offering the following functional
 
 ## Getting Started
 
-WalletKit is generally centered around a World ID. The most basic usage requires initializing a World ID `Identity`.
+WalletKit is generally centered around a World ID. The most basic usage requires initializing a `WorldID`.
 
 A World ID can then be used to generate [Zero-Knowledge Proofs](https://docs.world.org/world-id/further-reading/zero-knowledge-proofs).
 
 A ZKP is analogous to _presenting_ a credential.
 
 ```rust
-use walletkit::{Context, CredentialType, Environment, Identity};
+use walletkit::{Context, CredentialType, Environment, WorldID};
 use std::sync::Arc;
 
 async fn example() {
-    let identity = Identity::new(b"not_a_real_secret", &Environment::Staging);
+    let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
     let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Orb));
-    let proof = identity.generate_proof(&context).await.unwrap();
+    let proof = world_id.generate_proof(&context).await.unwrap();
 
     dbg!(proof.to_json()); // the JSON output can be passed to the Developer Portal or other places for verification
 }

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ WalletKit is broken down into separate crates, offering the following functional
 
 ## Getting Started
 
-WalletKit is generally centered around a World ID. The most basic usage requires initializing a `WorldID`.
+WalletKit is generally centered around a World ID. The most basic usage requires initializing a `WorldId`.
 
 A World ID can then be used to generate [Zero-Knowledge Proofs](https://docs.world.org/world-id/further-reading/zero-knowledge-proofs).
 
 A ZKP is analogous to _presenting_ a credential.
 
 ```rust
-use walletkit::{Context, CredentialType, Environment, WorldID};
+use walletkit::{Context, CredentialType, Environment, WorldId};
 use std::sync::Arc;
 
 async fn example() {
-    let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+    let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
     let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Orb));
     let proof = world_id.generate_proof(&context).await.unwrap();
 

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -24,8 +24,8 @@ pub use credential_type::*;
 mod error;
 pub use error::*;
 
-mod identity;
-pub use identity::*;
+mod world_id;
+pub use world_id::*;
 
 mod proof;
 pub use proof::*;

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -78,7 +78,7 @@ impl MerkleTreeProof {
 
 #[cfg(test)]
 mod tests {
-    use crate::{credential_type::CredentialType, world_id::WorldID, Environment};
+    use crate::{credential_type::CredentialType, world_id::WorldId, Environment};
 
     use super::*;
 
@@ -93,7 +93,7 @@ mod tests {
             .create_async()
             .await;
 
-        let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+        let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
 
         let merkle_proof = MerkleTreeProof::from_identity_commitment(
             &world_id.get_identity_commitment(&CredentialType::Device),

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -78,7 +78,7 @@ impl MerkleTreeProof {
 
 #[cfg(test)]
 mod tests {
-    use crate::{credential_type::CredentialType, identity::Identity, Environment};
+    use crate::{credential_type::CredentialType, world_id::WorldID, Environment};
 
     use super::*;
 
@@ -93,10 +93,10 @@ mod tests {
             .create_async()
             .await;
 
-        let identity = Identity::new(b"not_a_real_secret", &Environment::Staging);
+        let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
 
         let merkle_proof = MerkleTreeProof::from_identity_commitment(
-            &identity.get_identity_commitment(&CredentialType::Device),
+            &world_id.get_identity_commitment(&CredentialType::Device),
             &mock_server.url(),
         )
         .await

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -309,7 +309,7 @@ mod proof_tests {
         );
 
         assert_eq!(
-            U256Wrapper::from(world_id.commitment()).to_hex_string(),
+            U256Wrapper::from(identity.commitment()).to_hex_string(),
             "0x1a060ef75540e13711f074b779a419c126ab5a89d2c2e7d01e64dfd121e44671"
         );
 

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -303,19 +303,19 @@ mod proof_tests {
 
         let mut secret = b"not_a_real_secret".to_vec();
 
-        let identity = semaphore::identity::Identity::from_secret(
+        let world_id = semaphore::identity::Identity::from_secret(
             &mut secret,
             Some(context.credential_type.as_identity_trapdoor()),
         );
 
         assert_eq!(
-            U256Wrapper::from(identity.commitment()).to_hex_string(),
+            U256Wrapper::from(world_id.commitment()).to_hex_string(),
             "0x1a060ef75540e13711f074b779a419c126ab5a89d2c2e7d01e64dfd121e44671"
         );
 
         // Compute ZKP
         let zkp = generate_proof_with_semaphore_identity(
-            &identity,
+            &world_id,
             &helper_load_merkle_proof(),
             &context,
         )
@@ -353,14 +353,14 @@ mod proof_tests {
         );
 
         let mut secret = b"not_a_real_secret".to_vec();
-        let identity = semaphore::identity::Identity::from_secret(
+        let world_id = semaphore::identity::Identity::from_secret(
             &mut secret,
             Some(context.credential_type.as_identity_trapdoor()),
         );
 
         // Compute ZKP
         let zkp = generate_proof_with_semaphore_identity(
-            &identity,
+            &world_id,
             &helper_load_merkle_proof(),
             &context,
         )

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -59,7 +59,7 @@ impl WorldID {
     #[must_use]
     pub fn generate_nullifier_hash(&self, context: &Context) -> U256Wrapper {
         let world_id = self.semaphore_identity_for_credential(&context.credential_type);
-        generate_nullifier_hash(&identity, *context.external_nullifier).into()
+        generate_nullifier_hash(&world_id, *context.external_nullifier).into()
     }
 
     /// Generates the `identity_commitment` for a specific World ID identity and for a specific credential.
@@ -93,7 +93,7 @@ impl WorldID {
     /// # tokio_test::block_on(async {
     ///     let world_id = Identity::new(b"not_a_real_secret", &Environment::Staging);
     ///     let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Device));
-    ///     let proof = identity.generate_proof(&context).await.unwrap();
+    ///     let proof = world_id.generate_proof(&context).await.unwrap();
     ///     assert_eq!(proof.nullifier_hash.to_hex_string(), "0x302e253346d2b41a0fd71562ffc6e5ddcbab6d8ea3dd6d68e6a695b5639b1c37")
     /// # })
     ///

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -91,7 +91,7 @@ impl WorldID {
     /// use std::sync::Arc;
 
     /// # tokio_test::block_on(async {
-    ///     let world_id = Identity::new(b"not_a_real_secret", &Environment::Staging);
+    ///     let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
     ///     let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Device));
     ///     let proof = world_id.generate_proof(&context).await.unwrap();
     ///     assert_eq!(proof.nullifier_hash.to_hex_string(), "0x302e253346d2b41a0fd71562ffc6e5ddcbab6d8ea3dd6d68e6a695b5639b1c37")

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -22,7 +22,7 @@ use crate::{
 /// 2. Zeroize does not have good compatibility with `UniFFI` as `UniFFI` may make many copies of the bytes for usage in foreign code
 ///     ([reference](https://github.com/mozilla/uniffi-rs/issues/2080)). This needs to be further explored.
 #[derive(Clone, PartialEq, Eq, Debug, uniffi::Object)]
-pub struct WorldID {
+pub struct WorldId {
     /// The Semaphore-based identity specifically for the `CredentialType::Orb`
     canonical_orb_semaphore_identity: semaphore_rs::identity::Identity,
     /// The hashed World ID secret, cast to 64 bytes (0-padded). Actual hashed secret is 32 bytes.
@@ -32,7 +32,7 @@ pub struct WorldID {
 }
 
 #[uniffi::export]
-impl WorldID {
+impl WorldId {
     /// Initializes a new `Identity` from a World ID secret. The identity is initialized for a specific environment.
     #[must_use]
     #[uniffi::constructor]
@@ -58,8 +58,8 @@ impl WorldID {
     /// [Protocol Reference](https://docs.semaphore.pse.dev/V2/technical-reference/circuits#nullifier-hash).
     #[must_use]
     pub fn generate_nullifier_hash(&self, context: &Context) -> U256Wrapper {
-        let world_id = self.semaphore_identity_for_credential(&context.credential_type);
-        generate_nullifier_hash(&world_id, *context.external_nullifier).into()
+        let identity = self.semaphore_identity_for_credential(&context.credential_type);
+        generate_nullifier_hash(&identity, *context.external_nullifier).into()
     }
 
     /// Generates the `identity_commitment` for a specific World ID identity and for a specific credential.
@@ -73,8 +73,8 @@ impl WorldID {
         &self,
         credential_type: &CredentialType,
     ) -> U256Wrapper {
-        let world_id = self.semaphore_identity_for_credential(credential_type);
-        world_id.commitment().into()
+        let identity = self.semaphore_identity_for_credential(credential_type);
+        identity.commitment().into()
     }
 
     /// Generates a World ID Zero-knowledge proof (ZKP) for a specific context (i.e. app + action) and the identity.
@@ -87,11 +87,11 @@ impl WorldID {
     /// # Examples
     /// // NOTE: This is an integration test. Running this doctest example requires an HTTP connection to the sequencer.
     /// ```rust
-    /// use walletkit_core::{Context, CredentialType, Environment, WorldID};
+    /// use walletkit_core::{Context, CredentialType, Environment, WorldId};
     /// use std::sync::Arc;
     ///
     /// # tokio_test::block_on(async {
-    ///     let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+    ///     let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
     ///     let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Device));
     ///     let proof = world_id.generate_proof(&context).await.unwrap();
     ///     assert_eq!(proof.nullifier_hash.to_hex_string(), "0x302e253346d2b41a0fd71562ffc6e5ddcbab6d8ea3dd6d68e6a695b5639b1c37")
@@ -102,9 +102,9 @@ impl WorldID {
         &self,
         context: &Context,
     ) -> Result<ProofOutput, Error> {
-        let world_id = self.semaphore_identity_for_credential(&context.credential_type);
+        let identity = self.semaphore_identity_for_credential(&context.credential_type);
         // fetch directly instead of `get_identity_commitment` to avoid duplicate computations
-        let identity_commitment = world_id.commitment().into();
+        let identity_commitment = identity.commitment().into();
 
         let sequencer_host = context
             .credential_type
@@ -116,11 +116,11 @@ impl WorldID {
         )
         .await?;
 
-        generate_proof_with_semaphore_identity(&world_id, &merkle_tree_proof, context)
+        generate_proof_with_semaphore_identity(&identity, &merkle_tree_proof, context)
     }
 }
 
-impl WorldID {
+impl WorldId {
     /// Retrieves the Semaphore identity for a specific `CredentialType` from memory or by computing it on the spot.
     #[must_use]
     #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn test_proof_generation() {
         // TODO: complete test
-        let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+        let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
         let context = Context::new("app_id", None, None, Arc::new(CredentialType::Orb));
         let nullifier_hash = world_id.generate_nullifier_hash(&context);
         println!("{}", nullifier_hash.to_hex_string());
@@ -181,7 +181,8 @@ mod tests {
 
     #[test]
     fn test_secret_hex_generation() {
-        let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+        let world_id: WorldId =
+            WorldId::new(b"not_a_real_secret", &Environment::Staging);
 
         // this is the expected SHA-256 of the secret (computed externally)
         let expected_hash: U256Wrapper = uint!(88026203285206540949013074047154212280150971633012190779810764227609557184952_U256).into();
@@ -196,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_identity_commitment_generation() {
-        let world_id = WorldID::new(b"not_a_real_secret", &Environment::Staging);
+        let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
         let commitment = world_id.get_identity_commitment(&CredentialType::Orb);
 
         assert_eq!(


### PR DESCRIPTION
`WorldID` seems to be a more accurate representation. This essentially represents a `WorldID` with which a user can interact with the Protocol