### PR TITLE
Enable v4 features in Android release workflow to include Authenticator API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Build for target
         run: |
-          CROSS_NO_WARNINGS=0 cross build -p walletkit --target ${{ matrix.settings.target }} --release --locked
+          CROSS_NO_WARNINGS=0 cross build -p walletkit --target ${{ matrix.settings.target }} --release --locked --features v4
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Enables v4 features in Android release workflow to include Authenticator API

The release workflow was building Android binaries without the v4 feature flag, causing the Authenticator API (`InitializingAuthenticator`, `RegistrationStatus`, etc.) to be excluded from published releases. The local build script (`kotlin/build.sh`) already includes `--features v4`, but the CI workflow was missing it. This adds `--features v4` to the parallel matrix builds in the release workflow to match local builds and include the v4 API.