### PR TITLE
fix: don't publish uniffi-bindgen

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -29,8 +29,3 @@ git_release_enable = false
 changelog_update = false
 release = true
 publish = true
-
-[[package]]
-name = "uniffi-bindgen"
-release = false
-publish = false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that adjusts release-plz publish settings; main impact is on the release pipeline behavior rather than runtime code.
> 
> **Overview**
> Updates `release-plz.toml` to explicitly control publishing: disables workspace-wide publishing (`publish = false`) while enabling `publish = true` for `walletkit`, `walletkit-core`, and `walletkit-db`.
> 
> Removes the `uniffi-bindgen` package entry from release-plz config so it is no longer considered for release/publish automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b503756d15a024a16099e1acebedc8206754366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->