### PR TITLE
chore: update gateway url

### DIFF
--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -61,7 +61,7 @@ impl DefaultConfig for Config {
                 480, // Staging also runs on World Chain Mainnet by default
                 WORLD_ID_REGISTRY,
                 indexer_url(region, environment),
-                "https://world-id-gateway.stage-crypto.worldcoin.org".to_string(),
+                "https://gateway.id-infra.worldcoin.dev".to_string(),
                 oprf_node_urls(region, environment),
                 3,
             )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant URL change affecting only the staging default configuration; low risk aside from potential connectivity issues if the new endpoint is incorrect.
> 
> **Overview**
> Updates the default **staging** World ID gateway URL in `walletkit-core` config defaults, switching from the legacy `world-id-gateway.stage-crypto.worldcoin.org` endpoint to `https://gateway.id-infra.worldcoin.dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e3739cda3b8ab8f8af4f49f0083719da2f46457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->