### PR TITLE
feat: multi-region indexer

### DIFF
--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -11,12 +11,6 @@ const OPRF_NODE_COUNT: usize = 5;
 
 /// Generates the list of OPRF node URLs for a given region and environment.
 fn oprf_node_urls(region: Region, environment: &Environment) -> Vec<String> {
-    let region_code = match region {
-        Region::Us => "us",
-        Region::Eu => "eu",
-        Region::Ap => "ap",
-    };
-
     let env_segment = match environment {
         Environment::Staging => ".staging",
         Environment::Production => "",
@@ -24,11 +18,17 @@ fn oprf_node_urls(region: Region, environment: &Environment) -> Vec<String> {
 
     (0..OPRF_NODE_COUNT)
         .map(|i| {
-            format!(
-                "https://node{i}.{region_code}{env_segment}.world.oprf.taceo.network"
-            )
+            format!("https://node{i}.{region}{env_segment}.world.oprf.taceo.network")
         })
         .collect()
+}
+
+fn indexer_url(region: Region, environment: &Environment) -> String {
+    let domain = match environment {
+        Environment::Staging => "worldcoin.dev",
+        Environment::Production => "world.org",
+    };
+    format!("https://indexer.{region}.id-infra.{domain}")
 }
 
 /// Build a [`Config`] from well-known defaults for a given [`Environment`].
@@ -60,7 +60,7 @@ impl DefaultConfig for Config {
                 rpc_url,
                 480, // Staging also runs on World Chain Mainnet by default
                 WORLD_ID_REGISTRY,
-                "https://world-id-indexer.stage-crypto.worldcoin.org".to_string(),
+                indexer_url(region, environment),
                 "https://world-id-gateway.stage-crypto.worldcoin.org".to_string(),
                 oprf_node_urls(region, environment),
                 3,

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -19,7 +19,7 @@
     dead_code
 )]
 
-use strum::EnumString;
+use strum::{Display, EnumString};
 
 /// Library initialization function called automatically on load.
 ///
@@ -49,7 +49,10 @@ pub enum Environment {
 }
 
 /// Region for node selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, uniffi::Enum)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, uniffi::Enum, EnumString, Display,
+)]
+#[strum(serialize_all = "lowercase")]
 pub enum Region {
     /// United States
     Us,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default network endpoints used for proof/registry interactions; mis-serialization of `Region` or incorrect domain formatting could route clients to the wrong infrastructure.
> 
> **Overview**
> `Config::from_environment` now derives the indexer endpoint from the selected `Region` instead of using a single hardcoded staging URL, via a new `indexer_url(region, environment)` helper.
> 
> OPRF node URL generation is simplified to use `Region`’s string representation directly, and `Region` now derives `EnumString`/`Display` with lowercase serialization to support these URL formats consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f2be1de19ec1913e6c0de2f1606b0bcf07cd59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->