### PR TITLE
feat: full merkle proof caching & retrieval

### DIFF
--- a/walletkit-core/src/authenticator/utils.rs
+++ b/walletkit-core/src/authenticator/utils.rs
@@ -2,7 +2,6 @@ use std::convert::TryFrom;
 
 use crate::error::WalletKitError;
 use crate::U256Wrapper;
-use ruint::aliases::U256;
 
 /// Converts a leaf index from `U256Wrapper` to `u64`.
 ///
@@ -16,20 +15,4 @@ pub(super) fn leaf_index_to_u64(
         attribute: "leaf_index".to_string(),
         reason: "leaf index does not fit in u64".to_string(),
     })
-}
-
-pub(super) fn parse_fixed_bytes<const N: usize>(
-    bytes: Vec<u8>,
-    label: &str,
-) -> Result<[u8; N], WalletKitError> {
-    bytes
-        .try_into()
-        .map_err(|bytes: Vec<u8>| WalletKitError::InvalidInput {
-            attribute: label.to_string(),
-            reason: format!("length mismatch: expected {N}, got {}", bytes.len()),
-        })
-}
-
-pub(super) fn u256_to_hex(value: U256) -> String {
-    format!("{value:#066x}")
 }

--- a/walletkit-core/src/authenticator/with_storage.rs
+++ b/walletkit-core/src/authenticator/with_storage.rs
@@ -1,18 +1,18 @@
+use ruint::aliases::U256;
 use serde::{Deserialize, Serialize};
 use world_id_core::primitives::authenticator::AuthenticatorPublicKeySet;
 use world_id_core::primitives::merkle::MerkleInclusionProof;
 use world_id_core::primitives::TREE_DEPTH;
-use world_id_core::OnchainKeyRepresentable;
 
 use crate::error::WalletKitError;
 
-use super::utils::{leaf_index_to_u64, parse_fixed_bytes, u256_to_hex};
+use super::utils::leaf_index_to_u64;
 use super::Authenticator;
 
-/// Buffer cached proofs to remain valid during on-chain verification.
-const MERKLE_PROOF_VALIDITY_BUFFER_SECS: u64 = 120;
+/// The amount of time a Merkle inclusion proof remains valid in the cache.
+const MERKLE_PROOF_VALIDITY_SECONDS: u64 = 60 * 15;
 
