### PR TITLE
 Fix UniFFI constructor bug and enable v4 feature for Android builds

### DIFF
--- a/kotlin/build.sh
+++ b/kotlin/build.sh
@@ -8,16 +8,16 @@ mkdir -p ./lib/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
 
 # Build for all Android architectures
 echo "Building for aarch64-linux-android..."
-cross build -p walletkit --release --target=aarch64-linux-android
+cross build -p walletkit --release --target=aarch64-linux-android --features v4
 
 echo "Building for armv7-linux-androideabi..."
-cross build -p walletkit --release --target=armv7-linux-androideabi
+cross build -p walletkit --release --target=armv7-linux-androideabi --features v4
 
 echo "Building for x86_64-linux-android..."
-cross build -p walletkit --release --target=x86_64-linux-android
+cross build -p walletkit --release --target=x86_64-linux-android --features v4
 
 echo "Building for i686-linux-android..."
-cross build -p walletkit --release --target=i686-linux-android
+cross build -p walletkit --release --target=i686-linux-android --features v4
 
 # Move .so files to jniLibs
 echo "Moving native libraries..."

--- a/walletkit-core/src/authenticator.rs
+++ b/walletkit-core/src/authenticator.rs
@@ -106,59 +106,6 @@ impl Authenticator {
         Ok(Self(authenticator))
     }
 
-    /// Registers a new World ID with SDK defaults.
-    ///
-    /// This returns immediately and does not wait for registration to complete.
-    /// The returned `InitializingAuthenticator` can be used to poll the registration status.
-    ///
-    /// # Errors
-    /// See `CoreAuthenticator::register` for potential errors.
-    #[uniffi::constructor]
-    pub async fn register_with_defaults(
-        seed: &[u8],
-        rpc_url: Option<String>,
-        environment: &Environment,
-        recovery_address: Option<String>,
-    ) -> Result<InitializingAuthenticator, WalletKitError> {
-        let recovery_address =
-            Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
-
-        let config = Config::from_environment(environment, rpc_url)?;
-
-        let initializing_authenticator =
-            CoreAuthenticator::register(seed, config, recovery_address).await?;
-
-        Ok(InitializingAuthenticator(initializing_authenticator))
-    }
-
-    /// Registers a new World ID.
-    ///
-    /// This returns immediately and does not wait for registration to complete.
-    /// The returned `InitializingAuthenticator` can be used to poll the registration status.
-    ///
-    /// # Errors
-    /// See `CoreAuthenticator::register` for potential errors.
-    #[uniffi::constructor]
-    pub async fn register(
-        seed: &[u8],
-        config: &str,
-        recovery_address: Option<String>,
-    ) -> Result<InitializingAuthenticator, WalletKitError> {
-        let recovery_address =
-            Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
-
-        let config =
-            Config::from_json(config).map_err(|_| WalletKitError::InvalidInput {
-                attribute: "config".to_string(),
-                reason: "Invalid config".to_string(),
-            })?;
-
-        let initializing_authenticator =
-            CoreAuthenticator::register(seed, config, recovery_address).await?;
-
-        Ok(InitializingAuthenticator(initializing_authenticator))
-    }
-
     /// Returns the packed account data for the holder's World ID.
     ///
     /// The packed account data is a 256 bit integer which includes the user's leaf index, their recovery counter,
@@ -248,6 +195,59 @@ pub struct InitializingAuthenticator(CoreInitializingAuthenticator);
 
 #[uniffi::export(async_runtime = "tokio")]
 impl InitializingAuthenticator {
+    /// Registers a new World ID with SDK defaults.
+    ///
+    /// This returns immediately and does not wait for registration to complete.
+    /// The returned `InitializingAuthenticator` can be used to poll the registration status.
+    ///
+    /// # Errors
+    /// See `CoreAuthenticator::register` for potential errors.
+    #[uniffi::constructor]
+    pub async fn register_with_defaults(
+        seed: &[u8],
+        rpc_url: Option<String>,
+        environment: &Environment,
+        recovery_address: Option<String>,
+    ) -> Result<Self, WalletKitError> {
+        let recovery_address =
+            Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
+
+        let config = Config::from_environment(environment, rpc_url)?;
+
+        let initializing_authenticator =
+            CoreAuthenticator::register(seed, config, recovery_address).await?;
+
+        Ok(Self(initializing_authenticator))
+    }
+
+    /// Registers a new World ID.
+    ///
+    /// This returns immediately and does not wait for registration to complete.
+    /// The returned `InitializingAuthenticator` can be used to poll the registration status.
+    ///
+    /// # Errors
+    /// See `CoreAuthenticator::register` for potential errors.
+    #[uniffi::constructor]
+    pub async fn register(
+        seed: &[u8],
+        config: &str,
+        recovery_address: Option<String>,
+    ) -> Result<Self, WalletKitError> {
+        let recovery_address =
+            Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
+
+        let config =
+            Config::from_json(config).map_err(|_| WalletKitError::InvalidInput {
+                attribute: "config".to_string(),
+                reason: "Invalid config".to_string(),
+            })?;
+
+        let initializing_authenticator =
+            CoreAuthenticator::register(seed, config, recovery_address).await?;
+
+        Ok(Self(initializing_authenticator))
+    }
+
     /// Polls the registration status from the gateway.
     ///
     /// # Errors

--- a/walletkit/Cargo.toml
+++ b/walletkit/Cargo.toml
@@ -27,6 +27,7 @@ walletkit-core = { workspace = true }
 [features]
 default = ["semaphore"]
 semaphore = ["walletkit-core/semaphore"]
+v4 = ["walletkit-core/v4"]
 
 [package.metadata.docs.rs]
 no-default-features = true


### PR DESCRIPTION
-  Fixes UniFFI constructor bug and enable v4 feature for Android builds

## Changes
- Moved `register()` and `register_with_defaults()` from `Authenticator` to `InitializingAuthenticator` as constructors (fixes `"Constructor return type must be Self or Arc<Self>"` error)
- Added v4 feature propagation in `walletkit/Cargo.toml`
- Enabled `--features v4` flag in Android build script to include `Authenticator` API in Kotlin bindings

## Testing
- All unit tests pass
- Android bindings generate successfully
- No breaking changes (no existing code calls these methods on `Authenticator`)

cc @thomas-waite @forceunwrap @sideround @lukejmann @paolodamico 