### PR TITLE
fix: crates.io release & run docs.rs on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,14 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  doc:
+    name: Check docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustc, cargo
       - uses: dtolnay/install@cargo-docs-rs
       - run: |
-          cargo docs-rs -p walletkit-core
-          cargo docs-rs -p walletkit
-        env:
-          CARGO_CHANNEL: nightly
+          cargo +nightly docs-rs -p walletkit-core
+          cargo +nightly docs-rs -p walletkit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustc, cargo
       - uses: dtolnay/install@cargo-docs-rs
       - run: |
           cargo docs-rs -p walletkit-core
           cargo docs-rs -p walletkit
+        env:
+          CARGO_CHANNEL: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,4 +167,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
-      - run: cargo docs-rs
+      - run: |
+          cargo docs-rs -p walletkit-core
+          cargo docs-rs -p walletkit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
+      commit_sha: ${{ github.sha }}
 
     steps:
       - name: Checkout code
@@ -52,6 +53,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
       - name: Setup Rust environment
         uses: ./.github/actions/rust-setup
@@ -112,6 +115,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
       - name: Setup Rust environment
         uses: ./.github/actions/rust-setup
@@ -144,6 +149,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
       - name: Setup Rust environment
         uses: ./.github/actions/rust-setup
@@ -208,13 +215,13 @@ jobs:
           make_latest: true
 
   publish-to-crates-io:
-    needs: [create-github-release]
+    needs: [pre-release-checks, create-github-release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
       - name: Set up Rust
         run: |
@@ -224,5 +231,5 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo publish --token $CARGO_REGISTRY_TOKEN --package walletkit --locked
           cargo publish --token $CARGO_REGISTRY_TOKEN --package walletkit-core --locked
+          cargo publish --token $CARGO_REGISTRY_TOKEN --package walletkit --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/walletkit/README.md
+++ b/walletkit/README.md
@@ -1,1 +1,1 @@
-../../README.md
+../README.md


### PR DESCRIPTION
- Run a CI check to test docs.rs build
- Ensure all jobs in the release workflow use the same commit ref in case there are race conditions with merged PRs
- Fix README loading for walletkit crate