### PR TITLE
chore: add BigInt dep to swift

### DIFF
--- a/swift/archive_swift.sh
+++ b/swift/archive_swift.sh
@@ -74,10 +74,16 @@ let package = Package(
             name: "WalletKit",
             targets: ["WalletKit"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.7.0")),
+    ],
     targets: [
         .target(
             name: "WalletKit",
-            dependencies: ["walletkit_coreFFI"],
+            dependencies: [
+                "walletkit_coreFFI",
+                .product(name: "BigInt", package: "BigInt"),
+            ],
             path: "Sources/WalletKit"
         ),
         .binaryTarget(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes SwiftPM packaging for the Swift release artifact, with no runtime logic changes beyond introducing a new external dependency.
> 
> **Overview**
> The Swift release packaging script `swift/archive_swift.sh` now generates a `Package.swift` that declares a SwiftPM dependency on `attaswift/BigInt` and adds the `BigInt` product to the `WalletKit` target dependencies alongside the existing `walletkit_coreFFI` binary target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90792d6e21d9c5a10506dcde2b7737ff01e5c187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->