### PR TITLE
Enable legacy-nullifiers and common-apps features for walletkit-core

### DIFF
--- a/walletkit/Cargo.toml
+++ b/walletkit/Cargo.toml
@@ -21,7 +21,7 @@ name = "walletkit"
 
 [dependencies]
 uniffi = { workspace = true, features = ["build", "tokio"] }
-walletkit-core = { workspace = true }
+walletkit-core = { workspace = true, features = ["legacy-nullifiers", "common-apps"] }
 
 
 [features]


### PR DESCRIPTION
Previously, the app relied on WalletKit through Oxide which exported the bindings for `AddressBook` (and other types) using the `legacy-nullifiers` feature. 

Adding this functionality to `WalletKit` to enable clients to migrate from `Oxide` to `WalletKit` without missing dependencies.