### PR TITLE
fix: correctly derive asset URL from release outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Get metadata
         id: meta
         run: |
-          ASSET_URL="${{ fromJSON(steps.release.outputs.assets)[0].browser_download_url }}"
+          ASSET_URL="${{ fromJSON(steps.release.outputs.assets)[0].url }}.zip"
           echo "asset_url=${ASSET_URL}" >> $GITHUB_OUTPUT
 
           CHECKSUM=$(swift package compute-checksum WalletKit.xcframework.zip)


### PR DESCRIPTION
## Description

The release workflow is not triggered by a tag push, so deriving the asset URL from the tag was incorrect. This updates the workflow to resolve the asset URL.