### PR TITLE
TFH NFC Issuer code improvements

### DIFF
--- a/walletkit-core/src/issuers/mod.rs
+++ b/walletkit-core/src/issuers/mod.rs
@@ -2,4 +2,4 @@
 
 mod tfh_nfc;
 
-pub use tfh_nfc::{NfcCredential, TfhNfcIssuer};
+pub use tfh_nfc::TfhNfcIssuer;

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -4,6 +4,7 @@ use crate::{error::WalletKitError, http_request::Request, Environment};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::Deserialize;
 use std::collections::HashMap;
+use world_id_core::Credential;
 
 /// Response from NFC refresh endpoint
 #[derive(Debug, Clone, Deserialize)]
@@ -17,22 +18,19 @@ struct NfcRefreshResultRaw {
     credential: String,
 }
 
-/// Raw NFC credential blob
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct NfcCredential {
-    /// Raw credential bytes (decoded from base64)
-    pub credential_blob: Vec<u8>,
-}
-
 impl NfcRefreshResultRaw {
-    fn parse(&self) -> Result<NfcCredential, WalletKitError> {
-        let credential_blob = STANDARD.decode(&self.credential).map_err(|e| {
+    fn parse(&self) -> Result<Credential, WalletKitError> {
+        let credential_bytes = STANDARD.decode(&self.credential).map_err(|e| {
             WalletKitError::SerializationError {
                 error: format!("Failed to decode NFC base64 credential: {e}"),
             }
         })?;
 
-        Ok(NfcCredential { credential_blob })
+        serde_json::from_slice(&credential_bytes).map_err(|e| {
+            WalletKitError::SerializationError {
+                error: format!("Failed to deserialize NFC credential: {e}"),
+            }
+        })
     }
 }
 
@@ -43,7 +41,7 @@ pub struct TfhNfcIssuer {
     request: Request,
 }
 
-#[uniffi::export(async_runtime = "tokio")]
+#[uniffi::export]
 impl TfhNfcIssuer {
     /// Create a new TFH NFC issuer for the specified environment
     #[uniffi::constructor]
@@ -60,17 +58,21 @@ impl TfhNfcIssuer {
             request: Request::new(),
         }
     }
+}
 
-    /// Refresh an NFC credential (migrate PCP to v4)
+impl TfhNfcIssuer {
+    /// Refresh an NFC credential (migrate PCP to v4).
+    ///
+    /// Calls the `/v2/refresh` endpoint and returns a parsed [`Credential`].
     ///
     /// # Errors
     ///
-    /// Returns error on network failure or invalid response
+    /// Returns error on network failure or invalid response.
     pub async fn refresh_nfc_credential(
         &self,
         request_body: &str,
         headers: HashMap<String, String>,
-    ) -> Result<NfcCredential, WalletKitError> {
+    ) -> Result<Credential, WalletKitError> {
         let url = format!("{}/v2/refresh", self.base_url);
 
         let headers_vec: Vec<(&str, &str)> = headers
@@ -135,21 +137,33 @@ mod tests {
 
     #[test]
     fn test_parse_credential() {
-        let credential_bytes = b"raw credential data";
-        let credential_base64 = STANDARD.encode(credential_bytes);
+        let credential = Credential::new();
+        let credential_json = serde_json::to_vec(&credential).unwrap();
+        let credential_base64 = STANDARD.encode(&credential_json);
 
         let raw = NfcRefreshResultRaw {
             credential: credential_base64,
         };
 
         let parsed = raw.parse().unwrap();
-        assert_eq!(parsed.credential_blob, credential_bytes);
+        assert_eq!(parsed.version, credential.version);
+        assert_eq!(parsed.issuer_schema_id, credential.issuer_schema_id);
     }
 
     #[test]
     fn test_parse_credential_invalid_base64() {
         let raw = NfcRefreshResultRaw {
             credential: "not valid base64!!!".to_string(),
+        };
+
+        let err = raw.parse().unwrap_err();
+        assert!(matches!(err, WalletKitError::SerializationError { .. }));
+    }
+
+    #[test]
+    fn test_parse_credential_invalid_json() {
+        let raw = NfcRefreshResultRaw {
+            credential: STANDARD.encode(b"not valid json"),
         };
 
         let err = raw.parse().unwrap_err();


### PR DESCRIPTION
1. Refactor: return parsed `Credential` from `refresh_nfc_credential` instead of raw bytes;