### PR TITLE
Enable v4 features for Swift walletkit

### DIFF
--- a/build_swift.sh
+++ b/build_swift.sh
@@ -18,9 +18,6 @@ mkdir -p $BASE_PATH/Sources/WalletKit
 
 export IPHONEOS_DEPLOYMENT_TARGET="13.0"
 export RUSTFLAGS="-C link-arg=-Wl,-application_extension"
-cargo build --package walletkit-core --target aarch64-apple-ios-sim --release --features v4
-cargo build --package walletkit-core --target aarch64-apple-ios --release --features v4
-cargo build --package walletkit-core --target x86_64-apple-ios --release --features v4
 cargo build --package walletkit --target aarch64-apple-ios-sim --release --features v4
 cargo build --package walletkit --target aarch64-apple-ios --release --features v4
 cargo build --package walletkit --target x86_64-apple-ios --release --features v4


### PR DESCRIPTION
v4 features were not being included in the `walletkit` build, so types like the `Authenticator` were not in scope when writing foreign binding tests in swift.