### PR TITLE
chore: cargo trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,9 @@ jobs:
   publish-to-crates-io:
     needs: [pre-release-checks, create-github-release]
     runs-on: ubuntu-latest
+    environment: production
     permissions:
+      id-token: write
       contents: read
 
     steps:
@@ -236,9 +238,12 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+          
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cargo publish --token $CARGO_REGISTRY_TOKEN --package walletkit-core --locked
           cargo publish --token $CARGO_REGISTRY_TOKEN --package walletkit --locked


### PR DESCRIPTION
use Rust trusted publishing through OIDC instead of relying on a user-based API token, https://crates.io/docs/trusted-publishing
