### PR TITLE
fix: use static webpki-roots for ssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,16 +2147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "cxx-build"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6547,7 +6537,6 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "ciborium",
- "ctor",
  "dotenvy",
  "eyre",
  "hex",
@@ -6574,6 +6563,7 @@ dependencies = [
  "tracing-subscriber 0.3.22",
  "uniffi",
  "uuid",
+ "webpki-roots 1.0.6",
  "world-id-core",
  "zeroize",
 ]

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -25,7 +25,7 @@ alloy-core = { workspace = true }
 alloy-primitives = { workspace = true }
 backon = "1.6"
 base64 = { version = "0.22", optional = true }
-ctor = "0.2"
+webpki-roots = "1"
 hex = "0.4"
 hkdf = { version = "0.12", optional = true }
 log = "0.4"
@@ -59,8 +59,8 @@ world-id-core = { workspace = true, features = [
 ] }
 ciborium = { version = "0.2.2", optional = true }
 
-# for Android, OpenSSL gets bundled through openssl-sys
 [target.'cfg(target_os = "android")'.dependencies]
+# OpenSSL gets bundled through openssl-sys
 rusqlite = { version = "0.32", default-features = false, features = [
   "bundled-sqlcipher-vendored-openssl",
 ], optional = true }
@@ -84,7 +84,6 @@ dotenvy = "0.15.7"
 eyre = "0.6"
 mockito = "1.6"
 regex = "1.11"
-rustls = { version = "0.23", features = ["ring"] }
 taceo-oprf = { version = "0.5", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-test = "0.4"

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -21,19 +21,6 @@
 
 use strum::EnumString;
 
-/// Library initialization function called automatically on load.
-///
-/// Installs the ring crypto provider as the default for rustls.
-/// Uses the `ctor` crate to ensure this runs when the dynamic library loads,
-/// before any user code executes.
-#[cfg(not(test))]
-#[ctor::ctor]
-fn init() {
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("Failed to install default crypto provider");
-}
-
 /// Represents the environment in which a World ID is being presented and used.
 ///
 /// Each environment uses different sources of truth for the World ID credentials.

--- a/walletkit-core/tests/authenticator_integration.rs
+++ b/walletkit-core/tests/authenticator_integration.rs
@@ -28,9 +28,6 @@ fn setup_anvil() -> AnvilInstance {
 
 #[tokio::test]
 async fn test_authenticator_integration() {
-    // Install default crypto provider for rustls
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
     let anvil = setup_anvil();
 
     let authenticator_seeder = PrivateKeySigner::random();


### PR DESCRIPTION
reqwest 0.13 uses platform-verifier by default, which is a bit problematic on Android (see https://github.com/rustls/rustls-platform-verifier#android). this reverts back to using the static Mozilla's root store.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS root trust and crypto-provider initialization paths; mistakes could cause connection failures or unexpected trust behavior, especially across platforms (Android vs others).
> 
> **Overview**
> Switches HTTP/TLS setup to avoid Android panics from `rustls-platform-verifier` by building `reqwest` clients with a preconfigured rustls `ClientConfig` using bundled Mozilla roots (`webpki-roots`).
> 
> Removes the `ctor`-based library-load initializer and instead ensures the ring crypto provider is installed on-demand (`ensure_crypto_provider`) from authenticator constructors and the HTTP client builder; tests are updated accordingly and dependencies are adjusted (`ctor` dropped, `webpki-roots` added).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9af10abec8b4a63205a9933b81c8bc7db3e7d9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->