### PR TITLE
chore: add default RPC URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run tests
         env:
-          WORLDCHAIN_SEPOLIA_RPC_URL: ${{ secrets.WORLDCHAIN_SEPOLIA_RPC_URL }}
+          WORLDCHAIN_SEPOLIA_RPC_URL: ${{ secrets.WORLDCHAIN_SEPOLIA_RPC_URL || 'https://worldchain-sepolia.g.alchemy.com/public' }}
         run: |
           cargo test --all --all-features
 


### PR DESCRIPTION
PRs from forks or from dependabot won't have access to secrets. This ensures we can still run tests.