### PR TITLE
experiment: ARC runner + cross with shared toolchain volume

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,9 @@ jobs:
     name: Prepare Kotlin
     runs-on: arc-public-8xlarge-amd64-runner
     needs: [pre-release-checks]
+    env:
+      CARGO_HOME: /home/runner/_work/_cargo
+      RUSTUP_HOME: /home/runner/_work/_rustup
     permissions:
       contents: write # to upload artifacts
 
@@ -151,6 +154,9 @@ jobs:
           - target: i686-linux-android
 
     steps:
+      - name: Add Cargo to PATH
+        run: echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Test whether placing CARGO_HOME and RUSTUP_HOME under the shared `/home/runner/_work/` volume fixes cross-compilation on ARC DinD runners.

Based on #267.