-#[uniffi::export(async_runtime = "tokio")]
+#[uniffi::export]
 impl Authenticator {
     /// Initializes storage using the authenticator's leaf index.
     ///
@@ -20,75 +20,61 @@ impl Authenticator {
     ///
     /// Returns an error if the leaf index is invalid or storage initialization fails.
     pub fn init_storage(&self, now: u64) -> Result<(), WalletKitError> {
+        // TODO: Update leaf_index to final type to avoid conversion (requires upstream protocol update)
         let leaf_index = leaf_index_to_u64(&self.leaf_index())?;
         self.store.init(leaf_index, now)?;
         Ok(())
     }
+}
 
-    /// Fetches an inclusion proof, using the storage cache when possible.
-    ///
-    /// The cached payload uses `CachedInclusionProof` CBOR encoding and is keyed by
-    /// (`registry_kind`, `root`, `leaf_index`).
-    ///
-    /// Returns the decoded proof with hex-encoded field elements and compressed
-    /// authenticator public keys.
+impl Authenticator {
+    /// Fetches a [`MerkleInclusionProof`] from the indexer, or from cache if it's available and fresh.
     ///
     /// # Errors
     ///
     /// Returns an error if fetching or caching the proof fails.
-    #[allow(clippy::future_not_send)]
-    pub async fn fetch_inclusion_proof_cached(
+    #[allow(dead_code)] // TODO: Temporary while this gets integrated
+    async fn fetch_inclusion_proof_with_cache(
         &self,
-        registry_kind: u8,
-        root: Vec<u8>,
         now: u64,
-        ttl_seconds: u64,
-    ) -> Result<InclusionProofPayload, WalletKitError> {
-        let root = parse_fixed_bytes::<32>(root, "root")?;
-        let valid_before = now.saturating_add(MERKLE_PROOF_VALIDITY_BUFFER_SECS);
-        if let Some(bytes) =
-            self.store
-                .merkle_cache_get(registry_kind, root.to_vec(), valid_before)?
-        {
+    ) -> Result<
+        (MerkleInclusionProof<TREE_DEPTH>, AuthenticatorPublicKeySet),
+        WalletKitError,
+    > {
+        // If there is a cached inclusion proof, return it
+        if let Some(bytes) = self.store.merkle_cache_get(now)? {
             if let Some(cached) = CachedInclusionProof::deserialize(&bytes) {
-                return inclusion_proof_payload_from_cached(&cached);
+                if U256::from(cached.inclusion_proof.leaf_index) == self.leaf_index().0
+                {
+                    return Ok((cached.inclusion_proof, cached.authenticator_keyset));
+                }
             }
         }
 
-        let (proof, key_set) = self.inner.fetch_inclusion_proof().await?;
+        // Otherwise, fetch from the indexer and cache it
+        let (inclusion_proof, authenticator_keyset) =
+            self.inner.fetch_inclusion_proof().await?;
         let payload = CachedInclusionProof {
-            proof: proof.clone(),
-            authenticator_pubkeys: key_set,
+            inclusion_proof: inclusion_proof.clone(),
+            authenticator_keyset: authenticator_keyset.clone(),
         };
-        let payload_bytes = payload.serialize()?;
-        let proof_root = {
-            let mut bytes = Vec::new();
-            proof.root.serialize_as_bytes(&mut bytes)?;
-            parse_fixed_bytes::<32>(bytes, "field_element")?
-        };
-        if proof_root != root {
-            return Err(WalletKitError::InvalidInput {
-                attribute: "root".to_string(),
-                reason: "fetched proof root does not match requested root".to_string(),
-            });
+        let payload = payload.serialize()?;
+
+        if let Err(e) =
+            self.store
+                .merkle_cache_put(payload, now, MERKLE_PROOF_VALIDITY_SECONDS)
+        {
+            log::error!("Failed to cache Merkle inclusion proof: {e}");
         }
-        self.store.merkle_cache_put(
-            registry_kind,
-            root.to_vec(),
-            payload_bytes,
-            now,
-            ttl_seconds,
-        )?;
-        // FIXME: this requires a refactor. deliberately panicking because it should not be used yet.
-        todo!("this requires refactoring for the proof caching");
-        //inclusion_proof_payload_from_cached(&payload)
+
+        Ok((inclusion_proof, authenticator_keyset))
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedInclusionProof {
-    proof: MerkleInclusionProof<TREE_DEPTH>,
-    authenticator_pubkeys: AuthenticatorPublicKeySet,
+    inclusion_proof: MerkleInclusionProof<TREE_DEPTH>,
+    authenticator_keyset: AuthenticatorPublicKeySet,
 }
 
 impl CachedInclusionProof {
@@ -105,47 +91,6 @@ impl CachedInclusionProof {
     fn deserialize(bytes: &[u8]) -> Option<Self> {
         ciborium::de::from_reader(bytes).ok()
     }
-}
-
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct InclusionProofPayload {
-    /// Merkle root as hex string.
-    pub root: String,
-    /// Leaf index for the account.
-    pub leaf_index: u64,
-    /// Sibling path as hex strings.
-    pub siblings: Vec<String>,
-    /// Compressed authenticator public keys as hex strings.
-    pub authenticator_pubkeys: Vec<String>,
-}
-
-fn inclusion_proof_payload_from_cached(
-    payload: &CachedInclusionProof,
-) -> Result<InclusionProofPayload, WalletKitError> {
-    let authenticator_pubkeys = payload
-        .authenticator_pubkeys
-        .iter()
-        .map(|pk| {
-            let encoded = pk.to_ethereum_representation().map_err(|err| {
-                WalletKitError::Generic {
-                    error: format!("failed to encode authenticator pubkey: {err}"),
-                }
-            })?;
-            Ok(u256_to_hex(encoded))
-        })
-        .collect::<Result<Vec<_>, WalletKitError>>()?;
-
-    Ok(InclusionProofPayload {
-        root: payload.proof.root.to_string(),
-        leaf_index: payload.proof.leaf_index,
-        siblings: payload
-            .proof
-            .siblings
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect(),
-        authenticator_pubkeys,
-    })
 }
 
 #[cfg(test)]
@@ -166,35 +111,27 @@ mod tests {
 
         let siblings = [FieldElement::from(0u64); TREE_DEPTH];
         let root_fe = FieldElement::from(123u64);
-        let proof = MerkleInclusionProof::new(root_fe, 42, siblings);
-        let key_set = AuthenticatorPublicKeySet::new(None).expect("key set");
+        let inclusion_proof = MerkleInclusionProof::new(root_fe, 42, siblings);
+        let authenticator_keyset =
+            AuthenticatorPublicKeySet::new(None).expect("key set");
         let payload = CachedInclusionProof {
-            proof: proof.clone(),
-            authenticator_pubkeys: key_set,
+            inclusion_proof,
+            authenticator_keyset,
         };
         let payload_bytes = payload.serialize().expect("serialize");
-        let root_bytes: [u8; 32] = {
-            let mut bytes = Vec::new();
-            proof
-                .root
-                .serialize_as_bytes(&mut bytes)
-                .expect("serialize field element");
-            parse_fixed_bytes::<32>(bytes, "field_element")
-                .expect("field element bytes")
-        };
 
         store
-            .merkle_cache_put(1, root_bytes.to_vec(), payload_bytes, 100, 60)
+            .merkle_cache_put(payload_bytes, 100, 60)
             .expect("cache put");
-        let valid_before = 110;
+        let now = 110;
         let cached = store
-            .merkle_cache_get(1, root_bytes.to_vec(), valid_before)
+            .merkle_cache_get(now)
             .expect("cache get")
             .expect("cache hit");
         let decoded = CachedInclusionProof::deserialize(&cached).expect("decode");
-        assert_eq!(decoded.proof.leaf_index, 42);
-        assert_eq!(decoded.proof.root, root_fe);
-        assert_eq!(decoded.authenticator_pubkeys.len(), 0);
+        assert_eq!(decoded.inclusion_proof.leaf_index, 42);
+        assert_eq!(decoded.inclusion_proof.root, root_fe);
+        assert_eq!(decoded.authenticator_keyset.len(), 0);
         cleanup_test_storage(&root);
     }
 }

--- a/walletkit-core/src/storage/cache/merkle.rs
+++ b/walletkit-core/src/storage/cache/merkle.rs
@@ -2,11 +2,10 @@
 
 use rusqlite::Connection;
 
-use crate::storage::error::StorageResult;
+use crate::storage::{cache::util::CACHE_KEY_PREFIX_MERKLE, error::StorageResult};
 
 use super::util::{
-    cache_entry_times, get_cache_entry, merkle_cache_key, prune_expired_entries,
-    upsert_cache_entry,
+    cache_entry_times, get_cache_entry, prune_expired_entries, upsert_cache_entry,
 };
 
 /// Fetches a cached Merkle proof if it is still valid.
@@ -16,13 +15,9 @@ use super::util::{
 /// Returns an error if the query or conversion fails.
 pub(super) fn get(
     conn: &Connection,
-    registry_kind: u8,
-    root: [u8; 32],
-    leaf_index: u64,
-    valid_before: u64,
+    valid_until: u64,
 ) -> StorageResult<Option<Vec<u8>>> {
-    let key = merkle_cache_key(registry_kind, root, leaf_index);
-    get_cache_entry(conn, key.as_slice(), valid_before, None)
+    get_cache_entry(conn, &[CACHE_KEY_PREFIX_MERKLE], valid_until, None)
 }
 
 /// Inserts or replaces a cached Merkle proof with a TTL.
@@ -32,15 +27,11 @@ pub(super) fn get(
 /// Returns an error if pruning or insert fails.
 pub(super) fn put(
     conn: &Connection,
-    registry_kind: u8,
-    root: [u8; 32],
-    leaf_index: u64,
     proof_bytes: &[u8],
     now: u64,
     ttl_seconds: u64,
 ) -> StorageResult<()> {
     prune_expired_entries(conn, now)?;
-    let key = merkle_cache_key(registry_kind, root, leaf_index);
     let times = cache_entry_times(now, ttl_seconds)?;
-    upsert_cache_entry(conn, key.as_slice(), proof_bytes, times)
+    upsert_cache_entry(conn, &[CACHE_KEY_PREFIX_MERKLE], proof_bytes, times)
 }

--- a/walletkit-core/src/storage/cache/util.rs
+++ b/walletkit-core/src/storage/cache/util.rs
@@ -187,19 +187,6 @@ fn cache_key_with_prefix(prefix: u8, payload: &[u8]) -> Vec<u8> {
     key
 }
 
-/// Builds the cache key for a Merkle proof entry.
-pub(super) fn merkle_cache_key(
-    registry_kind: u8,
-    root: [u8; 32],
-    leaf_index: u64,
-) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(1 + 32 + 8);
-    payload.push(registry_kind);
-    payload.extend_from_slice(root.as_ref());
-    payload.extend_from_slice(&leaf_index.to_be_bytes());
-    cache_key_with_prefix(CACHE_KEY_PREFIX_MERKLE, &payload)
-}
-
 /// Builds the cache key for a session key entry.
 pub(super) fn session_cache_key(rp_id: [u8; 32]) -> Vec<u8> {
     cache_key_with_prefix(CACHE_KEY_PREFIX_SESSION, rp_id.as_ref())

--- a/walletkit-core/tests/common.rs
+++ b/walletkit-core/tests/common.rs
@@ -27,6 +27,12 @@ impl InMemoryKeystore {
     }
 }
 
+impl Default for InMemoryKeystore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DeviceKeystore for InMemoryKeystore {
     fn seal(
         &self,
@@ -84,6 +90,12 @@ impl InMemoryBlobStore {
         Self {
             blobs: Mutex::new(HashMap::new()),
         }
+    }
+}
+
+impl Default for InMemoryBlobStore {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/walletkit-core/tests/credential_storage_integration.rs
+++ b/walletkit-core/tests/credential_storage_integration.rs
@@ -31,58 +31,14 @@ fn test_storage_flow_end_to_end() {
     assert_eq!(record.issuer_schema_id, 7);
     assert_eq!(record.expires_at, 1_800_000_000);
 
-    let root_bytes = vec![0xAAu8; 32];
     store
-        .merkle_cache_put(1, root_bytes.clone(), vec![9, 9], 100, 10)
+        .merkle_cache_put(vec![9, 9], 100, 10)
         .expect("cache put");
-    let valid_before = 105;
-    let hit = store
-        .merkle_cache_get(1, root_bytes.clone(), valid_before)
-        .expect("cache get");
+    let now = 105;
+    let hit = store.merkle_cache_get(now).expect("cache get");
     assert_eq!(hit, Some(vec![9, 9]));
-    let miss = store
-        .merkle_cache_get(1, root_bytes, 111)
-        .expect("cache get");
+    let miss = store.merkle_cache_get(111).expect("cache get");
     assert!(miss.is_none());
-
-    // FIXME
-    // let request_id = [0xABu8; 32];
-    // let nullifier = [0xCDu8; 32];
-    // let fresh = CredentialStorage::begin_replay_guard(
-    //     &mut store,
-    //     request_id,
-    //     nullifier,
-    //     vec![1, 2],
-    //     200,
-    //     50,
-    // )
-    // .expect("disclose");
-    // assert_eq!(
-    //     fresh,
-    //     ReplayGuardResult {
-    //         kind: ReplayGuardKind::Fresh,
-    //         bytes: vec![1, 2],
-    //     }
-    // );
-    // let cached = CredentialStorage::is_nullifier_replay(&store, request_id, 210)
-    //     .expect("disclosure lookup");
-    // assert_eq!(cached, Some(vec![1, 2]));
-    // let replay = CredentialStorage::begin_replay_guard(
-    //     &mut store,
-    //     request_id,
-    //     nullifier,
-    //     vec![9, 9],
-    //     201,
-    //     50,
-    // )
-    // .expect("replay");
-    // assert_eq!(
-    //     replay,
-    //     ReplayGuardResult {
-    //         kind: ReplayGuardKind::Replay,
-    //         bytes: vec![1, 2],
-    //     }
-    // );
 
     common::cleanup_storage(&root);
 }


### PR DESCRIPTION
### What changed?

- Simplified the Merkle proof caching API by caching one global inclusion proof response. We don't need namespacing per-index or root, otherwise the caching is not useful.
- Removed unused utility functions (`parse_fixed_bytes` and `u256_to_hex`) from the authenticator utils

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Merkle-proof cache keying and public storage APIs, which can affect cache hit/miss behavior and correctness if consumers relied on per-root/per-registry scoping.
> 
> **Overview**
> Simplifies Merkle inclusion proof caching to a *single global cache entry* (keyed only by the Merkle-cache prefix) instead of being namespaced by `registry_kind`, `root`, and `leaf_index`, updating `CredentialStore`/`CacheDb` APIs and tests accordingly.
> 
> Adds an `Authenticator::fetch_inclusion_proof_with_cache` path that reads/writes the cached CBOR-encoded `(MerkleInclusionProof, AuthenticatorPublicKeySet)` with a 15-minute TTL (and leaf-index guard), and removes now-unused authenticator utilities (`parse_fixed_bytes`, `u256_to_hex`) plus adds `Default` impls for in-memory test keystore/blob store helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edd05136eae6168cefa73368d3a1c92cded80632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->