### PR TITLE
add support for legacy ext nullifier hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,4 @@ Sources/
 cache/
 **/out/build-info
 
-.vscode
-
 # NOTE: Cargo.lock is not ignored because it is used for FFI builds (Swift & Kotlin)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.cargo.features": [
+        "default",
+        "legacy-nullifiers"
+    ],
+    "rust-analyzer.check.command": "clippy"
+}


### PR DESCRIPTION
### Context
Before conventions were introduced for external nullifiers with `app_id` & `action`, raw field elements were used.


### Changes
- Introduces a `legacy-nullifiers` feature flag.
- Introduces two methods to create `ProofContext`s to generate World ID proofs for different use cases (e.g. Recurring Grant Drop & World ID Addressbook).