### PR TITLE
feat!: allow specifying only mined inclusion proofs

### DIFF
--- a/walletkit-core/src/common_apps.rs
+++ b/walletkit-core/src/common_apps.rs
@@ -67,6 +67,7 @@ impl AddressBook {
             &ADDRESS_BOOK_EXTERNAL_NULLIFIER.into(),
             CredentialType::Orb,
             Some(signal),
+            true, // The address book explicitly requires a mined proof
         )?;
 
         Ok(proof_context)

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -29,4 +29,7 @@ pub enum WalletKitError {
     /// The requested credential is not issued for this World ID
     #[error("credential_not_issued")]
     CredentialNotIssued,
+    /// The requested credential has not been submitted on-chain
+    #[error("credential_not_mined")]
+    CredentialNotMined,
 }

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -31,6 +31,8 @@ pub struct ProofContext {
     /// The hashed signal which is included in the ZKP and committed to in the proof.
     /// When verifying the proof, the same signal must be provided.
     pub signal_hash: U256Wrapper,
+    /// Whether the request requires a mined on-chain proof.
+    pub require_mined_proof: bool,
 }
 
 #[cfg_attr(feature = "ffi", uniffi::export)]
@@ -173,6 +175,7 @@ impl ProofContext {
             external_nullifier,
             credential_type,
             signal_hash: *signal_hash,
+            require_mined_proof: false,
         }
     }
 }
@@ -202,12 +205,14 @@ impl ProofContext {
         external_nullifier: &[u8],
         credential_type: CredentialType,
         signal: Option<Vec<u8>>,
+        require_mined_proof: bool,
     ) -> Self {
         let external_nullifier: U256Wrapper = hash_to_field(external_nullifier).into();
         Self {
             external_nullifier,
             credential_type,
             signal_hash: hash_to_field(signal.unwrap_or_default().as_slice()).into(),
+            require_mined_proof,
         }
     }
 
@@ -236,6 +241,7 @@ impl ProofContext {
         external_nullifier: &U256Wrapper,
         credential_type: CredentialType,
         signal: Option<Vec<u8>>,
+        require_mined_proof: bool,
     ) -> Result<Self, WalletKitError> {
         if external_nullifier.0 >= MODULUS {
             return Err(WalletKitError::InvalidNumber);
@@ -245,6 +251,7 @@ impl ProofContext {
             external_nullifier: *external_nullifier,
             credential_type,
             signal_hash: hash_to_field(signal.unwrap_or_default().as_slice()).into(),
+            require_mined_proof,
         })
     }
 }
@@ -468,6 +475,7 @@ mod external_nullifier_tests {
             b"internal_addressbook",
             CredentialType::Device,
             None,
+            false,
         );
 
         // the expected nullifier hash from the contract
@@ -496,6 +504,7 @@ mod external_nullifier_tests {
             &external_nullifier_hash.into(),
             CredentialType::Device,
             None,
+            false,
         )
         .unwrap();
 
@@ -517,6 +526,7 @@ mod external_nullifier_tests {
                 &external_nullifier.into(),
                 CredentialType::Device,
                 None,
+                false,
             );
             assert!(context.is_err());
         }

--- a/walletkit-core/src/world_id.rs
+++ b/walletkit-core/src/world_id.rs
@@ -104,6 +104,7 @@ impl WorldId {
         let merkle_tree_proof = MerkleTreeProof::from_identity_commitment(
             &identity_commitment,
             sequencer_host,
+            context.require_mined_proof,
         )
         .await?;
 


### PR DESCRIPTION
### Motivation

Certain proofs that need to be verified on-chain, require Merkle inclusion proofs that have already been mined on-chain. This allows specifying the requirement for proofs.

### Changes
- Allows passing a `require_mined_proof` attribute which if true will only accepted mined Merkle inclusion proofs.
- This is a breaking change for the advanced internal `legacy-nullifiers` feature flag.