### PR TITLE
feat!: refactor naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A World ID can then be used to generate [Zero-Knowledge Proofs](https://docs.wor
 A ZKP is analogous to _presenting_ a credential.
 
 ```rust
-use walletkit::{ProofContext, CredentialType, Environment, WorldId};
+use walletkit::{proof::ProofContext, CredentialType, Environment, world_id::WorldId};
 use std::sync::Arc;
 
 async fn example() {

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ A World ID can then be used to generate [Zero-Knowledge Proofs](https://docs.wor
 A ZKP is analogous to _presenting_ a credential.
 
 ```rust
-use walletkit::{Context, CredentialType, Environment, WorldId};
+use walletkit::{ProofContext, CredentialType, Environment, WorldId};
 use std::sync::Arc;
 
 async fn example() {
     let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
-    let context = Context::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Orb));
+    let context = ProofContext::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Orb));
     let proof = world_id.generate_proof(&context).await.unwrap();
 
     dbg!(proof.to_json()); // the JSON output can be passed to the Developer Portal or other places for verification

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 /// Error outputs from `WalletKit`
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
-pub enum Error {
+pub enum WalletKitError {
     /// The presented input is not valid for the requested operation
     #[error("invalid_input")]
     InvalidInput,

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -19,21 +19,24 @@ pub enum Environment {
 }
 
 mod credential_type;
-pub use credential_type::*;
+pub use credential_type::CredentialType;
 
-mod error;
-pub use error::*;
+/// Contains error outputs from `WalletKit`
+pub mod error;
 
-mod world_id;
-pub use world_id::*;
+/// Contains all components to interact and use a World ID
+pub mod world_id;
 
-mod proof;
-pub use proof::*;
+/// This module handles World ID proof generation
+pub mod proof;
 
 mod u256;
-pub use u256::*;
+pub use u256::U256Wrapper;
 
-// private modules
+////////////////////////////////////////////////////////////////////////////////
+// Private modules
+////////////////////////////////////////////////////////////////////////////////
+
 mod merkle_tree;
 mod request;
 

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -1,7 +1,7 @@
 use semaphore_rs::poseidon_tree::Proof;
 use serde::{Deserialize, Serialize};
 
-use crate::{error::Error, request::Request, u256::U256Wrapper};
+use crate::{error::WalletKitError, request::Request, u256::U256Wrapper};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -42,7 +42,7 @@ impl MerkleTreeProof {
     pub async fn from_identity_commitment(
         identity_commitment: &U256Wrapper,
         sequencer_host: &str,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, WalletKitError> {
         let url = format!("{sequencer_host}/inclusionProof");
 
         // TODO: Cache inclusion proof for 10-15 mins
@@ -64,14 +64,17 @@ impl MerkleTreeProof {
     }
 
     #[uniffi::constructor]
-    pub fn from_json_proof(json_proof: &str, merkle_root: &str) -> Result<Self, Error> {
-        let proof: Proof =
-            serde_json::from_str(json_proof).map_err(|_| Error::InvalidInput)?;
+    pub fn from_json_proof(
+        json_proof: &str,
+        merkle_root: &str,
+    ) -> Result<Self, WalletKitError> {
+        let proof: Proof = serde_json::from_str(json_proof)
+            .map_err(|_| WalletKitError::InvalidInput)?;
 
         Ok(Self {
             poseidon_proof: proof,
             merkle_root: U256Wrapper::try_from_hex_string(merkle_root)
-                .map_err(|_| Error::InvalidInput)?,
+                .map_err(|_| WalletKitError::InvalidInput)?,
         })
     }
 }

--- a/walletkit-core/src/u256.rs
+++ b/walletkit-core/src/u256.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::error::Error;
+use crate::error::WalletKitError;
 use ruint::aliases::U256;
 use serde::{Deserialize, Serialize};
 
@@ -29,11 +29,11 @@ impl U256Wrapper {
     /// # Errors
     /// Will return an `Error::InvalidNumber` if the input is not a valid hex-string-presented number up to 256 bits.
     #[uniffi::constructor]
-    pub fn try_from_hex_string(hex_string: &str) -> Result<Self, Error> {
+    pub fn try_from_hex_string(hex_string: &str) -> Result<Self, WalletKitError> {
         let hex_string = hex_string.trim().trim_start_matches("0x");
 
-        let number =
-            U256::from_str_radix(hex_string, 16).map_err(|_| Error::InvalidNumber)?;
+        let number = U256::from_str_radix(hex_string, 16)
+            .map_err(|_| WalletKitError::InvalidNumber)?;
 
         Ok(Self(number))
     }

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -87,7 +87,7 @@ impl WorldId {
     /// # Examples
     /// // NOTE: This is an integration test. Running this doctest example requires an HTTP connection to the sequencer.
     /// ```rust
-    /// use walletkit_core::{ProofContext, CredentialType, Environment, WorldId};
+    /// use walletkit_core::{proof::ProofContext, CredentialType, Environment, world_id::WorldId};
     /// use std::sync::Arc;
     ///
     /// # tokio_test::block_on(async {

--- a/walletkit-core/tests/solidity.rs
+++ b/walletkit-core/tests/solidity.rs
@@ -5,7 +5,7 @@ use alloy::{
     sol,
     sol_types::SolValue,
 };
-use walletkit_core::{Context, CredentialType};
+use walletkit_core::{proof::ProofContext, CredentialType};
 
 sol!(
     #[allow(missing_docs)]
@@ -33,7 +33,7 @@ async fn test_advanced_external_nullifier_generation_on_chain() {
     let custom_action =
         [addr.abi_encode_packed(), "test_text".abi_encode_packed()].concat();
 
-    let context = Context::new_from_bytes(
+    let context = ProofContext::new_from_bytes(
         &app_id,
         Some(custom_action),
         None,


### PR DESCRIPTION
- Changes naming conventions of `Context` to `ProofContext` to make objects clear in foreign binding code which may not respect the modules structure.
- Similarly renames `Error` to `WalletKitError` to avoid ambiguity when used in conjunction with other UniFFI-based crates