### PR TITLE
feat: new walletkit cli commands for simpler e2e testing

### DIFF
--- a/walletkit-cli/src/commands/auth.rs
+++ b/walletkit-cli/src/commands/auth.rs
@@ -12,6 +12,72 @@ use super::{
     resolve_seed, Cli,
 };
 
+/// Outcome of a registration attempt.
+pub enum RegisterOutcome {
+    Finalized,
+    AlreadyRegistered,
+}
+
+/// Registers an authenticator and polls until finalized or already registered.
+pub async fn register_and_poll(
+    cli: &Cli,
+    seed: &[u8],
+    recovery_address: Option<&str>,
+    poll_interval: u64,
+) -> eyre::Result<RegisterOutcome> {
+    let config_json = resolve_config(cli)?;
+
+    let result = if let Some(ref config) = config_json {
+        InitializingAuthenticator::register(
+            seed,
+            config,
+            recovery_address.map(String::from),
+        )
+        .await
+    } else {
+        let env = resolve_environment(cli)?;
+        let region = resolve_region(cli)?;
+        InitializingAuthenticator::register_with_defaults(
+            seed,
+            cli.rpc_url.clone(),
+            &env,
+            region,
+            recovery_address.map(String::from),
+        )
+        .await
+    };
+
+    let init_auth = match result {
+        Ok(auth) => auth,
+        Err(WalletKitError::NetworkError { ref error, .. })
+            if error.contains("authenticator_already_exists") =>
+        {
+            return Ok(RegisterOutcome::AlreadyRegistered);
+        }
+        Err(e) => return Err(e).wrap_err("registration failed"),
+    };
+
+    loop {
+        let status = init_auth.poll_status().await.wrap_err("poll failed")?;
+
+        match &status {
+            RegistrationStatus::Finalized => return Ok(RegisterOutcome::Finalized),
+            RegistrationStatus::Failed { error, error_code } => {
+                eyre::bail!("registration failed: {error} (code: {error_code:?})");
+            }
+            _ => {
+                let status_str = format!("{status:?}");
+                if !cli.json {
+                    eprintln!(
+                        "Status: {status_str} — polling again in {poll_interval}s..."
+                    );
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(poll_interval)).await;
+            }
+        }
+    }
+}
+
 #[derive(Subcommand)]
 pub enum AuthCommand {
     /// Register a new World ID (returns immediately).
@@ -91,68 +157,25 @@ async fn run_register_wait(
     poll_interval: u64,
 ) -> eyre::Result<()> {
     let seed = resolve_seed(cli)?;
-    let config_json = resolve_config(cli)?;
+    let outcome =
+        register_and_poll(cli, &seed, recovery_address, poll_interval).await?;
 
-    let result = if let Some(ref config) = config_json {
-        InitializingAuthenticator::register(
-            &seed,
-            config,
-            recovery_address.map(String::from),
-        )
-        .await
-    } else {
-        let env = resolve_environment(cli)?;
-        let region = resolve_region(cli)?;
-        InitializingAuthenticator::register_with_defaults(
-            &seed,
-            cli.rpc_url.clone(),
-            &env,
-            region,
-            recovery_address.map(String::from),
-        )
-        .await
-    };
-
-    let init_auth = match result {
-        Ok(auth) => auth,
-        Err(WalletKitError::NetworkError { ref error, .. })
-            if error.contains("authenticator_already_exists") =>
-        {
+    match outcome {
+        RegisterOutcome::AlreadyRegistered => {
             output::print_success("Already registered.", cli.json);
-            return Ok(());
         }
-        Err(e) => return Err(e).wrap_err("registration failed"),
-    };
-
-    loop {
-        let status = init_auth.poll_status().await.wrap_err("poll failed")?;
-
-        match &status {
-            RegistrationStatus::Finalized => {
-                if cli.json {
-                    output::print_json_data(
-                        &serde_json::json!({ "status": "Finalized" }),
-                        true,
-                    );
-                } else {
-                    println!("Registration finalized.");
-                }
-                return Ok(());
-            }
-            RegistrationStatus::Failed { error, error_code } => {
-                eyre::bail!("registration failed: {error} (code: {error_code:?})");
-            }
-            _ => {
-                let status_str = format!("{status:?}");
-                if !cli.json {
-                    eprintln!(
-                        "Status: {status_str} — polling again in {poll_interval}s..."
-                    );
-                }
-                tokio::time::sleep(std::time::Duration::from_secs(poll_interval)).await;
+        RegisterOutcome::Finalized => {
+            if cli.json {
+                output::print_json_data(
+                    &serde_json::json!({ "status": "Finalized" }),
+                    true,
+                );
+            } else {
+                println!("Registration finalized.");
             }
         }
     }
+    Ok(())
 }
 
 fn run_recovery_data(cli: &Cli) -> eyre::Result<()> {

--- a/walletkit-cli/src/commands/credential.rs
+++ b/walletkit-cli/src/commands/credential.rs
@@ -264,27 +264,29 @@ async fn run_issue(
 }
 
 const FAUX_ISSUER_URL: &str = "https://faux-issuer.us.id-infra.worldcoin.dev/issue";
-const FAUX_ISSUER_SCHEMA_ID: u64 = 128;
+pub const FAUX_ISSUER_SCHEMA_ID: u64 = 128;
 
-async fn run_issue_test(cli: &Cli) -> eyre::Result<()> {
-    let (authenticator, store) = init_authenticator(cli).await?;
+/// Result of issuing a test credential from the faux issuer.
+pub struct IssuedTestCredential {
+    pub credential_id: u64,
+    pub issuer_schema_id: u64,
+    pub expires_at: u64,
+    pub blinding_factor: FieldElement,
+}
 
-    // Step 1: OPRF to get blinding factor
+/// Issues a test credential from the staging faux issuer (schema 128).
+pub async fn issue_test_credential(
+    authenticator: &walletkit_core::Authenticator,
+    store: &walletkit_core::storage::CredentialStore,
+) -> eyre::Result<IssuedTestCredential> {
     let bf = authenticator
         .generate_credential_blinding_factor_remote(FAUX_ISSUER_SCHEMA_ID)
         .await
         .wrap_err("blinding factor generation failed")?;
 
-    // Step 2: Compute sub from blinding factor
     let sub = authenticator.compute_credential_sub(&bf);
     let sub_hex = sub.to_hex_string();
 
-    if !cli.json {
-        println!("Computed sub: {sub_hex}");
-        println!("Requesting credential from faux issuer...");
-    }
-
-    // Step 3: POST to faux issuer
     let client = reqwest::Client::new();
     let resp = client
         .post(FAUX_ISSUER_URL)
@@ -314,27 +316,44 @@ async fn run_issue_test(cli: &Cli) -> eyre::Result<()> {
         .wrap_err("invalid credential from faux issuer")?;
     let expires_at = cred.expires_at();
 
-    // Step 4: Store the credential
     let now = now_secs()?;
     let id = store
         .store_credential(&cred, &bf, expires_at, None, now)
         .wrap_err("store credential failed")?;
 
+    Ok(IssuedTestCredential {
+        credential_id: id,
+        issuer_schema_id: FAUX_ISSUER_SCHEMA_ID,
+        expires_at,
+        blinding_factor: bf,
+    })
+}
+
+async fn run_issue_test(cli: &Cli) -> eyre::Result<()> {
+    let (authenticator, store) = init_authenticator(cli).await?;
+    let result = issue_test_credential(&authenticator, &store).await?;
+
     if cli.json {
         output::print_json_data(
             &serde_json::json!({
-                "credential_id": id,
-                "issuer_schema_id": FAUX_ISSUER_SCHEMA_ID,
-                "expires_at": expires_at,
-                "blinding_factor": bf.to_hex_string(),
+                "credential_id": result.credential_id,
+                "issuer_schema_id": result.issuer_schema_id,
+                "expires_at": result.expires_at,
+                "blinding_factor": result.blinding_factor.to_hex_string(),
             }),
             true,
         );
     } else {
-        println!("Credential issued from faux issuer (id={id})");
-        println!("  issuer_schema_id: {FAUX_ISSUER_SCHEMA_ID}");
-        println!("  expires_at: {expires_at}");
-        println!("  blinding_factor: {}", bf.to_hex_string());
+        println!(
+            "Credential issued from faux issuer (id={})",
+            result.credential_id
+        );
+        println!("  issuer_schema_id: {}", result.issuer_schema_id);
+        println!("  expires_at: {}", result.expires_at);
+        println!(
+            "  blinding_factor: {}",
+            result.blinding_factor.to_hex_string()
+        );
     }
     Ok(())
 }

--- a/walletkit-cli/src/commands/mod.rs
+++ b/walletkit-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod credential;
 mod proof;
 mod recovery_agent;
 mod recovery_binding;
+mod setup;
 mod wallet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -110,6 +111,12 @@ pub enum Command {
     RecoveryBinding {
         #[command(subcommand)]
         action: recovery_binding::RecoveryBindingCommand,
+    },
+    /// Initialize wallet and register account in one step.
+    Setup {
+        /// Poll interval in seconds while waiting for registration.
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
     },
 }
 
@@ -251,5 +258,6 @@ pub async fn run(cli: Cli) -> eyre::Result<()> {
             let environment = resolve_environment(&cli)?;
             recovery_binding::run(&cli, action, &environment).await
         }
+        Command::Setup { poll_interval } => setup::run(&cli, *poll_interval).await,
     }
 }

--- a/walletkit-cli/src/commands/proof.rs
+++ b/walletkit-cli/src/commands/proof.rs
@@ -18,6 +18,7 @@ use world_id_core::requests::{
 
 use crate::output;
 
+use super::credential::{issue_test_credential, FAUX_ISSUER_SCHEMA_ID};
 use super::{init_authenticator, Cli};
 
 const DEFAULT_RPC_URL: &str = "https://worldchain-mainnet.g.alchemy.com/public";
@@ -85,6 +86,12 @@ pub enum ProofCommand {
         /// Override the `WorldID` verifier contract address (default: mainnet).
         #[arg(long)]
         verifier_address: Option<String>,
+    },
+    /// End-to-end test: issue a test credential, generate a proof, and verify it on-chain.
+    Test {
+        /// Signal string for the proof request.
+        #[arg(long, default_value = "test_signal")]
+        signal: String,
     },
 }
 
@@ -159,20 +166,21 @@ fn run_inspect_request(cli: &Cli, request: &str) -> eyre::Result<()> {
     Ok(())
 }
 
-async fn run_verify(
+/// Result of verifying one proof response item against the `WorldIDVerifier` contract.
+pub struct VerifyItemResult {
+    pub issuer_schema_id: u64,
+    pub identifier: String,
+    pub verified: bool,
+    pub error: Option<String>,
+}
+
+/// Verifies a proof request + response pair on-chain. Returns per-item results.
+pub async fn verify_proof_onchain(
     cli: &Cli,
-    request_path: &str,
-    response_path: &str,
+    proof_request: &CoreProofRequest,
+    proof_response: &CoreProofResponse,
     verifier_address: Option<&str>,
-) -> eyre::Result<()> {
-    let request_json = read_file_or_stdin(request_path)?;
-    let response_json = read_file_or_stdin(response_path)?;
-
-    let proof_request: CoreProofRequest =
-        serde_json::from_str(&request_json).wrap_err("invalid proof request")?;
-    let proof_response: CoreProofResponse =
-        serde_json::from_str(&response_json).wrap_err("invalid proof response")?;
-
+) -> eyre::Result<Vec<VerifyItemResult>> {
     if let Some(ref err) = proof_response.error {
         eyre::bail!("proof response contains error: {err}");
     }
@@ -194,7 +202,6 @@ async fn run_verify(
     let rp_id = proof_request.rp_id.into_inner();
 
     let mut results = Vec::new();
-
     for response_item in &proof_response.responses {
         let request_item = proof_request
             .find_request_by_issuer_schema_id(response_item.issuer_schema_id)
@@ -227,51 +234,85 @@ async fn run_verify(
             .call()
             .await;
 
-        let verified = result.is_ok();
-        let error_msg = result.err().map(|e| format!("{e:#}"));
+        results.push(VerifyItemResult {
+            issuer_schema_id: response_item.issuer_schema_id,
+            identifier: response_item.identifier.clone(),
+            verified: result.is_ok(),
+            error: result.err().map(|e| format!("{e:#}")),
+        });
+    }
+    Ok(results)
+}
 
-        results.push(serde_json::json!({
-            "issuer_schema_id": response_item.issuer_schema_id,
-            "identifier": response_item.identifier,
-            "verified": verified,
-            "error": error_msg,
-        }));
-
-        if !cli.json {
-            if verified {
-                println!(
-                    "  [PASS] {} (issuer_schema_id={})",
-                    response_item.identifier, response_item.issuer_schema_id
-                );
-            } else {
-                println!(
-                    "  [FAIL] {} (issuer_schema_id={}): {}",
-                    response_item.identifier,
-                    response_item.issuer_schema_id,
-                    error_msg.as_deref().unwrap_or("unknown")
-                );
-            }
+fn print_verify_items_human(results: &[VerifyItemResult]) {
+    for r in results {
+        if r.verified {
+            println!(
+                "  [PASS] {} (issuer_schema_id={})",
+                r.identifier, r.issuer_schema_id
+            );
+        } else {
+            println!(
+                "  [FAIL] {} (issuer_schema_id={}): {}",
+                r.identifier,
+                r.issuer_schema_id,
+                r.error.as_deref().unwrap_or("unknown")
+            );
         }
     }
+}
 
-    let all_passed = results.iter().all(|r| r["verified"] == true);
+fn verify_items_to_json(results: &[VerifyItemResult]) -> Vec<serde_json::Value> {
+    results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "issuer_schema_id": r.issuer_schema_id,
+                "identifier": r.identifier,
+                "verified": r.verified,
+                "error": r.error,
+            })
+        })
+        .collect()
+}
+
+async fn run_verify(
+    cli: &Cli,
+    request_path: &str,
+    response_path: &str,
+    verifier_address: Option<&str>,
+) -> eyre::Result<()> {
+    let request_json = read_file_or_stdin(request_path)?;
+    let response_json = read_file_or_stdin(response_path)?;
+
+    let proof_request: CoreProofRequest =
+        serde_json::from_str(&request_json).wrap_err("invalid proof request")?;
+    let proof_response: CoreProofResponse =
+        serde_json::from_str(&response_json).wrap_err("invalid proof response")?;
+
+    let results =
+        verify_proof_onchain(cli, &proof_request, &proof_response, verifier_address)
+            .await?;
+    let all_passed = results.iter().all(|r| r.verified);
 
     if cli.json {
         output::print_json_data(
             &serde_json::json!({
                 "verified": all_passed,
-                "results": results,
+                "results": verify_items_to_json(&results),
             }),
             true,
         );
-    } else if all_passed {
-        println!("All proofs verified on-chain.");
+    } else {
+        print_verify_items_human(&results);
+        if all_passed {
+            println!("All proofs verified on-chain.");
+        }
     }
 
     if !all_passed {
         std::process::exit(1);
     }
-
     Ok(())
 }
 
@@ -283,12 +324,12 @@ const STAGING_RP_SIGNING_KEY: [u8; 32] = alloy::primitives::hex!(
     "1111111111111111111111111111111111111111111111111111111111111111"
 );
 
-fn run_generate_test_request(
-    cli: &Cli,
+/// Builds a signed test proof request using hardcoded staging RP keys.
+fn build_test_request(
     issuer_schema_id: u64,
     signal: &str,
     expires_in: u64,
-) -> eyre::Result<()> {
+) -> eyre::Result<CoreProofRequest> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time after epoch")
@@ -310,8 +351,6 @@ fn run_generate_test_request(
     );
     let signature = signer.sign_message_sync(&msg).wrap_err("signing failed")?;
 
-    // Build as JSON value to avoid depending on the exact `OprfKeyId`
-    // crate version used by `world-id-primitives`.
     let rp_id = RpId::new(STAGING_RP_ID);
     let request_item = RequestItem::new(
         "test".to_string(),
@@ -321,13 +360,12 @@ fn run_generate_test_request(
         None,
     );
 
-    let partial = CoreProofRequest {
+    Ok(CoreProofRequest {
         id: "test_request".to_string(),
         version: RequestVersion::V1,
         created_at,
         expires_at,
         rp_id,
-        // Use a placeholder — we patch it below via JSON.
         oprf_key_id: serde_json::from_value(serde_json::json!(format!(
             "0x{:040x}",
             STAGING_RP_ID
@@ -339,9 +377,17 @@ fn run_generate_test_request(
         nonce,
         requests: vec![request_item],
         constraints: None,
-    };
+    })
+}
 
-    let json = serde_json::to_string_pretty(&partial)?;
+fn run_generate_test_request(
+    cli: &Cli,
+    issuer_schema_id: u64,
+    signal: &str,
+    expires_in: u64,
+) -> eyre::Result<()> {
+    let request = build_test_request(issuer_schema_id, signal, expires_in)?;
+    let json = serde_json::to_string_pretty(&request)?;
 
     if cli.json {
         let parsed: serde_json::Value = serde_json::from_str(&json)?;
@@ -350,6 +396,66 @@ fn run_generate_test_request(
         println!("{json}");
     }
 
+    Ok(())
+}
+
+/// End-to-end test: issue a test credential, generate a proof, and verify it on-chain.
+async fn run_test(cli: &Cli, signal: &str) -> eyre::Result<()> {
+    let (authenticator, store) = init_authenticator(cli).await?;
+
+    if !cli.json {
+        eprintln!("Issuing test credential from faux issuer...");
+    }
+    let issued = issue_test_credential(&authenticator, &store).await?;
+
+    if !cli.json {
+        eprintln!("Generating test proof request...");
+    }
+    let proof_request = build_test_request(FAUX_ISSUER_SCHEMA_ID, signal, 300)?;
+
+    if !cli.json {
+        eprintln!("Generating proof...");
+    }
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_secs();
+    let walletkit_request =
+        ProofRequest::from_json(&serde_json::to_string(&proof_request)?)
+            .wrap_err("invalid proof request")?;
+    let proof_response = authenticator
+        .generate_proof(&walletkit_request, Some(ts))
+        .await
+        .wrap_err("proof generation failed")?;
+
+    if !cli.json {
+        eprintln!("Verifying proof on-chain...");
+    }
+    let results =
+        verify_proof_onchain(cli, &proof_request, &proof_response.0, None).await?;
+    let all_passed = results.iter().all(|r| r.verified);
+
+    if cli.json {
+        output::print_json_data(
+            &serde_json::json!({
+                "credential_id": issued.credential_id,
+                "issuer_schema_id": issued.issuer_schema_id,
+                "blinding_factor": issued.blinding_factor.to_hex_string(),
+                "verified": all_passed,
+                "results": verify_items_to_json(&results),
+            }),
+            true,
+        );
+    } else {
+        print_verify_items_human(&results);
+        if all_passed {
+            println!("End-to-end test passed.");
+        }
+    }
+
+    if !all_passed {
+        std::process::exit(1);
+    }
     Ok(())
 }
 
@@ -369,5 +475,6 @@ pub async fn run(cli: &Cli, action: &ProofCommand) -> eyre::Result<()> {
             response,
             verifier_address,
         } => run_verify(cli, request, response, verifier_address.as_deref()).await,
+        ProofCommand::Test { signal } => run_test(cli, signal).await,
     }
 }

--- a/walletkit-cli/src/commands/setup.rs
+++ b/walletkit-cli/src/commands/setup.rs
@@ -1,0 +1,127 @@
+//! `walletkit setup` — one-shot wallet initialization and account registration.
+
+use eyre::WrapErr as _;
+use walletkit_core::error::WalletKitError;
+use walletkit_core::storage::cache_embedded_groth16_material;
+use walletkit_core::{InitializingAuthenticator, RegistrationStatus};
+
+use crate::output;
+use crate::provider::create_fs_credential_store;
+
+use super::{
+    resolve_config, resolve_environment, resolve_region, resolve_root, Cli,
+};
+
+pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
+    let root = resolve_root(cli)?;
+    let seed_path = root.join("seed");
+
+    // Fail if wallet already exists.
+    eyre::ensure!(
+        !seed_path.exists(),
+        "wallet already exists at {}; use `walletkit auth register-wait` to register an existing wallet",
+        root.display()
+    );
+
+    // --- wallet init ---
+    std::fs::create_dir_all(&root)?;
+    let store = create_fs_credential_store(&root)?;
+    let paths = store.storage_paths()?;
+    cache_embedded_groth16_material(&paths)?;
+
+    // Generate and persist a 32-byte seed.
+    let mut seed = vec![0u8; 32];
+    {
+        use rand::RngCore;
+        rand::rngs::OsRng.fill_bytes(&mut seed);
+    }
+    let seed_hex = hex::encode(&seed);
+    std::fs::write(&seed_path, &seed_hex)?;
+
+    if !cli.json {
+        eprintln!("Wallet initialized at {}", root.display());
+        eprintln!("  seed: {seed_hex}");
+    }
+
+    // --- auth register-wait ---
+    let config_json = resolve_config(cli)?;
+
+    let result = if let Some(ref config) = config_json {
+        InitializingAuthenticator::register(
+            &seed,
+            config,
+            None, // no recovery address
+        )
+        .await
+    } else {
+        let env = resolve_environment(cli)?;
+        let region = resolve_region(cli)?;
+        InitializingAuthenticator::register_with_defaults(
+            &seed,
+            cli.rpc_url.clone(),
+            &env,
+            region,
+            None, // no recovery address
+        )
+        .await
+    };
+
+    let init_auth = match result {
+        Ok(auth) => auth,
+        Err(WalletKitError::NetworkError { ref error, .. })
+            if error.contains("authenticator_already_exists") =>
+        {
+            let data = serde_json::json!({
+                "seed": seed_hex,
+                "root": root.display().to_string(),
+                "status": "AlreadyRegistered",
+            });
+            if cli.json {
+                output::print_json_data(&data, true);
+            } else {
+                println!("Account already registered.");
+            }
+            return Ok(());
+        }
+        Err(e) => return Err(e).wrap_err("registration failed"),
+    };
+
+    if !cli.json {
+        eprintln!("Registration submitted, waiting for finalization...");
+    }
+
+    loop {
+        let status = init_auth.poll_status().await.wrap_err("poll failed")?;
+
+        match &status {
+            RegistrationStatus::Finalized => {
+                let data = serde_json::json!({
+                    "seed": seed_hex,
+                    "root": root.display().to_string(),
+                    "status": "Finalized",
+                });
+                if cli.json {
+                    output::print_json_data(&data, true);
+                } else {
+                    println!("Setup complete. Account registered and finalized.");
+                    println!("  root: {}", root.display());
+                    println!("  seed: {seed_hex}");
+                }
+                return Ok(());
+            }
+            RegistrationStatus::Failed { error, error_code } => {
+                eyre::bail!("registration failed: {error} (code: {error_code:?})");
+            }
+            _ => {
+                let status_str = format!("{status:?}");
+                if !cli.json {
+                    eprintln!(
+                        "Status: {status_str} — polling again in {poll_interval}s..."
+                    );
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(poll_interval))
+                    .await;
+            }
+        }
+    }
+}

--- a/walletkit-cli/src/commands/setup.rs
+++ b/walletkit-cli/src/commands/setup.rs
@@ -8,9 +8,7 @@ use walletkit_core::{InitializingAuthenticator, RegistrationStatus};
 use crate::output;
 use crate::provider::create_fs_credential_store;
 
-use super::{
-    resolve_config, resolve_environment, resolve_region, resolve_root, Cli,
-};
+use super::{resolve_config, resolve_environment, resolve_region, resolve_root, Cli};
 
 pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
     let root = resolve_root(cli)?;
@@ -48,9 +46,7 @@ pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
 
     let result = if let Some(ref config) = config_json {
         InitializingAuthenticator::register(
-            &seed,
-            config,
-            None, // no recovery address
+            &seed, config, None, // no recovery address
         )
         .await
     } else {
@@ -119,8 +115,7 @@ pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
                         "Status: {status_str} — polling again in {poll_interval}s..."
                     );
                 }
-                tokio::time::sleep(std::time::Duration::from_secs(poll_interval))
-                    .await;
+                tokio::time::sleep(std::time::Duration::from_secs(poll_interval)).await;
             }
         }
     }

--- a/walletkit-cli/src/commands/setup.rs
+++ b/walletkit-cli/src/commands/setup.rs
@@ -1,14 +1,12 @@
 //! `walletkit setup` — one-shot wallet initialization and account registration.
 
-use eyre::WrapErr as _;
-use walletkit_core::error::WalletKitError;
 use walletkit_core::storage::cache_embedded_groth16_material;
-use walletkit_core::{InitializingAuthenticator, RegistrationStatus};
 
 use crate::output;
 use crate::provider::create_fs_credential_store;
 
-use super::{resolve_config, resolve_environment, resolve_region, resolve_root, Cli};
+use super::auth::{register_and_poll, RegisterOutcome};
+use super::{resolve_root, Cli};
 
 pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
     let root = resolve_root(cli)?;
@@ -42,81 +40,29 @@ pub async fn run(cli: &Cli, poll_interval: u64) -> eyre::Result<()> {
     }
 
     // --- auth register-wait ---
-    let config_json = resolve_config(cli)?;
-
-    let result = if let Some(ref config) = config_json {
-        InitializingAuthenticator::register(
-            &seed, config, None, // no recovery address
-        )
-        .await
-    } else {
-        let env = resolve_environment(cli)?;
-        let region = resolve_region(cli)?;
-        InitializingAuthenticator::register_with_defaults(
-            &seed,
-            cli.rpc_url.clone(),
-            &env,
-            region,
-            None, // no recovery address
-        )
-        .await
-    };
-
-    let init_auth = match result {
-        Ok(auth) => auth,
-        Err(WalletKitError::NetworkError { ref error, .. })
-            if error.contains("authenticator_already_exists") =>
-        {
-            let data = serde_json::json!({
-                "seed": seed_hex,
-                "root": root.display().to_string(),
-                "status": "AlreadyRegistered",
-            });
-            if cli.json {
-                output::print_json_data(&data, true);
-            } else {
-                println!("Account already registered.");
-            }
-            return Ok(());
-        }
-        Err(e) => return Err(e).wrap_err("registration failed"),
-    };
-
     if !cli.json {
         eprintln!("Registration submitted, waiting for finalization...");
     }
 
-    loop {
-        let status = init_auth.poll_status().await.wrap_err("poll failed")?;
+    let outcome = register_and_poll(cli, &seed, None, poll_interval).await?;
 
-        match &status {
-            RegistrationStatus::Finalized => {
-                let data = serde_json::json!({
-                    "seed": seed_hex,
-                    "root": root.display().to_string(),
-                    "status": "Finalized",
-                });
-                if cli.json {
-                    output::print_json_data(&data, true);
-                } else {
-                    println!("Setup complete. Account registered and finalized.");
-                    println!("  root: {}", root.display());
-                    println!("  seed: {seed_hex}");
-                }
-                return Ok(());
-            }
-            RegistrationStatus::Failed { error, error_code } => {
-                eyre::bail!("registration failed: {error} (code: {error_code:?})");
-            }
-            _ => {
-                let status_str = format!("{status:?}");
-                if !cli.json {
-                    eprintln!(
-                        "Status: {status_str} — polling again in {poll_interval}s..."
-                    );
-                }
-                tokio::time::sleep(std::time::Duration::from_secs(poll_interval)).await;
-            }
-        }
+    let status = match outcome {
+        RegisterOutcome::Finalized => "Finalized",
+        RegisterOutcome::AlreadyRegistered => "AlreadyRegistered",
+    };
+
+    let data = serde_json::json!({
+        "seed": seed_hex,
+        "root": root.display().to_string(),
+        "status": status,
+    });
+
+    if cli.json {
+        output::print_json_data(&data, true);
+    } else {
+        println!("Setup complete. Account registered and finalized.");
+        println!("  root: {}", root.display());
+        println!("  seed: {seed_hex}");
     }
+    Ok(())
 }

--- a/walletkit-cli/tests/cli_tests.rs
+++ b/walletkit-cli/tests/cli_tests.rs
@@ -301,12 +301,7 @@ fn setup_fails_if_wallet_exists() {
 
     // Setup should fail because the wallet already exists.
     let output = Command::new(walletkit_bin())
-        .args([
-            "--root",
-            root.path().to_str().unwrap(),
-            "--json",
-            "setup",
-        ])
+        .args(["--root", root.path().to_str().unwrap(), "--json", "setup"])
         .output()
         .expect("failed to run setup");
     assert!(!output.status.success());

--- a/walletkit-cli/tests/cli_tests.rs
+++ b/walletkit-cli/tests/cli_tests.rs
@@ -30,6 +30,7 @@ fn help_exits_zero() {
     assert!(stdout.contains("auth"));
     assert!(stdout.contains("credential"));
     assert!(stdout.contains("proof"));
+    assert!(stdout.contains("setup"));
 }
 
 #[test]
@@ -285,4 +286,39 @@ fn auth_recovery_data_json_has_all_keys() {
     assert!(data["authenticator_address"].as_str().is_some());
     assert!(data["authenticator_pubkey"].as_str().is_some());
     assert!(data["offchain_signer_commitment"].as_str().is_some());
+}
+
+#[test]
+fn setup_fails_if_wallet_exists() {
+    let root = temp_root();
+
+    // Initialize a wallet first.
+    let init_output = Command::new(walletkit_bin())
+        .args(["--root", root.path().to_str().unwrap(), "wallet", "init"])
+        .output()
+        .expect("failed to run init");
+    assert!(init_output.status.success());
+
+    // Setup should fail because the wallet already exists.
+    let output = Command::new(walletkit_bin())
+        .args([
+            "--root",
+            root.path().to_str().unwrap(),
+            "--json",
+            "setup",
+        ])
+        .output()
+        .expect("failed to run setup");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stderr).expect("invalid json");
+    assert_eq!(parsed["ok"], false);
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("wallet already exists"),
+        "expected 'wallet already exists' error, got: {stderr}"
+    );
 }


### PR DESCRIPTION
Just adds a `setup` command that fully sets up a new account + wallet and a `test` command to that issues a credential and then generates and verifies a proof. 

Convenience commands for testing.