### PR TITLE
Remove global symbol stripping to fix Kotlin bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,4 @@ world-id-core = { version = "0.3", default-features = false, features = ["authen
 opt-level = 'z' # Optimize for size.
 lto = true      # Enable Link Time Optimization.
 panic = "abort"
-strip = "symbols"
 debug = false


### PR DESCRIPTION
- Removes global symbol stripping to fix Kotlin bindings

The `strip = "symbols"` setting in `Cargo.toml` breaks `uniffi-bindgen` because it can't read metadata from stripped libraries. iOS builds still get size optimizations from the linker flags added in PR #173 

Caught by https://github.com/worldcoin/walletkit/actions/runs/21462437422/job/61817588991?pr=173

```
Running `target/debug/uniffi-bindgen generate /home/runner/work/walletkit/walletkit/target/release/libwalletkit.so --language kotlin --library --crate walletkit_core --out-dir /home/runner/work/walletkit/walletkit/kotlin/walletkit/src/main/java`
Crate walletkit_core not found in /home/runner/work/walletkit/walletkit/target/release/libwalletkit.so
Error: Process completed with exit code 1.
```

## Testing
- Kotlin/Android CI builds should now pass
- iOS builds maintain their size optimizations

If everything looks good we need to issue a new release right after 🚀 