### PR TITLE
fix(ci): mark flaky staging integration test as #[ignore]

### DIFF
--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -91,6 +91,7 @@ sol!(
 /// 3. Proof generation with real staging OPRF nodes
 /// 4. On-chain proof verification via the staging `WorldIDVerifier`
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires staging infrastructure (OPRF nodes, indexer, gateway)"]
 async fn e2e_authenticator_generate_proof() -> Result<()> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(


### PR DESCRIPTION
## Summary

Adds the missing `#[ignore]` attribute to `e2e_authenticator_generate_proof` in `walletkit-core/tests/proof_generation_integration.rs`.

## Problem

The CI test job **Tests (1.92.0)** on PR #197 fails because `e2e_authenticator_generate_proof` calls external staging OPRF infrastructure and flakily errors with:

```
Error: blinding factor generation failed
Caused by: unexpected_authenticator_error
```

This same test also [flakily fails on `main`](https://github.com/worldcoin/walletkit/actions/runs/22362424624). When the MSRV job fails, the other matrix jobs (stable, nightly) get cancelled due to the default `fail-fast` strategy.

## Fix

The test's own doc comment already says:
> `cargo test --test proof_generation_integration --features default -- --ignored`

This indicates `#[ignore]` was always intended but was accidentally omitted. This PR adds:

```rust
#[ignore = "requires staging infrastructure (OPRF nodes, indexer, gateway)"]
```

The test remains available for manual runs against staging via `cargo test -- --ignored`.

## Validation

- `cargo check --workspace` passes ✅
- Test correctly shows as ignored when run ✅
- No other tests affected ✅

Resolves CI failures on #197.