### PR TITLE
Expose id() and version() on ProofRequest and ProofResponse (also error()) via uniffi

### DIFF
--- a/walletkit-core/src/requests.rs
+++ b/walletkit-core/src/requests.rs
@@ -73,7 +73,7 @@ impl ProofResponse {
         self.0.id.clone()
     }
 
-    /// Returns the protocol version as a `u8`.
+    /// Returns the response format version as a `u8`.
     #[must_use]
     pub const fn version(&self) -> u8 {
         self.0.version as u8


### PR DESCRIPTION
Allow foreign bindings to inspect request/response id and protocol version without parsing JSON. Also allows checking the error if any occured. Also removes the TODO comment on ProofResponse.