### PR TITLE
don't load semaphore circuits on docsrs

### DIFF
--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -25,12 +25,16 @@ alloy-core = { version = "0.8.12", default-features = false, features = ["sol-ty
 hex = "0.4.3"
 reqwest = { version = "0.12.9", features = ["json", "brotli"] }
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
-semaphore-rs = { version = "0.3.2", features = ["depth_30"] }
+semaphore-rs = { version = "0.3.2" }
 serde = "1.0.215"
 serde_json = "1.0.133"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "2.0.3"
 uniffi = { workspace = true, features = ["build", "tokio"] }
+
+# docs.rs runs without network access, hence we cannot build semaphore circuits
+[target.'cfg(not(docsrs))'.dependencies]
+semaphore-rs = { version = "0.3.2", features = ["depth_30"] }
 
 [dev-dependencies]
 alloy = { version = "0.6.4", default-features = false, features = ["json", "contract", "node-bindings"] }


### PR DESCRIPTION
Loading the `depth_30` feature flag triggers build.rs from `semaphore-rs` which requires downloading the circuits from the mirror. Docs.rs doesn't have network access so builds fail. This disables the feature flag on docsrs build.