### PR TITLE
feat: Implement deserialization for credential type

### DIFF
--- a/walletkit-core/src/credential_type.rs
+++ b/walletkit-core/src/credential_type.rs
@@ -127,7 +127,7 @@ mod tests {
             let serialized = serde_json::to_string(&variant).unwrap();
             let deserialized: CredentialType =
                 serde_json::from_str(&serialized).unwrap();
-            assert_eq!(variant, deserialized, "Roundtrip failed for {:?}", variant);
+            assert_eq!(variant, deserialized, "Roundtrip failed for {variant:?}");
         }
     }
 }


### PR DESCRIPTION
- Added deserialization for `credential_type`
- Switched serde to decorators using [rename_all](https://serde.rs/variant-attrs.html#rename_all) for cleaner approach
- Kept strum decorator for backwards compatibility