### PR TITLE
feat: handle OprfNodeError in WalletKitError conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6978,8 +6978,6 @@ dependencies = [
 [[package]]
 name = "world-id-authenticator"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5305cb93ebe90ce972c8b1d299a1b2bb8929468c31c6c6ecda9fcd1926f675"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7008,8 +7006,6 @@ dependencies = [
 [[package]]
 name = "world-id-core"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9078f6bd5e0958bdb1b2563c0b2a710f23a70aa9cf2983a1ab4aea3a7c33478b"
 dependencies = [
  "taceo-eddsa-babyjubjub",
  "world-id-authenticator",
@@ -7020,8 +7016,6 @@ dependencies = [
 [[package]]
 name = "world-id-primitives"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79730f390c946fe187180c4b314c5ecba69b38f8f95d8e074112dc8e32c164c3"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -7056,8 +7050,6 @@ dependencies = [
 [[package]]
 name = "world-id-proof"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e805651187da3e340276eec37a94356053f858409ecbddfc85362eceb1a4d0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -188,6 +188,19 @@ impl From<AuthenticatorError> for WalletKitError {
                 status: None,
             },
             AuthenticatorError::PublicKeyNotFound => Self::UnauthorizedAuthenticator,
+            AuthenticatorError::OprfNodeError {
+                threshold_required,
+                node_errors,
+            } => Self::AuthenticatorError {
+                error: format!(
+                    "OPRF nodes did not reach threshold ({threshold_required} required): {}",
+                    node_errors
+                        .iter()
+                        .map(|(url, err)| format!("{url}: {err}"))
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                ),
+            },
             AuthenticatorError::GatewayError { status, body } => Self::NetworkError {
                 url: "gateway".to_string(),
                 error: body,


### PR DESCRIPTION
## Summary

Adds explicit handling for the new `AuthenticatorError::OprfNodeError` variant in the `From<AuthenticatorError> for WalletKitError` conversion.

### Context

This is a follow-up to [worldcoin/world-id-protocol#499](https://github.com/worldcoin/world-id-protocol/pull/499) which adds structured OPRF node error propagation. With that change, OPRF failures now carry specific error reasons (e.g. `"unknown schema issuer: 127"`) instead of a generic `"Could not reach N responses"` message.

### Change

Adds a match arm that formats the OPRF node error reason into the `WalletKitError::AuthenticatorError` variant:

```rust
AuthenticatorError::OprfNodeError { reason, .. } => Self::AuthenticatorError {
    error: format!("OPRF node error: {reason}"),
},
```

### Dependencies

⚠️ **This PR depends on [worldcoin/world-id-protocol#499](https://github.com/worldcoin/world-id-protocol/pull/499) being merged and the updated `world-id-core` crate being published.** Until then, CI will not compile.

### Note

Even without this change, the improved error messages from the protocol PR will already flow through via the `Display` impl on the catch-all `_ => Self::AuthenticatorError { error: error.to_string() }` arm. This explicit match arm is for clarity and to prevent future refactors from accidentally changing the error format.