### PR TITLE
Add throwing helpful logs for errors on proofs

### DIFF
--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -12,8 +12,11 @@ pub enum WalletKitError {
     #[error("invalid_number")]
     InvalidNumber,
     /// Unexpected error serializing information
-    #[error("serialization_error")]
-    SerializationError,
+    #[error("serialization_error: {0}")]
+    SerializationError(String),
+    /// Network connection error with details
+    #[error("network_error: {0}")]
+    NetworkError(String),
     /// HTTP request failure
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -26,4 +26,7 @@ pub enum WalletKitError {
     /// The `semaphore` feature flag is not enabled
     #[error("semaphore_not_enabled")]
     SemaphoreNotEnabled,
+    /// The requested credential is not issued for this World ID
+    #[error("credential_not_issued")]
+    CredentialNotIssued,
 }

--- a/walletkit-core/src/merkle_tree.rs
+++ b/walletkit-core/src/merkle_tree.rs
@@ -59,7 +59,7 @@ impl MerkleTreeProof {
             Err(err) => {
                 // Create a new error with the network error details and URL
                 return Err(WalletKitError::NetworkError(format!(
-                    "Failed to connect to {url}: {err}"
+                    "[MerkleTreeProof] Failed to connect to {url}: {err}"
                 )));
             }
         };
@@ -70,22 +70,21 @@ impl MerkleTreeProof {
             Ok(text) => text,
             Err(err) => {
                 return Err(WalletKitError::SerializationError(
-                    format!("Failed to read response body from {url} with status {status}: {err}")
+                    format!("[MerkleTreeProof] Failed to read response body from {url} with status {status}: {err}")
                 ));
             }
         };
 
-        // Try to parse the JSON text manually
         match serde_json::from_str::<InclusionProofResponse>(&response_text) {
             Ok(response) => Ok(Self {
                 poseidon_proof: response.proof,
                 merkle_root: response.root,
             }),
             Err(parse_err) => {
-                // Return a more detailed error with the response content
+                // Return a more detailed error with first 20 characters of the response (only 20 to avoid logging something sensitive)
                 Err(WalletKitError::SerializationError(format!(
-                    "Failed to parse response from {url} with status {status}: {parse_err}, received: {}",
-                    response_text.chars().take(100).collect::<String>()
+                    "[MerkleTreeProof] Failed to parse response from {url} with status {status}: {parse_err}, received: {}",
+                    response_text.chars().take(20).collect::<String>()
                 )))
             }
         }

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -282,7 +282,11 @@ impl ProofOutput {
     /// # Errors
     /// Will error if serialization fails.
     pub fn to_json(&self) -> Result<String, WalletKitError> {
-        serde_json::to_string(self).map_err(|_| WalletKitError::SerializationError)
+        serde_json::to_string(self).map_err(|e| {
+            WalletKitError::SerializationError(format!(
+                "Failed to serialize proof: {e}"
+            ))
+        })
     }
 
     /// Exposes the nullifier hash to foreign code. Struct fields are not directly exposed to foreign code.

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -376,7 +376,15 @@ mod http_tests {
                 .await
                 .unwrap();
 
-        assert_eq!(response.status(), 200);
+        let status = response.status();
+
+        if status != 200 {
+            println!("received status from developer portal: {status}");
+            let body = response.text().await.unwrap();
+            println!("received body from developer portal: {body}");
+            panic!("test was unsuccessful");
+        }
+
         assert!(
             response.json::<serde_json::Value>().await.unwrap()["success"]
                 .as_bool()


### PR DESCRIPTION
### Notes
* ensure better errors are propogated to Oxide
* We see many errors in Android:

Crypto]: Failed to generate QR code: uniffi.oxide.OxideException$WalletKit: error decoding response body

This should help us to understand why the calls are failing