### PR TITLE
Fix Android binding generation and local build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ target/
 **/ios_build
 .swiftpm/
 
+# IDE
+.idea
+*.iml
+.vscode
+*/settings.json
+
 # Swift build outputs are not committed to this repo.
 WalletKit.xcframework/
 Sources/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 authors = ["World Contributors"]
 readme = "./README.md"
 homepage = "https://docs.world.org" # TODO: Update to specific WalletKit page
-rust-version = "1.86" # MSRV
+rust-version = "1.91" # MSRV
 repository = "https://github.com/worldcoin/walletkit"
 exclude = ["tests/", "uniffi-bindgen/"]
 keywords = ["ZKP", "WorldID", "World", "Identity", "Semaphore"]
@@ -26,6 +26,5 @@ world-id-core = { version = "0.3", default-features = false, features = ["authen
 [profile.release]
 opt-level = 'z' # Optimize for size.
 lto = true      # Enable Link Time Optimization.
-strip = true    # Automatically strip symbols from the binary.
 panic = "abort"
 debug = false

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,10 @@
+[build.env]
+passthrough = [
+    "CARGO_NET_GIT_FETCH_WITH_CLI=true", # to force cargo to use git cli with config --global in homedir
+    "HOME",                              # set $HOME to shared dir where we put .gitconfig
+    "RUSTUP_HOME",                       # override rustup home to prevent host permission issues
+    "CARGO_HOME",                        # override cargo home to prevent host permission issues
+]
 # max-page-size=16384:
 # Android 15 (API 35) introduces support for 16KB page sizes to improve performance on devices with larger RAM.
 # Apps with native libraries MUST be compiled with 16KB ELF alignment or they will crash on startup

--- a/README.md
+++ b/README.md
@@ -28,13 +28,51 @@ WalletKit's bindings for Kotlin are distributed through GitHub packages.
 ```kotlin
 dependencies {
     /// ...
-    implementation "org.world:walletkit:VERSION"
+    implementation "org.world:walletkit-android:VERSION"
 }
 ```
 
 Replace `VERSION` with the desired WalletKit version.
 
 2. Sync Gradle.
+
+## Local development (Android/Kotlin)
+
+### Prerequisites
+
+1. **Docker Desktop**: Required for cross-compilation
+   - The build uses [`cross`](https://github.com/cross-rs/cross) which runs builds in Docker containers with all necessary toolchains
+   - Install via Homebrew:
+     ```bash
+     brew install --cask docker
+     ```
+   - Launch Docker Desktop and ensure it's running before building
+
+2. **Android SDK + NDK**: Required for Gradle Android tasks
+   - Install via Android Studio > Settings > Android SDK (ensure the NDK is installed)
+   - Set `sdk.dir` (and `ndk.dir` if needed) in `kotlin/local.properties`
+
+3. **Protocol Buffers compiler**:
+   ```bash
+   brew install protobuf
+   ```
+
+### Building and publishing
+
+To test local changes before publishing a release, use the build script to compile the Rust library, generate UniFFI bindings, and publish a SNAPSHOT to Maven Local:
+
+```bash
+./build_android_local.sh 0.3.1-SNAPSHOT
+```
+
+> **Note**: The script sets `RUSTUP_HOME` and `CARGO_HOME` to `/tmp` by default to avoid Docker permission issues when using `cross`. You can override them by exporting your own values.
+
+This will:
+1. Build the Rust library for all Android architectures (arm64-v8a, armeabi-v7a, x86_64, x86)
+2. Generate Kotlin UniFFI bindings
+3. Publish to `~/.m2/repository/org/world/walletkit-android/`
+
+In your consuming project, ensure `mavenLocal()` is included in your repositories and update your dependency version to the SNAPSHOT version (e.g., `0.3.1-SNAPSHOT`).
 
 ## Overview
 

--- a/build_android_local.sh
+++ b/build_android_local.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+echo "Building WalletKit Android SDK for local development..."
+
+# Set rustup and cargo home to /tmp to prevent Docker permission issues
+export RUSTUP_HOME="${RUSTUP_HOME:-/tmp/.rustup}"
+export CARGO_HOME="${CARGO_HOME:-/tmp/.cargo}"
+
+# Version is required
+if [ -z "$1" ]; then
+    echo "Error: Version parameter is required"
+    echo "Usage: ./build_android_local.sh <version>"
+    echo "Example: ./build_android_local.sh 0.2.1-SNAPSHOT"
+    exit 1
+fi
+
+VERSION="$1"
+echo "Using version: $VERSION"
+
+# Build using kotlin/build.sh
+echo "Building WalletKit SDK..."
+cd kotlin
+./build.sh
+
+# Publish to Maven Local
+echo "Publishing to Maven Local..."
+./gradlew :lib:publishToMavenLocal -PversionName="$VERSION"
+
+echo ""
+echo "✅ Successfully published $VERSION to Maven Local!"
+echo "Published to: ~/.m2/repository/org/world/walletkit-android/$VERSION/"
+echo ""
+echo "To use in your project:"
+echo "  implementation 'org.world:walletkit-android:$VERSION'"

--- a/kotlin/.gitignore
+++ b/kotlin/.gitignore
@@ -1,5 +1,15 @@
-# Ignore Gradle project-specific cache directory
+*.iml
 .gradle
-
-# Ignore Gradle build output directory
-build
+/local.properties
+/.idea/caches
+/.idea/libraries
+/.idea/modules.xml
+/.idea/workspace.xml
+/.idea/navEditor.xml
+/.idea/assetWizardSettings.xml
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx
+local.properties

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,0 +1,6 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "8.3.0" apply false
+    id("com.android.library") version "8.3.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/kotlin/build.sh
+++ b/kotlin/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+echo "Building WalletKit Android SDK..."
+
+# Create jniLibs directories
+mkdir -p ./lib/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
+
+# Build for all Android architectures
+echo "Building for aarch64-linux-android..."
+cross build -p walletkit --release --target=aarch64-linux-android
+
+echo "Building for armv7-linux-androideabi..."
+cross build -p walletkit --release --target=armv7-linux-androideabi
+
+echo "Building for x86_64-linux-android..."
+cross build -p walletkit --release --target=x86_64-linux-android
+
+echo "Building for i686-linux-android..."
+cross build -p walletkit --release --target=i686-linux-android
+
+# Move .so files to jniLibs
+echo "Moving native libraries..."
+mv ../target/aarch64-linux-android/release/libwalletkit.so ./lib/src/main/jniLibs/arm64-v8a/libwalletkit.so
+mv ../target/armv7-linux-androideabi/release/libwalletkit.so ./lib/src/main/jniLibs/armeabi-v7a/libwalletkit.so
+mv ../target/x86_64-linux-android/release/libwalletkit.so ./lib/src/main/jniLibs/x86_64/libwalletkit.so
+mv ../target/i686-linux-android/release/libwalletkit.so ./lib/src/main/jniLibs/x86/libwalletkit.so
+
+# Generate Kotlin bindings
+echo "Generating Kotlin bindings..."
+cargo run -p uniffi-bindgen generate \
+  ./lib/src/main/jniLibs/arm64-v8a/libwalletkit.so \
+  --library \
+  --language kotlin \
+  --no-format \
+  --out-dir lib/src/main/java
+
+echo "✅ Build complete!"

--- a/kotlin/lib/.gitignore
+++ b/kotlin/lib/.gitignore
@@ -1,0 +1,2 @@
+/build
+/src/main/java/uniffi/

--- a/kotlin/lib/build.gradle.kts
+++ b/kotlin/lib/build.gradle.kts
@@ -8,13 +8,10 @@ plugins {
 
 android {
     namespace = "org.world.walletkit"
-    compileSdk = 33
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 23
-
-        @Suppress("deprecation")
-        targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/kotlin/lib/src/main/jniLibs/.gitignore
+++ b/kotlin/lib/src/main/jniLibs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,14 @@
+[toolchain]
+channel = "1.91.0"
+profile = "default"
+components = ["rustfmt", "clippy", "rust-analyzer"]
+targets = [
+    "aarch64-apple-ios-sim",
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "x86_64-linux-android",
+    "i686-linux-android",
+]


### PR DESCRIPTION
## Description
- Fixes Android binding generation and local build setup

## Changes
- Create `build_android_local.sh` script to build, generate UniFFI bindings (re-using `kotlin/build.sh`), and publish `SNAPSHOT`s
- Update `README` with local development prerequisites (NDK, protoc) and instructions
- Preserve UniFFI metadata in release builds so Kotlin bindings are generated and packaged in the Android AAR cc @paolodamico @lukejmann 
- Add a Rust toolchain file and local build env handling to make Android builds reproducible cc @paolodamico @lukejmann 
- Ensure native libs are built with 16KB page alignment to address Android 15 warnings cc @MarinJuricev @paolodamico (refs. https://github.com/worldcoin/walletkit/pull/129)
- Make the Kotlin project open cleanly in Android Studio by adding a root `build.gradle.kts` cc @MarinJuricev 
- Bump Android `compileSdk` to `35` in the `lib` module cc @MarinJuricev 
- Add Kotlin `.gitignore` rules so generated bindings, `jni` libs, and IDE/Gradle artifacts don't get committed
- iOS folks (@sideround @thomas-waite @forceunwrap @thomasbarbalet): please take a quick look to confirm no regressions on your side, I'm not fluent with Rust expert would appreciate a thorough review 🙏 

## Testing
- `$> RUSTUP_HOME=~/.rustup CARGO_HOME=~/.cargo ./build_android_local.sh 0.3.1-SNAPSHOT`
- Integrated `org.world:walletkit-android:0.3.1-SNAPSHOT` into `wld-android` and confirmed UniFFI bindings are present and 16KB page warnings are gone