### PR TITLE
chore: temporarily allow openssl

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,10 +6,11 @@ all-features = true
 unknown-registry = "deny"
 
 [bans]
-deny = [
-    { name = "openssl-sys", reason = "increases complexity for foreign binding compilation and bundle size" },
-    { name = "openssl", reason = "increases complexity for foreign binding compilation and bundle size" }
-]
+# FIXME: Temporarily allowing openssl until it can be removed prior to v4 release
+# deny = [
+#     { name = "openssl-sys", reason = "increases complexity for foreign binding compilation and bundle size" },
+#     { name = "openssl", reason = "increases complexity for foreign binding compilation and bundle size" }
+# ]
 
 [licenses]
 version = 2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that relaxes dependency policy checks. The main risk is allowing `openssl`/`openssl-sys` to persist unnoticed until the planned removal.
> 
> **Overview**
> **Relaxes `cargo-deny` bans** by commenting out the `[bans].deny` entries for `openssl` and `openssl-sys` in `deny.toml`.
> 
> Adds a `FIXME` note indicating this is temporary until OpenSSL can be removed before the v4 release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eae6420302fb851d6b008651d0edf9486a641aa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>eae6420</u></sup><!-- /BUGBOT_STATUS -->