### PR TITLE
feat: Allow overriding zkey_cache_dir in the init_with_defaults constructor

### DIFF
--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -171,8 +171,14 @@ impl Authenticator {
         environment: &Environment,
         region: Option<Region>,
         store: Arc<CredentialStore>,
+        // TODO: Add a builder pattern constructor to enable more configurability without breaking
+        // changes
+        zkey_cache_dir: Option<String>,
     ) -> Result<Self, WalletKitError> {
-        let config = Config::from_environment(environment, rpc_url, region)?;
+        let mut config = Config::from_environment(environment, rpc_url, region)?;
+        if let Some(zkey_cache_dir) = zkey_cache_dir {
+            config = config.with_zkey_cache_dir(zkey_cache_dir);
+        }
         let authenticator = CoreAuthenticator::init(seed, config).await?;
         Ok(Self {
             inner: authenticator,


### PR DESCRIPTION
This is to unblock the mobile apps for further testing. In the future a more robust mechanism of either explicit caching of circuits or a builder pattern constructor should be used.