### PR TITLE
chore: publish walletkit-db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,12 @@ alloy-core = { version = "1", default-features = false, features = [
   "sol-types",
 ] }
 alloy-primitives = { version = "1", default-features = false }
-walletkit-core = { version = "0.7.2", path = "walletkit-core", default-features = false }
 uniffi = { version = "0.31", features = ["tokio"] }
 world-id-core = { version = "0.5", default-features = false }
+
+# internal
+walletkit-core = { version = "0.7.2", path = "walletkit-core", default-features = false }
+walletkit-db = { version = "0.7.2", path = "walletkit-db" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -59,7 +59,7 @@ world-id-core = { workspace = true, features = [
   "zstd-compress-zkeys",
 ] }
 ciborium = { version = "0.2.2", optional = true }
-walletkit-db = { path = "../walletkit-db", optional = true }
+walletkit-db = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { version = "1", default-features = false, features = [

--- a/walletkit-db/Cargo.toml
+++ b/walletkit-db/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "walletkit-db"
 description = "Internal SQLite wrapper crate for WalletKit storage."
-publish = false
-
+publish = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Allow publishing walletkit-db to crates.io

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is packaging/manifest-only work to make `walletkit-db` publishable and wire it into workspace dependency management, with no runtime logic changes.
> 
> **Overview**
> Enables publishing `walletkit-db` to crates.io by setting `publish = true` in its `Cargo.toml`.
> 
> Also promotes `walletkit-db` to a first-class workspace dependency in the root `Cargo.toml` and switches `walletkit-core` to reference it via `workspace = true` (instead of a direct path dep), aligning dependency resolution for releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7698aaf97bdb57d91dabfc211b50a250fe1ef337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->