### PR TITLE
fixes for foreign bindings: CredentialType as enum & expose proof output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ A ZKP is analogous to _presenting_ a credential.
 
 ```rust
 use walletkit::{proof::ProofContext, CredentialType, Environment, world_id::WorldId};
-use std::sync::Arc;
 
 async fn example() {
     let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
-    let context = ProofContext::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Orb));
+    let context = ProofContext::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, CredentialType::Orb);
     let proof = world_id.generate_proof(&context).await.unwrap();
 
-    dbg!(proof.to_json()); // the JSON output can be passed to the Developer Portal or other places for verification
+    dbg!(proof.to_json()); // the JSON output can be passed to the Developer Portal, World ID contracts, etc. for verification
 }
 ```

--- a/walletkit-core/src/credential_type.rs
+++ b/walletkit-core/src/credential_type.rs
@@ -8,7 +8,7 @@ use crate::Environment;
 /// valid Orb-verified credential.
 ///
 /// More details in `https://docs.world.org/world-id/concepts#proof-of-personhood`
-#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Object, EnumString, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum, EnumString, Hash)]
 #[strum(serialize_all = "snake_case")]
 pub enum CredentialType {
     /// Represents persons who have been biometrically verified at an Orb. Highest level of proof of personhood verification.

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -92,7 +92,7 @@ impl WorldId {
     ///
     /// # tokio_test::block_on(async {
     ///     let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
-    ///     let context = ProofContext::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, Arc::new(CredentialType::Device));
+    ///     let context = ProofContext::new("app_ce4cb73cb75fc3b73b71ffb4de178410", Some("my_action".to_string()), None, CredentialType::Device);
     ///     let proof = world_id.generate_proof(&context).await.unwrap();
     ///     assert_eq!(proof.nullifier_hash.to_hex_string(), "0x302e253346d2b41a0fd71562ffc6e5ddcbab6d8ea3dd6d68e6a695b5639b1c37")
     /// # })
@@ -146,7 +146,6 @@ impl WorldId {
 mod tests {
 
     use ruint::uint;
-    use std::sync::Arc;
 
     use super::*;
 
@@ -154,8 +153,7 @@ mod tests {
     fn test_proof_generation() {
         // TODO: complete test
         let world_id = WorldId::new(b"not_a_real_secret", &Environment::Staging);
-        let context =
-            ProofContext::new("app_id", None, None, Arc::new(CredentialType::Orb));
+        let context = ProofContext::new("app_id", None, None, CredentialType::Orb);
         let nullifier_hash = world_id.generate_nullifier_hash(&context);
         println!("{}", nullifier_hash.to_hex_string());
     }

--- a/walletkit-core/tests/solidity.rs
+++ b/walletkit-core/tests/solidity.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use alloy::{
     providers::{ProviderBuilder, WalletProvider},
     sol,
@@ -37,7 +35,7 @@ async fn test_advanced_external_nullifier_generation_on_chain() {
         &app_id,
         Some(custom_action),
         None,
-        Arc::new(CredentialType::Orb),
+        CredentialType::Orb,
     );
 
     let nullifier = contract


### PR DESCRIPTION
- `CredentialType` was incorrectly marked as an object instead of `Enum` which was causing Kotlin to be unable to initialize it.
- Exposes key attributes of the `ProofOutput` to foreign code, as Kotlin cannot access even public fields in the struct.