### PR TITLE
fix(android): make local build script path-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ To test local changes before publishing a release, use the build script to compi
 ./kotlin/build_android_local.sh 0.3.1-SNAPSHOT
 ```
 
-> **Note**: The script sets `RUSTUP_HOME` and `CARGO_HOME` to `/tmp` by default to avoid Docker permission issues when using `cross`. You can override them by exporting your own values.
+Example with custom Rust locations:
+```bash
+RUSTUP_HOME=~/.rustup CARGO_HOME=~/.cargo ./kotlin/build_android_local.sh 0.1.0-SNAPSHOT
+```
+
+> **Note**: The script can be run from any working directory (it resolves its own location). It sets `RUSTUP_HOME` and `CARGO_HOME` to `/tmp` by default to avoid Docker permission issues when using `cross`. You can override them by exporting your own values.
 
 This will:
 1. Build the Rust library for all Android architectures (arm64-v8a, armeabi-v7a, x86_64, x86)

--- a/kotlin/build_android_local.sh
+++ b/kotlin/build_android_local.sh
@@ -19,8 +19,10 @@ VERSION="$1"
 echo "Using version: $VERSION"
 
 # Build using kotlin/build.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "Building WalletKit SDK..."
-cd kotlin
 ./build.sh
 
 # Publish to Maven Local


### PR DESCRIPTION
## Summary
- Make `build_android_local.sh` path-agnostic by resolving its own directory
- Update `README` with note and example for custom `RUSTUP_HOME/CARGO_HOME`

## Context
Regression from #214: running the script from `kotlin/` fails because it `cd`'s into `kotlin`

## Testing
- Tested locally while building https://github.com/worldcoin/walletkit/pull/235