### PR TITLE
refactor: pass explicit `dest_dir` for vault backup export

### DIFF
--- a/walletkit-core/src/storage/credential_storage.rs
+++ b/walletkit-core/src/storage/credential_storage.rs
@@ -800,7 +800,9 @@ mod tests {
         let export_dir = temp_root_path();
         std::fs::create_dir_all(&export_dir).expect("create export dir");
         let export_dir_str = export_dir.to_string_lossy().to_string();
-        let backup_path = src_inner.export_vault_for_backup(&export_dir_str).expect("export vault");
+        let backup_path = src_inner
+            .export_vault_for_backup(&export_dir_str)
+            .expect("export vault");
 
         // Verify the export file exists
         assert!(
@@ -897,7 +899,9 @@ mod tests {
         let export_dir = temp_root_path();
         std::fs::create_dir_all(&export_dir).expect("create export dir");
         let export_dir_str = export_dir.to_string_lossy().to_string();
-        let backup_path = src_inner.export_vault_for_backup(&export_dir_str).expect("export vault");
+        let backup_path = src_inner
+            .export_vault_for_backup(&export_dir_str)
+            .expect("export vault");
 
         let dst_root = temp_root_path();
         let dst_provider = InMemoryStorageProvider::new(&dst_root);
@@ -975,7 +979,9 @@ mod tests {
         let export_dir = temp_root_path();
         std::fs::create_dir_all(&export_dir).expect("create export dir");
         let export_dir_str = export_dir.to_string_lossy().to_string();
-        let backup_path = inner.export_vault_for_backup(&export_dir_str).expect("export vault");
+        let backup_path = inner
+            .export_vault_for_backup(&export_dir_str)
+            .expect("export vault");
 
         // Importing into a non-empty vault should fail — the import checks that
         // destination tables are empty before inserting.
@@ -1043,7 +1049,9 @@ mod tests {
         let export_dir = temp_root_path();
         std::fs::create_dir_all(&export_dir).expect("create export dir");
         let export_dir_str = export_dir.to_string_lossy().to_string();
-        let backup_path = inner.export_vault_for_backup(&export_dir_str).expect("export vault");
+        let backup_path = inner
+            .export_vault_for_backup(&export_dir_str)
+            .expect("export vault");
 
         // Corrupt the *last* table in BACKUP_TABLES inside the backup.
         // We target the last table so that earlier tables' INSERTs succeed
@@ -1189,5 +1197,4 @@ mod tests {
 
         cleanup_test_storage(&root);
     }
-
 }

--- a/walletkit-core/src/storage/paths.rs
+++ b/walletkit-core/src/storage/paths.rs
@@ -3,7 +3,8 @@
 use std::path::{Path, PathBuf};
 
 const VAULT_FILENAME: &str = "account.vault.sqlite";
-pub(crate) const PLAINTEXT_VAULT_BACKUP_FILENAME: &str = "vault_backup_plaintext.sqlite";
+pub(crate) const PLAINTEXT_VAULT_BACKUP_FILENAME: &str =
+    "vault_backup_plaintext.sqlite";
 const CACHE_FILENAME: &str = "account.cache.sqlite";
 const LOCK_FILENAME: &str = "lock";
 const GROTH16_DIRNAME: &str = "groth16";


### PR DESCRIPTION
Updates `export_vault_for_backup()` to take a file path to which the plaintext exported vault will be written - `dest_dir`. 

## Motivation
Previously, the plaintext vault export was written to WalletKit's own storage directory under `Documents/worldid/`. This meant that any orchestrator calling `export_vault_for_backup()`, e.g. an iOS native app, needs to copy the exported file themselves to the correct location from which any existing backup process would occur. This creates two copies of the unencrypted vault data which both need to be cleaned up. 

By making `dest_dir` an arg, the caller can write the exported plaintext vault directly to the correct place. e.g. in a reference World App implementation, World App could write the vault export directly to Bedrock's filesystem without having to first copy the file over from WalletKit storage.

Further, this change means an integrator could pass a temporary directory as the location to write the vault export: https://github.com/worldcoin/walletkit/issues/280


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API/UniFFI signature change can break downstream callers and introduces new path-handling expectations (e.g., invalid or unwritable `dest_dir`).
> 
> **Overview**
> Refactors plaintext vault backup export to require an explicit destination directory: `CredentialStore::export_vault_for_backup(dest_dir)` now writes `vault_backup_plaintext.sqlite` into the caller-provided folder instead of WalletKit’s own storage directory.
> 
> Updates internal implementation to build the export path from `dest_dir` + `PLAINTEXT_VAULT_BACKUP_FILENAME`, removes the `StoragePaths::plaintext_vault_backup_path*` helpers, and adjusts tests to create/clean up a dedicated export directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffba8c32f1e2d188fc04fc669221bfe2f9538dec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->