### PR TITLE
[Feat] Enable issuers feature in walletkit package

### DIFF
--- a/walletkit/Cargo.toml
+++ b/walletkit/Cargo.toml
@@ -21,7 +21,7 @@ name = "walletkit"
 
 [dependencies]
 uniffi = { workspace = true, features = ["build", "tokio"] }
-walletkit-core = { workspace = true, features = ["legacy-nullifiers", "common-apps", "storage"] }
+walletkit-core = { workspace = true, features = ["legacy-nullifiers", "common-apps", "storage", "issuers"] }
 
 
 [features]


### PR DESCRIPTION
Add issuers feature to walletkit package dependencies to enable NFC credential issuer functionality in Swift and Kotlin bindings.