### PR TITLE
chore: remove openssl except android builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
@@ -162,7 +162,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
       - run: |

--- a/.github/workflows/initiate-release.yml
+++ b/.github/workflows/initiate-release.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get new version
         id: version
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
@@ -75,7 +75,7 @@ jobs:
           zip -r WalletKit.xcframework.zip swift/WalletKit.xcframework
 
       - name: Checkout swift repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: worldcoin/walletkit-swift
           token: ${{ secrets.WALLETKIT_BOT_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
@@ -186,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 
@@ -261,7 +261,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.pre-release-checks.outputs.commit_sha }} # to ensure all builds are consistent
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,11 +6,10 @@ all-features = true
 unknown-registry = "deny"
 
 [bans]
-# FIXME: Temporarily allowing openssl until it can be removed prior to v4 release
-# deny = [
-#     { name = "openssl-sys", reason = "increases complexity for foreign binding compilation and bundle size" },
-#     { name = "openssl", reason = "increases complexity for foreign binding compilation and bundle size" }
-# ]
+deny = [
+    # openssl-sys is allowed to bundle it in Android apps which require it for sqlcipher
+    { name = "openssl", reason = "increases complexity for foreign binding compilation and bundle size" }
+]
 
 [licenses]
 version = 2

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -48,13 +48,21 @@ subtle = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 zeroize = "1"
-rusqlite = { version = "0.32", features = [
-    "bundled-sqlcipher-vendored-openssl",
-], optional = true }
 uuid = { version = "1.10", features = ["v4"], optional = true }
 uniffi = { workspace = true, features = ["build", "tokio"] }
 world-id-core = { workspace = true }
 ciborium = { version = "0.2.2", optional = true }
+
+# For Android, OpenSSL gets bundled through openssl-sys
+[target.'cfg(target_os = "android")'.dependencies]
+rusqlite = { version = "0.32", default-features = false, features = [
+    "bundled-sqlcipher-vendored-openssl",
+], optional = true }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+rusqlite = { version = "0.32", default-features = false, features = [
+    "bundled-sqlcipher",
+], optional = true }
 
 [dev-dependencies]
 alloy = { version = "1", default-features = false, features = [


### PR DESCRIPTION
Potentially supersedes https://github.com/worldcoin/walletkit/pull/193. Simpler approach to bundling OpenSSL only on Android targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency feature flags and cargo-deny bans around `openssl`/`rusqlite`, which can affect build/linking and bundled artifacts across platforms; CI workflow updates are low risk.
> 
> **Overview**
> This PR updates all GitHub Actions workflows to use `actions/checkout@v6` in CI and release pipelines.
> 
> It changes `walletkit-core`’s `rusqlite` configuration to be target-specific: Android builds use `bundled-sqlcipher-vendored-openssl` while non-Android builds use `bundled-sqlcipher`, aiming to avoid bundling OpenSSL outside Android.
> 
> It also re-enables `cargo-deny` banning for `openssl` (while leaving `openssl-sys` implicitly allowed for Android bundling), replacing the previously commented-out temporary allowlist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be97155979bd475a77b2833e8ce720764d4ee832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->