### PR TITLE
add credential storage docs from notion

### DIFF
--- a/walletkit-core/src/storage/cache/merkle.rs
+++ b/walletkit-core/src/storage/cache/merkle.rs
@@ -1,6 +1,6 @@
 //! Merkle proof cache helpers.
 
-use crate::storage::{cache::util::CACHE_KEY_PREFIX_MERKLE, error::StorageResult};
+use crate::storage::{cache::schema::CACHE_KEY_PREFIX_MERKLE, error::StorageResult};
 use walletkit_db::Connection;
 
 use super::util::{

--- a/walletkit-core/src/storage/cache/nullifiers.rs
+++ b/walletkit-core/src/storage/cache/nullifiers.rs
@@ -1,10 +1,18 @@
 //! Used-nullifier cache helpers for replay protection.
 //!
-//! Records each disclosed nullifier so a repeated disclosure of the same
-//! nullifier can be detected and refused. Enforcement is transactional. A
-//! grace period ([`REPLAY_REQUEST_NBF_SECONDS`]) delays enforcement so a proof
-//! that failed to reach the RP can be retried; entries expire after
-//! [`REPLAY_REQUEST_TTL_SECONDS`] and may be pruned.
+//! Records each disclosed nullifier so a later disclosure of the same nullifier
+//! can be detected and refused. A grace period ([`REPLAY_REQUEST_NBF_SECONDS`])
+//! delays enforcement so a proof that failed to reach the RP can be retried;
+//! entries expire after [`REPLAY_REQUEST_TTL_SECONDS`] and may be pruned.
+//!
+//! Each `replay_guard_set` insert is atomic and idempotent. Detection is *not*
+//! atomic end-to-end, though: the proof flow calls `is_nullifier_replay` (a read),
+//! generates the proof, then calls `replay_guard_set` (the insert) as separate
+//! steps, holding no lock across them. Two concurrent requests for the same
+//! nullifier can therefore both pass the check before either records its guard and
+//! both disclose. This guard defends against sequential reuse, not a concurrent
+//! race; callers that need strict single-use must serialize the check-and-set
+//! themselves.
 
 use crate::storage::error::StorageResult;
 use walletkit_db::Connection;

--- a/walletkit-core/src/storage/cache/nullifiers.rs
+++ b/walletkit-core/src/storage/cache/nullifiers.rs
@@ -26,7 +26,7 @@ const REPLAY_REQUEST_NBF_SECONDS: u64 = 600; // 10 minutes
 /// Retention window for a replay guard entry.
 ///
 /// Bounded rather than indefinite so the cache doesn't grow into a permanent
-/// on-device record of every action ever performed.
+/// record.
 static REPLAY_REQUEST_TTL_SECONDS: u64 = 60 * 60 * 24 * 365; // 1 year
 
 /// Checks whether a replay guard entry exists for the given nullifier.

--- a/walletkit-core/src/storage/cache/nullifiers.rs
+++ b/walletkit-core/src/storage/cache/nullifiers.rs
@@ -1,7 +1,10 @@
 //! Used-nullifier cache helpers for replay protection.
 //!
-//! Tracks request ids and nullifiers to enforce single-use disclosures while
-//! remaining idempotent for retries within the TTL window.
+//! Records each disclosed nullifier so a repeated disclosure of the same
+//! nullifier can be detected and refused. Enforcement is transactional. A
+//! grace period ([`REPLAY_REQUEST_NBF_SECONDS`]) delays enforcement so a proof
+//! that failed to reach the RP can be retried; entries expire after
+//! [`REPLAY_REQUEST_TTL_SECONDS`] and may be pruned.
 
 use crate::storage::error::StorageResult;
 use walletkit_db::Connection;
@@ -20,6 +23,10 @@ use super::util::{
 /// FUTURE: Parametrize this as a configuration option.
 const REPLAY_REQUEST_NBF_SECONDS: u64 = 600; // 10 minutes
 
+/// Retention window for a replay guard entry.
+///
+/// Bounded rather than indefinite so the cache doesn't grow into a permanent
+/// on-device record of every action ever performed.
 static REPLAY_REQUEST_TTL_SECONDS: u64 = 60 * 60 * 24 * 365; // 1 year
 
 /// Checks whether a replay guard entry exists for the given nullifier.

--- a/walletkit-core/src/storage/cache/nullifiers.rs
+++ b/walletkit-core/src/storage/cache/nullifiers.rs
@@ -5,14 +5,6 @@
 //! delays enforcement so a proof that failed to reach the RP can be retried;
 //! entries expire after [`REPLAY_REQUEST_TTL_SECONDS`] and may be pruned.
 //!
-//! Each `replay_guard_set` insert is atomic and idempotent. Detection is *not*
-//! atomic end-to-end, though: the proof flow calls `is_nullifier_replay` (a read),
-//! generates the proof, then calls `replay_guard_set` (the insert) as separate
-//! steps, holding no lock across them. Two concurrent requests for the same
-//! nullifier can therefore both pass the check before either records its guard and
-//! both disclose. This guard defends against sequential reuse, not a concurrent
-//! race; callers that need strict single-use must serialize the check-and-set
-//! themselves.
 
 use crate::storage::error::StorageResult;
 use walletkit_db::Connection;
@@ -31,10 +23,7 @@ use super::util::{
 /// FUTURE: Parametrize this as a configuration option.
 const REPLAY_REQUEST_NBF_SECONDS: u64 = 600; // 10 minutes
 
-/// Retention window for a replay guard entry.
-///
-/// Bounded rather than indefinite so the cache doesn't grow into a permanent
-/// record.
+/// Retention window for a replay guard entry. Bounded to avoid indefinite growth.
 static REPLAY_REQUEST_TTL_SECONDS: u64 = 60 * 60 * 24 * 365; // 1 year
 
 /// Checks whether a replay guard entry exists for the given nullifier.

--- a/walletkit-core/src/storage/cache/schema.rs
+++ b/walletkit-core/src/storage/cache/schema.rs
@@ -1,4 +1,12 @@
 //! Cache database schema management.
+//!
+//! All cacheable data lives in a single `cache_entries` table with a unified
+//! key/value/TTL structure. Entries are distinguished by a 1-byte key prefix
+//! followed by type-specific key material (see `cache/util.rs`):
+//!
+//! - `0x01 || …` — Merkle inclusion proof; value is the proof bytes.
+//! - `0x02 || oprf_seed` — session seed; value is the `session_id_r_seed`.
+//! - `0x03 || nullifier` — replay guard; value is a presence marker.
 
 use walletkit_db::{params, Connection, DbResult};
 

--- a/walletkit-core/src/storage/cache/schema.rs
+++ b/walletkit-core/src/storage/cache/schema.rs
@@ -1,10 +1,11 @@
 //! Cache database schema management.
 //!
-//! All cacheable data lives in a single `cache_entries` table with a unified
-//! key/value/TTL structure. Entries are distinguished by a 1-byte key prefix
-//! followed by type-specific key material (see `cache/util.rs`):
+//! A table for storing cachable data. Each row has a key (`key_bytes`),
+//! value (`value_bytes`) and TTL columns (see `ensure_entries_schema` for details).
 //!
-//! - `0x01 || …` — Merkle inclusion proof; value is the proof bytes.
+//! The keys adhere to the following schema:
+//!
+//! - `0x01` — Merkle inclusion proof; at most one entry; value is the proof bytes.
 //! - `0x02 || oprf_seed` — session seed; value is the `session_id_r_seed`.
 //! - `0x03 || nullifier` — replay guard; value is a presence marker.
 

--- a/walletkit-core/src/storage/cache/schema.rs
+++ b/walletkit-core/src/storage/cache/schema.rs
@@ -8,6 +8,10 @@
 //! - `0x02 || oprf_seed` — session seed; value is the `session_id_r_seed`.
 //! - `0x03 || nullifier` — replay guard; value is a presence marker.
 
+pub(super) const CACHE_KEY_PREFIX_MERKLE: u8 = 0x01;
+pub(super) const CACHE_KEY_PREFIX_SESSION: u8 = 0x02;
+pub(super) const CACHE_KEY_PREFIX_REPLAY_NULLIFIER: u8 = 0x03;
+
 use walletkit_db::{params, Connection, DbResult};
 
 const CACHE_SCHEMA_VERSION: i64 = 2;

--- a/walletkit-core/src/storage/cache/util.rs
+++ b/walletkit-core/src/storage/cache/util.rs
@@ -2,7 +2,10 @@
 
 use std::io;
 
-use crate::storage::error::{StorageError, StorageResult};
+use crate::storage::{
+    cache::schema::{CACHE_KEY_PREFIX_REPLAY_NULLIFIER, CACHE_KEY_PREFIX_SESSION},
+    error::{StorageError, StorageResult},
+};
 use walletkit_db::{params, Connection, DbError, Transaction};
 
 /// Maps a database error into a cache storage error.
@@ -34,10 +37,6 @@ pub(super) fn parse_fixed_bytes<const N: usize>(
     out.copy_from_slice(bytes);
     Ok(out)
 }
-
-pub(super) const CACHE_KEY_PREFIX_MERKLE: u8 = 0x01;
-pub(super) const CACHE_KEY_PREFIX_SESSION: u8 = 0x02;
-pub(super) const CACHE_KEY_PREFIX_REPLAY_NULLIFIER: u8 = 0x03;
 
 /// Timestamps for cache entry insertion and expiry.
 #[derive(Clone, Copy, Debug)]

--- a/walletkit-core/src/storage/keys.rs
+++ b/walletkit-core/src/storage/keys.rs
@@ -1,17 +1,10 @@
-//! Key hierarchy management for credential storage.
+//! Key management for credential storage.
 //!
-//! ## Key structure
-//!
-//! - `K_device`: device-bound root key managed by `DeviceKeystore`.
-//! - `account_keys.bin`: account key envelope stored via `AtomicBlobStore` and
-//!   containing `DeviceKeystore::seal` of `K_intermediate` with associated data
-//!   `worldid:account-key-envelope`.
-//! - `K_intermediate`: 32-byte per-account key unsealed at init and kept in
-//!   memory for the lifetime of the storage handle.
-//! - `SQLCipher` databases: `account.vault.sqlite` (authoritative) and
-//!   `account.cache.sqlite` (non-authoritative) are opened with `K_intermediate`.
-//! - Derived keys: per relying-party session keys may be derived from
-//!   `K_intermediate` and cached in `account.cache.sqlite` for performance.
+//! [`StorageKeys`] opens (or creates on first use) the account key envelope via
+//! `walletkit-db` and holds the resulting `K_intermediate` in memory for the lifetime
+//! of the storage handle; both databases are opened with it. The `K_device` →
+//! `K_intermediate` hierarchy, envelope sealing, and encryption are described in the
+//! `walletkit-db` README.
 
 use secrecy::SecretBox;
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/walletkit-core/src/storage/mod.rs
+++ b/walletkit-core/src/storage/mod.rs
@@ -41,12 +41,7 @@
 //! ## Security and privacy properties
 //!
 //! Encryption, the sealed-envelope threat model, and integrity checks are covered by
-//! the `walletkit-db` README. Specific to credential storage:
-//!
-//! - No filesystem paths encode `leaf_index`, RP identifiers, issuer names, or action
-//!   name. See [`crate::storage::StoragePaths`].
-//! - The vault (authoritative) holds the `leaf_index`, credentials, and blobs; the
-//!   cache DB holds only regenerable, TTL-bounded entries.
+//! the `walletkit-db` README.
 
 pub mod cache;
 pub mod credential_storage;

--- a/walletkit-core/src/storage/mod.rs
+++ b/walletkit-core/src/storage/mod.rs
@@ -1,18 +1,11 @@
-//! On-device encrypted storage for World ID credentials.
+//! # Credential Store
 //!
-//! # Goal
+//! On-device consisted encrypted storage for World ID credentials.
 //!
-//! A consistent method to store credentials:
-//!
-//! - Consistent API across different credential types.
-//! - Store different versions of the same credential.
-//! - Eventually (not yet implemented):
-//!   - Awareness of a credential on multiple devices (sync, originating authenticator).
-//!   - Pruning/compaction.
-//!   - Purging.
-//!   - Per-credential encryption keys (hardware-backed where available) with access
-//!     control proportional to each credential's sensitivity, rather than the single
-//!     vault-wide `K_intermediate` used today.
+//! The storage layer handles structured storage of all credentials and their
+//! associated data (only storage, the semantics of the associated data is the
+//! Issuer's responsibility). In addition the storage layer handles encryption
+//! and clean up after expiration.
 //!
 //! # Components
 //!

--- a/walletkit-core/src/storage/mod.rs
+++ b/walletkit-core/src/storage/mod.rs
@@ -1,4 +1,130 @@
-//! Credential storage primitives: key envelope and key hierarchy helpers.
+//! On-device encrypted storage for World ID credentials.
+//!
+//! # Goal
+//!
+//! A consistent method to store credentials:
+//!
+//! - Consistent API across different credential types.
+//! - Store different versions of the same credential.
+//! - Eventually (not yet implemented):
+//!   - Awareness of a credential on multiple devices (sync, originating authenticator).
+//!   - Pruning/compaction.
+//!   - Purging.
+//!   - Per-credential encryption keys (hardware-backed where available) with access
+//!     control proportional to each credential's sensitivity, rather than the single
+//!     vault-wide `K_intermediate` used today.
+//!
+//! # Components
+//!
+//! [`crate::storage::CredentialStore`] is the facade exposed to hosts (via `UniFFI`). It owns the
+//! account key envelope and two `SQLCipher` databases opened with the resulting key.
+//! The lower-level primitives (key-envelope sealing, `SQLCipher` setup,
+//! content-addressed blobs, cross-process locking, and the threat model) live in the
+//! `walletkit-db` crate — see its README for the key hierarchy and on-disk format.
+//!
+//! 1. **Device keystore root (`K_device`)** — device-bound, preferably non-exportable
+//!    key backed by Secure Enclave / Android Keystore / `WebCrypto` where available.
+//!    Used only to unwrap `K_intermediate` at init; never used directly for database
+//!    encryption. Provided by the host via [`crate::storage::DeviceKeystore`].
+//! 2. **Account key envelope (`account_keys.bin`)** — `K_intermediate` sealed under
+//!    `K_device`. Opened once per storage init and kept in memory for the lifetime of
+//!    the handle. Device-local; not synced across devices.
+//! 3. **Vault database (`account.vault.sqlite`)** — authoritative storage for
+//!    credentials, associated blobs, issuer subject blinding factors, and the account
+//!    leaf index. Encrypted via sqlite3mc (`ChaCha20-Poly1305` by default) and
+//!    integrity-protected. Corruption is a hard failure. See [`crate::storage::CredentialVault`].
+//! 4. **Cache database (`account.cache.sqlite`)** — non-authoritative, regenerable
+//!    entries: Merkle inclusion proof cache, per-account session seed, and nullifier
+//!    replay guards. Subject to TTL pruning and can be rebuilt at any time without
+//!    correctness loss. See [`crate::storage::CacheDb`].
+//!
+//! # Cryptographic keys
+//!
+//! - `K_device` — device-bound root key from the platform keystore; MUST be
+//!   non-exportable when supported.
+//! - `K_intermediate` — 32-byte per-account key, generated randomly on first use,
+//!   stored sealed under `K_device` in `account_keys.bin`, loaded once at init and
+//!   retained in memory. Used as the sqlite3mc key for both databases.
+//! - Session seed — a `session_id_r_seed` derived for session proof flows and cached
+//!   in the cache DB keyed by the OPRF seed (see `cache/session.rs`). Because it is
+//!   derived from device-local material, caching it is an optimization: a missing
+//!   entry is re-derived.
+//!
+//! ## Key hierarchy
+//!
+//! ```text
+//! Level 0 — Device Keystore Root
+//!   K_device: device-bound root key
+//!   (Secure Enclave / Android Keystore / WebCrypto; non-exportable when supported)
+//!        │ seal / open (AD = "worldid:account-key-envelope")
+//!        ▼
+//! Level 1 — Account Key Envelope (account_keys.bin)
+//!   Stores seal(AD, K_intermediate) under K_device
+//!   In-memory after init: K_intermediate (32 bytes)
+//!        │ sqlite3mc key                    │ sqlite3mc key
+//!        ▼                                  ▼
+//!   Vault DB (.vault.sqlite)           Cache DB (.cache.sqlite)
+//!   leaf_index, credentials, blobs     merkle cache, session seed, replay guards
+//! ```
+//!
+//! # On-disk layout
+//!
+//! Storage root: `<root>/worldid/` — see [`crate::storage::StoragePaths`].
+//!
+//! ```text
+//! account_keys.bin            # DeviceKeystore-sealed K_intermediate envelope
+//! account.cache.sqlite        # sqlite3mc-encrypted cache DB (keyed by K_intermediate)
+//! account.vault.sqlite        # sqlite3mc-encrypted vault DB (keyed by K_intermediate)
+//! lock                        # account-scoped lock
+//! ```
+//!
+//! # Locking and concurrency
+//!
+//! Operations that modify a persistent layer (envelope writes, vault writes, cache
+//! writes) run under an account-wide lock (`walletkit-db`'s cross-process `flock`).
+//!
+//! # Security and privacy properties
+//!
+//! - No filesystem paths encode `leaf_index`, RP identifiers, issuer names, or action
+//!   names — see [`crate::storage::StoragePaths`].
+//! - Vault contents are encrypted via sqlite3mc (keyed by `K_intermediate`,
+//!   `ChaCha20-Poly1305` by default); untrusted storage cannot read credentials. No
+//!   `OpenSSL` dependency is required.
+//! - `K_intermediate` is sealed under `K_device`; without the device keystore, neither
+//!   the envelope nor the encrypted databases can be opened.
+//! - The vault (authoritative) holds the `leaf_index`, credentials, and blobs. The
+//!   cache DB holds only regenerable, TTL-bounded entries.
+//! - Nullifier replay guards are intentionally short-lived to avoid creating a
+//!   long-lived "interaction history" on device.
+//!
+//! # Operational flow: unique action proof
+//!
+//! ```text
+//! RP ─► Authenticator: signed proof request (rp_id, action, nonce, signal)
+//!
+//! ── Account initialized/unlocked once per session ──
+//! Authenticator ─► Storage: init(leaf_index, now)
+//!   Storage: unwrap K_intermediate via device keystore,
+//!            open sqlite3mc vault + cache DBs keyed by K_intermediate
+//!
+//! ── Merkle inclusion proof lookup ──
+//! Authenticator ─► Storage: merkle_cache_get(valid_until)
+//!   if cache hit (not expired): return proof_bytes
+//!   else: fetch inclusion proof from Indexer, then
+//!         Storage: merkle_cache_put(proof_bytes, now, ttl_seconds)
+//!
+//! ── OPRF query phase (blinded leaf index + query proof) ──
+//! Authenticator ─► OPRF Nodes: query proof + blinded request context
+//! OPRF Nodes ─► Authenticator: blinded responses (threshold)
+//! Authenticator: construct proof + nullifier
+//!
+//! ── Replay-safety / single-use enforcement ──
+//! Authenticator ─► Storage: is_nullifier_replay(nullifier, now)
+//!   if true (seen before, past the grace period):
+//!     MUST NOT disclose a new proof for that nullifier
+//!   else:
+//!     Storage: replay_guard_set(nullifier, now); disclose proof to RP
+//! ```
 
 pub mod cache;
 pub mod credential_storage;

--- a/walletkit-core/src/storage/mod.rs
+++ b/walletkit-core/src/storage/mod.rs
@@ -1,123 +1,49 @@
 //! # Credential Store
 //!
-//! On-device consisted encrypted storage for World ID credentials.
+//! On-device, consistent, encrypted storage for World ID credentials.
 //!
 //! The storage layer handles structured storage of all credentials and their
 //! associated data (only storage, the semantics of the associated data is the
 //! Issuer's responsibility). In addition the storage layer handles encryption
 //! and clean up after expiration.
 //!
-//! # Components
+//! ## Components
 //!
-//! [`crate::storage::CredentialStore`] is the facade exposed to hosts (via `UniFFI`). It owns the
-//! account key envelope and two `SQLCipher` databases opened with the resulting key.
-//! The lower-level primitives (key-envelope sealing, `SQLCipher` setup,
-//! content-addressed blobs, cross-process locking, and the threat model) live in the
-//! `walletkit-db` crate — see its README for the key hierarchy and on-disk format.
+//! [`crate::storage::CredentialStore`] is the facade exposed to hosts (via `UniFFI`).
+//! It owns the account key envelope and two databases:
 //!
-//! 1. **Device keystore root (`K_device`)** — device-bound, preferably non-exportable
-//!    key backed by Secure Enclave / Android Keystore / `WebCrypto` where available.
-//!    Used only to unwrap `K_intermediate` at init; never used directly for database
-//!    encryption. Provided by the host via [`crate::storage::DeviceKeystore`].
-//! 2. **Account key envelope (`account_keys.bin`)** — `K_intermediate` sealed under
-//!    `K_device`. Opened once per storage init and kept in memory for the lifetime of
-//!    the handle. Device-local; not synced across devices.
-//! 3. **Vault database (`account.vault.sqlite`)** — authoritative storage for
-//!    credentials, associated blobs, issuer subject blinding factors, and the account
-//!    leaf index. Encrypted via sqlite3mc (`ChaCha20-Poly1305` by default) and
-//!    integrity-protected. Corruption is a hard failure. See [`crate::storage::CredentialVault`].
-//! 4. **Cache database (`account.cache.sqlite`)** — non-authoritative, regenerable
+//! 1. **Vault database (`account.vault.sqlite`)** — authoritative storage for
+//!    credentials, associated data blobs, issuer subject blinding factors, and the account
+//!    leaf index. Corruption is a hard failure. See [`crate::storage::CredentialVault`].
+//! 2. **Cache database (`account.cache.sqlite`)** — non-authoritative, regenerable
 //!    entries: Merkle inclusion proof cache, per-account session seed, and nullifier
 //!    replay guards. Subject to TTL pruning and can be rebuilt at any time without
 //!    correctness loss. See [`crate::storage::CacheDb`].
 //!
-//! # Cryptographic keys
+//! The encrypted-storage primitives beneath these — the sealed key envelope, the
+//! `K_device` → `K_intermediate` key hierarchy, sqlite3mc encryption, the
+//! cross-process lock, content-addressed blobs, and the threat model are owned by
+//! the [`walletkit-db`](https://docs.rs/crate/walletkit-db/latest) crate.
 //!
-//! - `K_device` — device-bound root key from the platform keystore; MUST be
-//!   non-exportable when supported.
-//! - `K_intermediate` — 32-byte per-account key, generated randomly on first use,
-//!   stored sealed under `K_device` in `account_keys.bin`, loaded once at init and
-//!   retained in memory. Used as the sqlite3mc key for both databases.
-//! - Session seed — a `session_id_r_seed` derived for session proof flows and cached
-//!   in the cache DB keyed by the OPRF seed (see `cache/session.rs`). Because it is
-//!   derived from device-local material, caching it is an optimization: a missing
-//!   entry is re-derived.
+//! ## Keys
 //!
-//! ## Key hierarchy
+//! Both databases are opened with the single `K_intermediate` managed by
+//! `walletkit-db`.
 //!
-//! ```text
-//! Level 0 — Device Keystore Root
-//!   K_device: device-bound root key
-//!   (Secure Enclave / Android Keystore / WebCrypto; non-exportable when supported)
-//!        │ seal / open (AD = "worldid:account-key-envelope")
-//!        ▼
-//! Level 1 — Account Key Envelope (account_keys.bin)
-//!   Stores seal(AD, K_intermediate) under K_device
-//!   In-memory after init: K_intermediate (32 bytes)
-//!        │ sqlite3mc key                    │ sqlite3mc key
-//!        ▼                                  ▼
-//!   Vault DB (.vault.sqlite)           Cache DB (.cache.sqlite)
-//!   leaf_index, credentials, blobs     merkle cache, session seed, replay guards
-//! ```
+//! ## On-disk layout
 //!
-//! # On-disk layout
+//! All artifacts live under `<root>/worldid/`; see [`crate::storage::StoragePaths`]
+//! for the full file layout.
 //!
-//! Storage root: `<root>/worldid/` — see [`crate::storage::StoragePaths`].
+//! ## Security and privacy properties
 //!
-//! ```text
-//! account_keys.bin            # DeviceKeystore-sealed K_intermediate envelope
-//! account.cache.sqlite        # sqlite3mc-encrypted cache DB (keyed by K_intermediate)
-//! account.vault.sqlite        # sqlite3mc-encrypted vault DB (keyed by K_intermediate)
-//! lock                        # account-scoped lock
-//! ```
-//!
-//! # Locking and concurrency
-//!
-//! Operations that modify a persistent layer (envelope writes, vault writes, cache
-//! writes) run under an account-wide lock (`walletkit-db`'s cross-process `flock`).
-//!
-//! # Security and privacy properties
+//! Encryption, the sealed-envelope threat model, and integrity checks are covered by
+//! the `walletkit-db` README. Specific to credential storage:
 //!
 //! - No filesystem paths encode `leaf_index`, RP identifiers, issuer names, or action
-//!   names — see [`crate::storage::StoragePaths`].
-//! - Vault contents are encrypted via sqlite3mc (keyed by `K_intermediate`,
-//!   `ChaCha20-Poly1305` by default); untrusted storage cannot read credentials. No
-//!   `OpenSSL` dependency is required.
-//! - `K_intermediate` is sealed under `K_device`; without the device keystore, neither
-//!   the envelope nor the encrypted databases can be opened.
-//! - The vault (authoritative) holds the `leaf_index`, credentials, and blobs. The
+//!   name. See [`crate::storage::StoragePaths`].
+//! - The vault (authoritative) holds the `leaf_index`, credentials, and blobs; the
 //!   cache DB holds only regenerable, TTL-bounded entries.
-//! - Nullifier replay guards are intentionally short-lived to avoid creating a
-//!   long-lived "interaction history" on device.
-//!
-//! # Operational flow: unique action proof
-//!
-//! ```text
-//! RP ─► Authenticator: signed proof request (rp_id, action, nonce, signal)
-//!
-//! ── Account initialized/unlocked once per session ──
-//! Authenticator ─► Storage: init(leaf_index, now)
-//!   Storage: unwrap K_intermediate via device keystore,
-//!            open sqlite3mc vault + cache DBs keyed by K_intermediate
-//!
-//! ── Merkle inclusion proof lookup ──
-//! Authenticator ─► Storage: merkle_cache_get(valid_until)
-//!   if cache hit (not expired): return proof_bytes
-//!   else: fetch inclusion proof from Indexer, then
-//!         Storage: merkle_cache_put(proof_bytes, now, ttl_seconds)
-//!
-//! ── OPRF query phase (blinded leaf index + query proof) ──
-//! Authenticator ─► OPRF Nodes: query proof + blinded request context
-//! OPRF Nodes ─► Authenticator: blinded responses (threshold)
-//! Authenticator: construct proof + nullifier
-//!
-//! ── Replay-safety / single-use enforcement ──
-//! Authenticator ─► Storage: is_nullifier_replay(nullifier, now)
-//!   if true (seen before, past the grace period):
-//!     MUST NOT disclose a new proof for that nullifier
-//!   else:
-//!     Storage: replay_guard_set(nullifier, now); disclose proof to RP
-//! ```
 
 pub mod cache;
 pub mod credential_storage;

--- a/walletkit-core/src/storage/mod.rs
+++ b/walletkit-core/src/storage/mod.rs
@@ -32,8 +32,11 @@
 //!
 //! ## On-disk layout
 //!
-//! All artifacts live under `<root>/worldid/`; see [`crate::storage::StoragePaths`]
-//! for the full file layout.
+//! The vault, cache, and lock live under `<root>/worldid/` — see
+//! [`crate::storage::StoragePaths`]. The account key envelope (`account_keys.bin`) is
+//! written separately through the host's [`crate::storage::AtomicBlobStore`] and its
+//! location is host-determined (not necessarily under `worldid/`); backup and
+//! deletion must include it.
 //!
 //! ## Security and privacy properties
 //!

--- a/walletkit-core/src/storage/paths.rs
+++ b/walletkit-core/src/storage/paths.rs
@@ -1,4 +1,18 @@
 //! Storage path helpers.
+//!
+//! All credential storage artifacts live under `<root>/worldid/`:
+//!
+//! ```text
+//! account_keys.bin            # DeviceKeystore-sealed K_intermediate envelope
+//! account.cache.sqlite        # sqlite3mc-encrypted cache DB (keyed by K_intermediate)
+//! account.vault.sqlite        # sqlite3mc-encrypted vault DB (keyed by K_intermediate)
+//! lock                        # account-scoped lock
+//! groth16/                    # cached Groth16 proving material
+//! ```
+//!
+//! Filenames are fixed and generic by design: none of them encode a relying-party
+//! ID, action name, issuer name, or the account's leaf index, so directory listings
+//! and backup archives don't leak which accounts or actions exist on a device.
 
 use std::path::{Path, PathBuf};
 

--- a/walletkit-core/src/storage/paths.rs
+++ b/walletkit-core/src/storage/paths.rs
@@ -17,10 +17,6 @@
 //! `<root>/account_keys.bin` alongside (not inside) the `worldid/` directory. Host
 //! implementors backing up or deleting an account MUST include the envelope from the
 //! blob store in addition to the `worldid/` files.
-//!
-//! Filenames are fixed and generic by design: none of them encode a relying-party
-//! ID, action name, issuer name, or the account's leaf index, so directory listings
-//! and backup archives don't leak which accounts or actions exist on a device.
 
 use std::path::{Path, PathBuf};
 

--- a/walletkit-core/src/storage/paths.rs
+++ b/walletkit-core/src/storage/paths.rs
@@ -1,14 +1,22 @@
 //! Storage path helpers.
 //!
-//! All credential storage artifacts live under `<root>/worldid/`:
+//! [`StoragePaths`] governs the on-disk files under `<root>/worldid/`:
 //!
 //! ```text
-//! account_keys.bin            # DeviceKeystore-sealed K_intermediate envelope
 //! account.cache.sqlite        # sqlite3mc-encrypted cache DB (keyed by K_intermediate)
 //! account.vault.sqlite        # sqlite3mc-encrypted vault DB (keyed by K_intermediate)
 //! lock                        # account-scoped lock
 //! groth16/                    # cached Groth16 proving material
 //! ```
+//!
+//! The account key envelope (`account_keys.bin`) is **not** covered by
+//! [`StoragePaths`]. It is persisted through the host's `AtomicBlobStore` using the
+//! bare filename `account_keys.bin`, so its physical location is whatever root the
+//! host roots that blob store at — which need not be `<root>/worldid/`. For example,
+//! the CLI provider roots the blob store at `<root>`, writing the envelope to
+//! `<root>/account_keys.bin` alongside (not inside) the `worldid/` directory. Host
+//! implementors backing up or deleting an account MUST include the envelope from the
+//! blob store in addition to the `worldid/` files.
 //!
 //! Filenames are fixed and generic by design: none of them encode a relying-party
 //! ID, action name, issuer name, or the account's leaf index, so directory listings

--- a/walletkit-core/src/storage/traits.rs
+++ b/walletkit-core/src/storage/traits.rs
@@ -53,6 +53,12 @@ pub trait DeviceKeystore: Send + Sync {
 }
 
 /// Atomic blob store for small binary files (e.g., `account_keys.bin`).
+///
+/// `path` is a bare, storage-relative filename (e.g. `account_keys.bin`), not an
+/// absolute path — the implementation resolves it against whatever root it chooses.
+/// That root is independent of [`StoragePaths`], so the key envelope need not live
+/// under `<root>/worldid/`; a host that backs up or deletes an account must persist
+/// and remove these blobs separately from the `worldid/` files.
 #[uniffi::export(with_foreign)]
 pub trait AtomicBlobStore: Send + Sync {
     /// Reads the blob at `path`, if present.

--- a/walletkit-core/src/storage/traits.rs
+++ b/walletkit-core/src/storage/traits.rs
@@ -53,12 +53,6 @@ pub trait DeviceKeystore: Send + Sync {
 }
 
 /// Atomic blob store for small binary files (e.g., `account_keys.bin`).
-///
-/// `path` is a bare, storage-relative filename (e.g. `account_keys.bin`), not an
-/// absolute path — the implementation resolves it against whatever root it chooses.
-/// That root is independent of [`StoragePaths`], so the key envelope need not live
-/// under `<root>/worldid/`; a host that backs up or deletes an account must persist
-/// and remove these blobs separately from the `worldid/` files.
 #[uniffi::export(with_foreign)]
 pub trait AtomicBlobStore: Send + Sync {
     /// Reads the blob at `path`, if present.

--- a/walletkit-core/src/storage/traits.rs
+++ b/walletkit-core/src/storage/traits.rs
@@ -1,4 +1,19 @@
 //! Platform interfaces for credential storage.
+//!
+//! These traits are the platform integration boundary. The host selects the storage
+//! root and provides a [`DeviceKeystore`] and [`AtomicBlobStore`]; core storage code
+//! is root-agnostic and consumes a provider-supplied [`StoragePaths`].
+//!
+//! # Expected platform components
+//!
+//! - **iOS (Swift):** [`DeviceKeystore`] backed by Keychain / Secure Enclave;
+//!   [`AtomicBlobStore`] over the app container filesystem (atomic replace).
+//! - **Android (Kotlin):** [`DeviceKeystore`] backed by the Android Keystore;
+//!   [`AtomicBlobStore`] over app internal storage (atomic replace).
+//! - **Node.js:** file-backed [`DeviceKeystore`] (development; production can use an
+//!   OS keystore); [`AtomicBlobStore`] over app internal storage.
+//! - **Browser (WASM):** `WebCrypto`-backed [`DeviceKeystore`]; [`AtomicBlobStore`]
+//!   over an origin-private storage namespace.
 
 use std::sync::Arc;
 

--- a/walletkit-core/src/storage/types.rs
+++ b/walletkit-core/src/storage/types.rs
@@ -39,6 +39,10 @@ pub use walletkit_db::ContentId;
 pub type RequestId = [u8; 32];
 
 /// Nullifier identifier used for replay safety.
+///
+/// Replay guard entries keyed by a nullifier are intentionally short-lived
+/// (bounded by TTL) to avoid accumulating a long-lived "interaction history"
+/// on device.
 pub type Nullifier = [u8; 32];
 
 /// In-memory representation of stored credential metadata.

--- a/walletkit-core/src/storage/types.rs
+++ b/walletkit-core/src/storage/types.rs
@@ -39,10 +39,6 @@ pub use walletkit_db::ContentId;
 pub type RequestId = [u8; 32];
 
 /// Nullifier identifier used for replay safety.
-///
-/// Replay guard entries keyed by a nullifier are intentionally short-lived
-/// (bounded by TTL) to avoid accumulating a long-lived "interaction history"
-/// on device.
 pub type Nullifier = [u8; 32];
 
 /// In-memory representation of stored credential metadata.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and import-path refactor only; no runtime or crypto logic changes.
> 
> **Overview**
> Adds **module-level documentation** across `walletkit-core` credential storage, ported from Notion: vault vs cache roles, `CredentialStore` facade, on-disk layout under `worldid/`, and pointers to `walletkit-db` for crypto/threat model.
> 
> **`storage/mod.rs`** is expanded into a full “Credential Store” overview. **`paths.rs`**, **`traits.rs`**, and **`keys.rs`** document layout, platform integration (iOS/Android/Node/WASM), and that key hierarchy lives in `walletkit-db`. **`cache/schema.rs`** documents the unified `cache_entries` key-byte schema (`0x01` Merkle, `0x02` session, `0x03` replay). **`nullifiers.rs`** clarifies replay-guard semantics (grace period, TTL).
> 
> **Refactor:** cache key prefix constants move from **`cache/util.rs`** to **`cache/schema.rs`**; **`merkle.rs`** and **`util.rs`** import them from schema (behavior unchanged). **`nullifiers.rs`** adds a doc comment on `REPLAY_REQUEST_TTL_SECONDS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710ee405e44014a851a436f4126641ced93586e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->