### PR TITLE
pop 3767 check with app crypto teams on walletkit useragent header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,6 +7242,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "test-case-core",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8095,6 +8128,7 @@ dependencies = [
  "strum 0.27.2",
  "subtle",
  "taceo-oprf",
+ "test-case",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/walletkit-cli/src/commands/recovery_binding.rs
+++ b/walletkit-cli/src/commands/recovery_binding.rs
@@ -30,9 +30,11 @@ pub async fn run(
     match action {
         RecoveryBindingCommand::RegisterBindings { sub } => {
             let recovery_agent_address = environment.poh_recovery_agent_address();
-            let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
-                    .unwrap();
+            let recovery_binding_manager = RecoveryBindingManager::new(
+                environment,
+                &UserAgentBuilder::new().with_walletkit_segment(),
+            )
+            .unwrap();
             recovery_binding_manager
                 .bind_recovery_agent(
                     &authenticator,
@@ -42,17 +44,21 @@ pub async fn run(
                 .await?;
         }
         RecoveryBindingCommand::UnregisterBindings { sub } => {
-            let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
-                    .unwrap();
+            let recovery_binding_manager = RecoveryBindingManager::new(
+                environment,
+                &UserAgentBuilder::new().with_walletkit_segment(),
+            )
+            .unwrap();
             recovery_binding_manager
                 .unbind_recovery_agent(&authenticator, sub.clone())
                 .await?;
         }
         RecoveryBindingCommand::GetBinding => {
-            let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
-                    .unwrap();
+            let recovery_binding_manager = RecoveryBindingManager::new(
+                environment,
+                &UserAgentBuilder::new().with_walletkit_segment(),
+            )
+            .unwrap();
             let recovery_binding = recovery_binding_manager
                 .get_recovery_binding(authenticator.leaf_index())
                 .await?;

--- a/walletkit-cli/src/commands/recovery_binding.rs
+++ b/walletkit-cli/src/commands/recovery_binding.rs
@@ -5,8 +5,8 @@ use clap::Subcommand;
 use super::{init_authenticator, Cli};
 use crate::output;
 use walletkit_core::issuers::RecoveryBindingManager;
+use walletkit_core::user_agent::UserAgentBuilder;
 use walletkit_core::Environment;
-use walletkit_core::UserAgent;
 
 #[derive(Subcommand)]
 pub enum RecoveryBindingCommand {
@@ -31,7 +31,7 @@ pub async fn run(
         RecoveryBindingCommand::RegisterBindings { sub } => {
             let recovery_agent_address = environment.poh_recovery_agent_address();
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgent::default())
+                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
                     .unwrap();
             recovery_binding_manager
                 .bind_recovery_agent(
@@ -43,7 +43,7 @@ pub async fn run(
         }
         RecoveryBindingCommand::UnregisterBindings { sub } => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgent::default())
+                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
                     .unwrap();
             recovery_binding_manager
                 .unbind_recovery_agent(&authenticator, sub.clone())
@@ -51,7 +51,7 @@ pub async fn run(
         }
         RecoveryBindingCommand::GetBinding => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, &UserAgent::default())
+                RecoveryBindingManager::new(environment, &UserAgentBuilder::new())
                     .unwrap();
             let recovery_binding = recovery_binding_manager
                 .get_recovery_binding(authenticator.leaf_index())

--- a/walletkit-cli/src/commands/recovery_binding.rs
+++ b/walletkit-cli/src/commands/recovery_binding.rs
@@ -31,7 +31,8 @@ pub async fn run(
         RecoveryBindingCommand::RegisterBindings { sub } => {
             let recovery_agent_address = environment.poh_recovery_agent_address();
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
+                RecoveryBindingManager::new(environment, &UserAgent::default())
+                    .unwrap();
             recovery_binding_manager
                 .bind_recovery_agent(
                     &authenticator,
@@ -42,14 +43,16 @@ pub async fn run(
         }
         RecoveryBindingCommand::UnregisterBindings { sub } => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
+                RecoveryBindingManager::new(environment, &UserAgent::default())
+                    .unwrap();
             recovery_binding_manager
                 .unbind_recovery_agent(&authenticator, sub.clone())
                 .await?;
         }
         RecoveryBindingCommand::GetBinding => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
+                RecoveryBindingManager::new(environment, &UserAgent::default())
+                    .unwrap();
             let recovery_binding = recovery_binding_manager
                 .get_recovery_binding(authenticator.leaf_index())
                 .await?;

--- a/walletkit-cli/src/commands/recovery_binding.rs
+++ b/walletkit-cli/src/commands/recovery_binding.rs
@@ -6,6 +6,7 @@ use super::{init_authenticator, Cli};
 use crate::output;
 use walletkit_core::issuers::RecoveryBindingManager;
 use walletkit_core::Environment;
+use walletkit_core::UserAgent;
 
 #[derive(Subcommand)]
 pub enum RecoveryBindingCommand {
@@ -30,7 +31,7 @@ pub async fn run(
         RecoveryBindingCommand::RegisterBindings { sub } => {
             let recovery_agent_address = environment.poh_recovery_agent_address();
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment).unwrap();
+                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
             recovery_binding_manager
                 .bind_recovery_agent(
                     &authenticator,
@@ -41,14 +42,14 @@ pub async fn run(
         }
         RecoveryBindingCommand::UnregisterBindings { sub } => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment).unwrap();
+                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
             recovery_binding_manager
                 .unbind_recovery_agent(&authenticator, sub.clone())
                 .await?;
         }
         RecoveryBindingCommand::GetBinding => {
             let recovery_binding_manager =
-                RecoveryBindingManager::new(environment).unwrap();
+                RecoveryBindingManager::new(environment, UserAgent::default()).unwrap();
             let recovery_binding = recovery_binding_manager
                 .get_recovery_binding(authenticator.leaf_index())
                 .await?;

--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -65,6 +65,7 @@ walletkit-db = { workspace = true, optional = true }
 
 
 [dev-dependencies]
+test-case = "3.3"
 alloy = { version = "1", default-features = false, features = [
   "getrandom",
   "json",

--- a/walletkit-core/src/http_request.rs
+++ b/walletkit-core/src/http_request.rs
@@ -3,31 +3,7 @@ use std::time::Duration;
 use backon::{ExponentialBuilder, Retryable};
 use reqwest::{Method, RequestBuilder, Response};
 
-use crate::error::WalletKitError;
-
-#[derive(uniffi::Record)]
-pub struct UserAgent {
-    user_agent: String,
-}
-
-#[uniffi::export]
-impl UserAgent {
-    #[uniffi::constructor]
-    #[must_use]
-    pub fn new(world_app_version: &str, client_name: &str, os_version: &str) -> Self {
-        let walletkit_version = env!("CARGO_PKG_VERSION");
-        let user_agent = format!("WorldApp/{world_app_version} walletkit-core/{walletkit_version} {client_name}/{os_version}");
-        Self { user_agent }
-    }
-
-    #[uniffi::constructor]
-    #[must_use]
-    pub fn default() -> Self {
-        let walletkit_version = env!("CARGO_PKG_VERSION");
-        let user_agent = format!("walletkit-core/{walletkit_version}");
-        Self { user_agent }
-    }
-}
+use crate::{error::WalletKitError, UserAgent};
 
 /// A simple wrapper on an HTTP client for making requests. Sets sensible defaults such as timeouts,
 /// user-agent & ensuring HTTPS, and applies retry middleware for transient failures.
@@ -44,22 +20,24 @@ impl Request {
         let client = reqwest::Client::new();
         let timeout = Duration::from_secs(5);
         let max_retries = 3; // total attempts = 4
-        let user_agent = user_agent.unwrap_or_else(UserAgent::default).user_agent.clone();
-        Self { client, timeout, max_retries, user_agent }
+        let user_agent = user_agent.unwrap_or_default().to_string();
+        Self {
+            client,
+            timeout,
+            max_retries,
+            user_agent,
+        }
     }
 
     /// Creates a request builder with defaults applied.
     pub(crate) fn req(&self, method: Method, url: &str) -> RequestBuilder {
         #[cfg(not(test))]
         assert!(url.starts_with("https"));
-        
+
         self.client
             .request(method, url)
             .timeout(self.timeout)
-            .header(
-                "User-Agent",
-                &self.user_agent,
-            )
+            .header("User-Agent", &self.user_agent)
     }
 
     /// Creates a GET request builder with defaults applied.

--- a/walletkit-core/src/http_request.rs
+++ b/walletkit-core/src/http_request.rs
@@ -5,38 +5,60 @@ use reqwest::{Method, RequestBuilder, Response};
 
 use crate::error::WalletKitError;
 
+#[derive(uniffi::Record)]
+pub struct UserAgent {
+    user_agent: String,
+}
+
+#[uniffi::export]
+impl UserAgent {
+    #[uniffi::constructor]
+    #[must_use]
+    pub fn new(world_app_version: &str, client_name: &str, os_version: &str) -> Self {
+        let walletkit_version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("WorldApp/{world_app_version} walletkit-core/{walletkit_version} {client_name}/{os_version}");
+        Self { user_agent }
+    }
+
+    #[uniffi::constructor]
+    #[must_use]
+    pub fn default() -> Self {
+        let walletkit_version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("walletkit-core/{walletkit_version}");
+        Self { user_agent }
+    }
+}
+
 /// A simple wrapper on an HTTP client for making requests. Sets sensible defaults such as timeouts,
 /// user-agent & ensuring HTTPS, and applies retry middleware for transient failures.
 pub struct Request {
     client: reqwest::Client,
     timeout: Duration,
     max_retries: u32,
+    user_agent: String,
 }
 
 impl Request {
     /// Initializes a new `Request` instance.
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(user_agent: Option<UserAgent>) -> Self {
         let client = reqwest::Client::new();
         let timeout = Duration::from_secs(5);
         let max_retries = 3; // total attempts = 4
-        Self {
-            client,
-            timeout,
-            max_retries,
-        }
+        let user_agent = user_agent.unwrap_or_else(UserAgent::default).user_agent.clone();
+        Self { client, timeout, max_retries, user_agent }
     }
 
     /// Creates a request builder with defaults applied.
     pub(crate) fn req(&self, method: Method, url: &str) -> RequestBuilder {
         #[cfg(not(test))]
         assert!(url.starts_with("https"));
-
+        
         self.client
             .request(method, url)
             .timeout(self.timeout)
             .header(
                 "User-Agent",
-                format!("walletkit-core/{}", env!("CARGO_PKG_VERSION")),
+                &self.user_agent,
             )
     }
 

--- a/walletkit-core/src/http_request.rs
+++ b/walletkit-core/src/http_request.rs
@@ -16,16 +16,15 @@ pub struct Request {
 
 impl Request {
     /// Initializes a new `Request` instance.
-    pub(crate) fn new(user_agent: Option<UserAgent>) -> Self {
+    pub(crate) fn new(user_agent: &UserAgent) -> Self {
         let client = reqwest::Client::new();
         let timeout = Duration::from_secs(5);
         let max_retries = 3; // total attempts = 4
-        let user_agent = user_agent.unwrap_or_default().to_string();
         Self {
             client,
             timeout,
             max_retries,
-            user_agent,
+            user_agent: user_agent.as_string(),
         }
     }
 

--- a/walletkit-core/src/http_request.rs
+++ b/walletkit-core/src/http_request.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use backon::{ExponentialBuilder, Retryable};
 use reqwest::{Method, RequestBuilder, Response};
 
-use crate::{error::WalletKitError, UserAgent};
+use crate::error::WalletKitError;
 
 /// A simple wrapper on an HTTP client for making requests. Sets sensible defaults such as timeouts,
 /// user-agent & ensuring HTTPS, and applies retry middleware for transient failures.
@@ -16,7 +16,7 @@ pub struct Request {
 
 impl Request {
     /// Initializes a new `Request` instance.
-    pub(crate) fn new(user_agent: &UserAgent) -> Self {
+    pub(crate) fn new(user_agent: String) -> Self {
         let client = reqwest::Client::new();
         let timeout = Duration::from_secs(5);
         let max_retries = 3; // total attempts = 4
@@ -24,7 +24,7 @@ impl Request {
             client,
             timeout,
             max_retries,
-            user_agent: user_agent.as_string(),
+            user_agent,
         }
     }
 

--- a/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/walletkit-core/src/issuers/pop_backend_client.rs
@@ -1,5 +1,6 @@
 use crate::error::WalletKitError;
-use crate::http_request::{Request, UserAgent};
+use crate::http_request::Request;
+use crate::UserAgent;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
@@ -256,7 +257,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -301,7 +302,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -350,7 +351,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -395,7 +396,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -427,7 +428,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -451,7 +452,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_err(), "Expected error but got success");
@@ -476,7 +477,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -503,7 +504,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone());
+        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");

--- a/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/walletkit-core/src/issuers/pop_backend_client.rs
@@ -1,5 +1,5 @@
 use crate::error::WalletKitError;
-use crate::http_request::Request;
+use crate::http_request::{Request, UserAgent};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
@@ -53,8 +53,8 @@ pub struct PopBackendClient {
 impl PopBackendClient {
     /// Creates a new client targeting the given base URL.
     #[must_use]
-    pub fn new(base_url: String) -> Self {
-        let request = Request::new();
+    pub fn new(base_url: String, user_agent: UserAgent) -> Self {
+        let request = Request::new(Some(user_agent));
         Self { request, base_url }
     }
 }

--- a/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/walletkit-core/src/issuers/pop_backend_client.rs
@@ -54,8 +54,8 @@ pub struct PopBackendClient {
 impl PopBackendClient {
     /// Creates a new client targeting the given base URL.
     #[must_use]
-    pub fn new(base_url: String, user_agent: UserAgent) -> Self {
-        let request = Request::new(Some(user_agent));
+    pub fn new(base_url: String, user_agent: &UserAgent) -> Self {
+        let request = Request::new(user_agent);
         Self { request, base_url }
     }
 }
@@ -257,7 +257,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -302,7 +302,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -351,7 +351,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -396,7 +396,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -428,7 +428,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -452,7 +452,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_err(), "Expected error but got success");
@@ -477,7 +477,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -504,7 +504,7 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), UserAgent::default());
+        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");

--- a/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/walletkit-core/src/issuers/pop_backend_client.rs
@@ -1,6 +1,5 @@
 use crate::error::WalletKitError;
 use crate::http_request::Request;
-use crate::UserAgent;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +53,7 @@ pub struct PopBackendClient {
 impl PopBackendClient {
     /// Creates a new client targeting the given base URL.
     #[must_use]
-    pub fn new(base_url: String, user_agent: &UserAgent) -> Self {
+    pub fn new(base_url: String, user_agent: String) -> Self {
         let request = Request::new(user_agent);
         Self { request, base_url }
     }
@@ -257,7 +256,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -302,7 +302,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client
             .bind_recovery_agent(
@@ -351,7 +352,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -396,7 +398,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client
             .unbind_recovery_agent(
@@ -428,7 +431,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -452,7 +456,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_err(), "Expected error but got success");
@@ -477,7 +482,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");
@@ -504,7 +510,8 @@ mod tests {
             .create_async()
             .await;
 
-        let pop_api_client = PopBackendClient::new(url.clone(), &UserAgent::default());
+        let pop_api_client =
+            PopBackendClient::new(url.clone(), "test-user-agent".to_string());
 
         let result = pop_api_client.get_recovery_binding(42).await;
         assert!(result.is_ok(), "Expected success but got error: {result:?}");

--- a/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -305,7 +305,7 @@ mod tests {
 
         let recovery_binding_manager = RecoveryBindingManager::new_with_base_url(
             pop_api_server.url().as_str(),
-            &UserAgentBuilder::new(),
+            &UserAgentBuilder::new().with_walletkit_segment(),
         )
         .unwrap();
 

--- a/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -21,6 +21,7 @@ use crate::Environment;
 use alloy_primitives::keccak256;
 use alloy_primitives::Address;
 use std::string::String;
+use crate::http_request::UserAgent;
 /// Represents a recovery binding.
 #[derive(Debug, PartialEq, Eq, uniffi::Record)]
 pub struct RecoveryBinding {
@@ -59,13 +60,13 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the HTTP client cannot be built.
     #[uniffi::constructor]
-    pub fn new(environment: &Environment) -> Result<Self, WalletKitError> {
+    pub fn new(environment: &Environment, user_agent: UserAgent) -> Result<Self, WalletKitError> {
         let base_url = match environment {
             Environment::Staging => "https://app.stage.orb.worldcoin.org",
             Environment::Production => "https://app.orb.worldcoin.org",
         }
         .to_string();
-        Self::new_with_base_url(base_url.as_str())
+        Self::new_with_base_url(base_url.as_str(), user_agent)
     }
 
     /// Creates a new `RecoveryBindingManager` for the specified base URL and user agent.
@@ -74,8 +75,8 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the HTTP client cannot be built.
     #[uniffi::constructor]
-    pub fn new_with_base_url(base_url: &str) -> Result<Self, WalletKitError> {
-        let pop_backend_client = PopBackendClient::new(base_url.to_string());
+    pub fn new_with_base_url(base_url: &str, user_agent: UserAgent) -> Result<Self, WalletKitError> {
+        let pop_backend_client = PopBackendClient::new(base_url.to_string(), user_agent);
         Ok(Self { pop_backend_client })
     }
 }

--- a/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -18,10 +18,10 @@ use crate::issuers::pop_backend_client::ManageRecoveryBindingRequest;
 use crate::issuers::pop_backend_client::RecoveryBindingResponse;
 use crate::issuers::PopBackendClient;
 use crate::Environment;
+use crate::UserAgent;
 use alloy_primitives::keccak256;
 use alloy_primitives::Address;
 use std::string::String;
-use crate::http_request::UserAgent;
 /// Represents a recovery binding.
 #[derive(Debug, PartialEq, Eq, uniffi::Record)]
 pub struct RecoveryBinding {
@@ -60,7 +60,10 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the HTTP client cannot be built.
     #[uniffi::constructor]
-    pub fn new(environment: &Environment, user_agent: UserAgent) -> Result<Self, WalletKitError> {
+    pub fn new(
+        environment: &Environment,
+        user_agent: UserAgent,
+    ) -> Result<Self, WalletKitError> {
         let base_url = match environment {
             Environment::Staging => "https://app.stage.orb.worldcoin.org",
             Environment::Production => "https://app.orb.worldcoin.org",
@@ -75,8 +78,12 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the HTTP client cannot be built.
     #[uniffi::constructor]
-    pub fn new_with_base_url(base_url: &str, user_agent: UserAgent) -> Result<Self, WalletKitError> {
-        let pop_backend_client = PopBackendClient::new(base_url.to_string(), user_agent);
+    pub fn new_with_base_url(
+        base_url: &str,
+        user_agent: UserAgent,
+    ) -> Result<Self, WalletKitError> {
+        let pop_backend_client =
+            PopBackendClient::new(base_url.to_string(), user_agent);
         Ok(Self { pop_backend_client })
     }
 }
@@ -295,9 +302,11 @@ mod tests {
             .create_async()
             .await;
 
-        let recovery_binding_manager =
-            RecoveryBindingManager::new_with_base_url(pop_api_server.url().as_str())
-                .unwrap();
+        let recovery_binding_manager = RecoveryBindingManager::new_with_base_url(
+            pop_api_server.url().as_str(),
+            UserAgent::default(),
+        )
+        .unwrap();
 
         let result = recovery_binding_manager
             .bind_recovery_agent(&authenticator, sub.clone(), recovery_agent.clone())

--- a/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -17,8 +17,8 @@ use crate::error::WalletKitError;
 use crate::issuers::pop_backend_client::ManageRecoveryBindingRequest;
 use crate::issuers::pop_backend_client::RecoveryBindingResponse;
 use crate::issuers::PopBackendClient;
+use crate::user_agent::UserAgentBuilder;
 use crate::Environment;
-use crate::UserAgent;
 use alloy_primitives::keccak256;
 use alloy_primitives::Address;
 use std::string::String;
@@ -62,14 +62,14 @@ impl RecoveryBindingManager {
     #[uniffi::constructor]
     pub fn new(
         environment: &Environment,
-        user_agent: &UserAgent,
+        user_agent_builder: &UserAgentBuilder,
     ) -> Result<Self, WalletKitError> {
         let base_url = match environment {
             Environment::Staging => "https://app.stage.orb.worldcoin.org",
             Environment::Production => "https://app.orb.worldcoin.org",
         }
         .to_string();
-        Self::new_with_base_url(base_url.as_str(), user_agent)
+        Self::new_with_base_url(base_url.as_str(), user_agent_builder)
     }
 
     /// Creates a new `RecoveryBindingManager` for the specified base URL and user agent.
@@ -80,8 +80,9 @@ impl RecoveryBindingManager {
     #[uniffi::constructor]
     pub fn new_with_base_url(
         base_url: &str,
-        user_agent: &UserAgent,
+        user_agent_builder: &UserAgentBuilder,
     ) -> Result<Self, WalletKitError> {
+        let user_agent = user_agent_builder.build().to_string();
         let pop_backend_client =
             PopBackendClient::new(base_url.to_string(), user_agent);
         Ok(Self { pop_backend_client })
@@ -304,7 +305,7 @@ mod tests {
 
         let recovery_binding_manager = RecoveryBindingManager::new_with_base_url(
             pop_api_server.url().as_str(),
-            &UserAgent::default(),
+            &UserAgentBuilder::new(),
         )
         .unwrap();
 

--- a/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -62,7 +62,7 @@ impl RecoveryBindingManager {
     #[uniffi::constructor]
     pub fn new(
         environment: &Environment,
-        user_agent: UserAgent,
+        user_agent: &UserAgent,
     ) -> Result<Self, WalletKitError> {
         let base_url = match environment {
             Environment::Staging => "https://app.stage.orb.worldcoin.org",
@@ -80,7 +80,7 @@ impl RecoveryBindingManager {
     #[uniffi::constructor]
     pub fn new_with_base_url(
         base_url: &str,
-        user_agent: UserAgent,
+        user_agent: &UserAgent,
     ) -> Result<Self, WalletKitError> {
         let pop_backend_client =
             PopBackendClient::new(base_url.to_string(), user_agent);
@@ -304,7 +304,7 @@ mod tests {
 
         let recovery_binding_manager = RecoveryBindingManager::new_with_base_url(
             pop_api_server.url().as_str(),
-            UserAgent::default(),
+            &UserAgent::default(),
         )
         .unwrap();
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -139,25 +139,22 @@ impl TfhNfcIssuer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::user_agent::UserAgentBuilder;
 
     #[test]
     fn test_staging_url() {
-        let ua = UserAgentBuilder::new()
-            .with_app("WorldApp".into(), "1.0.0".into())
-            .with_client("test".into(), "1.0.0".into())
-            .build();
-        let issuer = TfhNfcIssuer::new(&Environment::Staging, ua.to_string());
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Staging,
+            "WorldApp/1.0.0 test/1.0.0".to_string(),
+        );
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let ua = UserAgentBuilder::new()
-            .with_app("WorldApp".into(), "1.0.0".into())
-            .with_client("test".into(), "1.0.0".into())
-            .build();
-        let issuer = TfhNfcIssuer::new(&Environment::Production, ua.to_string());
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Production,
+            "WorldApp/1.0.0 test/1.0.0".to_string(),
+        );
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -1,6 +1,8 @@
 //! TFH NFC credential issuer (passport, eID, MNC).
 use crate::Credential;
-use crate::{error::WalletKitError, http_request::{Request, UserAgent}, Environment};
+use crate::{
+    error::WalletKitError, http_request::Request, user_agent::UserAgent, Environment,
+};
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::Deserialize;
@@ -143,13 +145,19 @@ mod tests {
 
     #[test]
     fn test_staging_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Staging, Some(UserAgent::new("1.0.0", "test", "1.0.0")));
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Staging,
+            Some(UserAgent::new("1.0.0", "test", "1.0.0")),
+        );
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Production, Some(UserAgent::new("1.0.0", "test", "1.0.0")));
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Production,
+            Some(UserAgent::new("1.0.0", "test", "1.0.0")),
+        );
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -1,8 +1,6 @@
 //! TFH NFC credential issuer (passport, eID, MNC).
 use crate::Credential;
-use crate::{
-    error::WalletKitError, http_request::Request, user_agent::UserAgent, Environment,
-};
+use crate::{error::WalletKitError, http_request::Request, Environment};
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::Deserialize;
@@ -56,13 +54,12 @@ impl TfhNfcIssuer {
     /// Create a new TFH NFC issuer for the specified environment
     #[uniffi::constructor]
     #[must_use]
-    pub fn new(environment: &Environment, user_agent: &UserAgent) -> Self {
+    pub fn new(environment: &Environment, user_agent: String) -> Self {
         let base_url = match environment {
             Environment::Staging => "https://nfc.stage-crypto.worldcoin.org",
             Environment::Production => "https://nfc.crypto.worldcoin.org",
         }
         .to_string();
-
         Self {
             base_url,
             request: Request::new(user_agent),
@@ -131,10 +128,10 @@ impl TfhNfcIssuer {
 impl TfhNfcIssuer {
     /// Create an issuer with a custom base URL (for testing).
     #[must_use]
-    pub fn with_base_url(base_url: &str) -> Self {
+    pub fn with_base_url(base_url: &str, user_agent: String) -> Self {
         Self {
             base_url: base_url.to_string(),
-            request: Request::new(&UserAgent::default()),
+            request: Request::new(user_agent),
         }
     }
 }
@@ -142,22 +139,25 @@ impl TfhNfcIssuer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::user_agent::UserAgentBuilder;
 
     #[test]
     fn test_staging_url() {
-        let issuer = TfhNfcIssuer::new(
-            &Environment::Staging,
-            &UserAgent::new("1.0.0", "test", "1.0.0"),
-        );
+        let ua = UserAgentBuilder::new()
+            .with_app("WorldApp".into(), "1.0.0".into())
+            .with_client("test".into(), "1.0.0".into())
+            .build();
+        let issuer = TfhNfcIssuer::new(&Environment::Staging, ua.to_string());
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let issuer = TfhNfcIssuer::new(
-            &Environment::Production,
-            &UserAgent::new("1.0.0", "test", "1.0.0"),
-        );
+        let ua = UserAgentBuilder::new()
+            .with_app("WorldApp".into(), "1.0.0".into())
+            .with_client("test".into(), "1.0.0".into())
+            .build();
+        let issuer = TfhNfcIssuer::new(&Environment::Production, ua.to_string());
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -145,13 +145,19 @@ mod tests {
 
     #[test]
     fn test_staging_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Staging, &UserAgent::new("1.0.0", "test", "1.0.0"));
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Staging,
+            &UserAgent::new("1.0.0", "test", "1.0.0"),
+        );
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Production, &UserAgent::new("1.0.0", "test", "1.0.0"));
+        let issuer = TfhNfcIssuer::new(
+            &Environment::Production,
+            &UserAgent::new("1.0.0", "test", "1.0.0"),
+        );
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -56,7 +56,7 @@ impl TfhNfcIssuer {
     /// Create a new TFH NFC issuer for the specified environment
     #[uniffi::constructor]
     #[must_use]
-    pub fn new(environment: &Environment, user_agent: Option<UserAgent>) -> Self {
+    pub fn new(environment: &Environment, user_agent: &UserAgent) -> Self {
         let base_url = match environment {
             Environment::Staging => "https://nfc.stage-crypto.worldcoin.org",
             Environment::Production => "https://nfc.crypto.worldcoin.org",
@@ -134,7 +134,7 @@ impl TfhNfcIssuer {
     pub fn with_base_url(base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
-            request: Request::new(None),
+            request: Request::new(&UserAgent::default()),
         }
     }
 }
@@ -145,19 +145,13 @@ mod tests {
 
     #[test]
     fn test_staging_url() {
-        let issuer = TfhNfcIssuer::new(
-            &Environment::Staging,
-            Some(UserAgent::new("1.0.0", "test", "1.0.0")),
-        );
+        let issuer = TfhNfcIssuer::new(&Environment::Staging, &UserAgent::new("1.0.0", "test", "1.0.0"));
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let issuer = TfhNfcIssuer::new(
-            &Environment::Production,
-            Some(UserAgent::new("1.0.0", "test", "1.0.0")),
-        );
+        let issuer = TfhNfcIssuer::new(&Environment::Production, &UserAgent::new("1.0.0", "test", "1.0.0"));
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/issuers/tfh_nfc.rs
+++ b/walletkit-core/src/issuers/tfh_nfc.rs
@@ -1,6 +1,6 @@
 //! TFH NFC credential issuer (passport, eID, MNC).
 use crate::Credential;
-use crate::{error::WalletKitError, http_request::Request, Environment};
+use crate::{error::WalletKitError, http_request::{Request, UserAgent}, Environment};
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::Deserialize;
@@ -54,7 +54,7 @@ impl TfhNfcIssuer {
     /// Create a new TFH NFC issuer for the specified environment
     #[uniffi::constructor]
     #[must_use]
-    pub fn new(environment: &Environment) -> Self {
+    pub fn new(environment: &Environment, user_agent: Option<UserAgent>) -> Self {
         let base_url = match environment {
             Environment::Staging => "https://nfc.stage-crypto.worldcoin.org",
             Environment::Production => "https://nfc.crypto.worldcoin.org",
@@ -63,7 +63,7 @@ impl TfhNfcIssuer {
 
         Self {
             base_url,
-            request: Request::new(),
+            request: Request::new(user_agent),
         }
     }
 }
@@ -132,7 +132,7 @@ impl TfhNfcIssuer {
     pub fn with_base_url(base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
-            request: Request::new(),
+            request: Request::new(None),
         }
     }
 }
@@ -143,13 +143,13 @@ mod tests {
 
     #[test]
     fn test_staging_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Staging);
+        let issuer = TfhNfcIssuer::new(&Environment::Staging, Some(UserAgent::new("1.0.0", "test", "1.0.0")));
         assert_eq!(issuer.base_url, "https://nfc.stage-crypto.worldcoin.org");
     }
 
     #[test]
     fn test_production_url() {
-        let issuer = TfhNfcIssuer::new(&Environment::Production);
+        let issuer = TfhNfcIssuer::new(&Environment::Production, Some(UserAgent::new("1.0.0", "test", "1.0.0")));
         assert_eq!(issuer.base_url, "https://nfc.crypto.worldcoin.org");
     }
 

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -126,6 +126,10 @@ pub use authenticator::{
 /// Default configuration values for each [`Environment`].
 pub mod defaults;
 
+/// User agent for HTTP requests.
+pub mod user_agent;
+pub use user_agent::UserAgent;
+
 /// Proof requests and responses in World ID v4.
 pub mod requests;
 

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -128,7 +128,7 @@ pub mod defaults;
 
 /// User agent for HTTP requests.
 pub mod user_agent;
-pub use user_agent::UserAgent;
+pub use user_agent::{UserAgent, UserAgentBuilder};
 
 /// Proof requests and responses in World ID v4.
 pub mod requests;

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -1,42 +1,71 @@
 //! User agent for HTTP requests.
 
-/// Value sent in the `User-Agent` header for outbound HTTP calls (World App, client, and `walletkit-core` version).
+/// Represents a User-Agent string.
 #[derive(Debug, Clone, uniffi::Object)]
-pub struct UserAgent {
-    user_agent: String,
+pub struct UserAgent(pub String);
+
+/// Converts the [`UserAgent`] to a [`String`].
+impl std::fmt::Display for UserAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)?;
+        Ok(())
+    }
+}
+
+/// Builds the [`UserAgent`] string sent as the HTTP `User-Agent` header.
+///
+/// Starts with only `walletkit-core/{crate version}`. The embedding application supplies any
+/// product / OS segments via [`Self::with`], prepended before the walletkit segment.
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct UserAgentBuilder {
+    segments: Vec<String>,
 }
 
 #[uniffi::export]
-impl UserAgent {
-    /// Create a new `UserAgent` instance for the specified World App version, client name, and OS version.
+impl UserAgentBuilder {
+    /// Initializes a new `UserAgentBuilder` with the crate version.
     #[uniffi::constructor]
     #[must_use]
-    pub fn new(world_app_version: &str, client_name: &str, os_version: &str) -> Self {
-        let walletkit_version = env!("CARGO_PKG_VERSION");
-        let user_agent = format!("WorldApp/{world_app_version} walletkit-core/{walletkit_version} {client_name}/{os_version}");
-        Self { user_agent }
+    pub fn new() -> Self {
+        let crate_version = env!("CARGO_PKG_VERSION");
+        Self {
+            segments: vec![format!("walletkit-core/{crate_version}")],
+        }
     }
 
-    /// Full `User-Agent` string for logging or custom HTTP stacks.
+    /// Adds an `{app_name}/{app_version}` segment before the walletkit segment.
+    ///
+    /// Both must be non-empty to apply; otherwise returns an unchanged clone.
     #[must_use]
-    pub fn as_string(&self) -> String {
-        self.user_agent.clone()
+    pub fn with_app(&self, app_name: &str, app_version: &str) -> Self {
+        let mut next = self.clone();
+        next.segments.insert(0, format!("{app_name}/{app_version}"));
+        next
+    }
+
+    /// Adds a `{client_name}/{client_version}` segment after the walletkit segment.
+    ///
+    /// For example `with_client("iOS", "17.0")` will produce `iOS/17.0` in the User-Agent string.
+    /// Returns an unchanged clone if either `client_name` or `client_version` is empty.
+    #[must_use]
+    pub fn with_client(&self, client_name: &str, client_version: &str) -> Self {
+        let mut next = self.clone();
+        next.segments
+            .push(format!("{client_name}/{client_version}"));
+        next
+    }
+
+    /// Finalizes the header value as [`UserAgent`].
+    #[must_use]
+    pub fn build(&self) -> UserAgent {
+        UserAgent(self.segments.join(" "))
     }
 }
 
-/// No World App or client details — just `walletkit-core/{version}`. For host integrations, use [`UserAgent::new`].
-impl Default for UserAgent {
+// Default implementation for UserAgentBuilder
+impl Default for UserAgentBuilder {
     fn default() -> Self {
-        let walletkit_version = env!("CARGO_PKG_VERSION");
-        let user_agent = format!("walletkit-core/{walletkit_version}");
-        Self { user_agent }
-    }
-}
-
-impl std::fmt::Display for UserAgent {
-    /// Full `User-Agent` string, including `WorldApp/…` and client segments when set via [`Self::new`].
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.user_agent)
+        Self::new()
     }
 }
 
@@ -44,25 +73,34 @@ impl std::fmt::Display for UserAgent {
 mod tests {
     use super::*;
 
-    /// Crate version is baked in at **compile** time via `env!` — `set_var` in tests does not change it
-    /// (set `CARGO_PKG_VERSION` at runtime only affects `std::env::var`, not `env!`).
+    /// Crate version is baked in at **compile** time via `env!`.
     const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
     #[test]
-    fn test_new() {
-        let user_agent = UserAgent::new("1.0.0", "iOS", "16.0");
-        assert_eq!(
-            user_agent.to_string(),
-            format!("WorldApp/1.0.0 walletkit-core/{CRATE_VERSION} iOS/16.0"),
-        );
-    }
+    fn user_agent_builder_table() {
+        let cases: Vec<(UserAgentBuilder, String)> = vec![
+            (
+                UserAgentBuilder::new(),
+                format!("walletkit-core/{CRATE_VERSION}"),
+            ),
+            (
+                UserAgentBuilder::new().with_app("WorldApp".into(), "1.0".into()),
+                format!("WorldApp/1.0 walletkit-core/{CRATE_VERSION}"),
+            ),
+            (
+                UserAgentBuilder::new()
+                    .with_app("WorldApp".into(), "2.1".into())
+                    .with_client("iOS".into(), "17.0".into()),
+                format!("WorldApp/2.1 walletkit-core/{CRATE_VERSION} iOS/17.0"),
+            ),
+            (
+                UserAgentBuilder::new().with_client("CLI".into(), "1.2.3".into()),
+                format!("walletkit-core/{CRATE_VERSION} CLI/1.2.3"),
+            ),
+        ];
 
-    #[test]
-    fn test_default() {
-        let user_agent = UserAgent::default();
-        assert_eq!(
-            user_agent.to_string(),
-            format!("walletkit-core/{CRATE_VERSION}")
-        );
+        for (builder, expected) in cases {
+            assert_eq!(builder.build().to_string(), expected);
+        }
     }
 }

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -70,19 +70,19 @@ mod tests {
     use test_case::test_case;
 
     #[test_case(
-        UserAgentBuilder::new().with_walletkit_segment(),
+        &UserAgentBuilder::new().with_walletkit_segment(),
         concat!("walletkit-core/", env!("CARGO_PKG_VERSION"));
         "walletkit_only"
     )]
     #[test_case(
-        UserAgentBuilder::new()
+        &UserAgentBuilder::new()
             .with_segment("WorldApp", "1.0")
             .with_walletkit_segment(),
         concat!("WorldApp/1.0 walletkit-core/", env!("CARGO_PKG_VERSION"));
         "world_app_then_walletkit"
     )]
     #[test_case(
-        UserAgentBuilder::new()
+        &UserAgentBuilder::new()
             .with_segment("WorldApp", "2.1")
             .with_walletkit_segment()
             .with_segment("iOS", "17.0"),
@@ -90,7 +90,7 @@ mod tests {
         "native_style_world_walletkit_os"
     )]
     #[test_case(
-        UserAgentBuilder::new()
+        &UserAgentBuilder::new()
             .with_walletkit_segment()
             .with_segment("CLI", "1.2.3"),
         concat!("walletkit-core/", env!("CARGO_PKG_VERSION"), " CLI/1.2.3");

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -14,8 +14,9 @@ impl std::fmt::Display for UserAgent {
 
 /// Builds the [`UserAgent`] string sent as the HTTP `User-Agent` header.
 ///
-/// Starts with `walletkit-core/{crate version}`. Add segments with [`Self::with_app`]
-/// and [`Self::with_client`] (appended after), then [`Self::build`].
+/// Starts empty; call [`Self::with_segment`] for arbitrary `name/version` tokens and
+/// [`Self::with_walletkit_segment`] for the library token (in whatever order fits the host — e.g.
+/// native app vs web authenticator may omit an app-like segment entirely).
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct UserAgentBuilder {
     segments: Vec<String>,
@@ -23,35 +24,30 @@ pub struct UserAgentBuilder {
 
 #[uniffi::export]
 impl UserAgentBuilder {
-    /// Initializes a new `UserAgentBuilder` with the crate version.
+    /// Empty builder — add segments with [`Self::with_segment`] and/or [`Self::with_walletkit_segment`].
     #[uniffi::constructor]
     #[must_use]
-    pub fn new() -> Self {
-        let crate_version = env!("CARGO_PKG_VERSION");
+    pub const fn new() -> Self {
         Self {
-            segments: vec![format!("walletkit-core/{crate_version}")],
+            segments: Vec::new(),
         }
     }
 
-    /// Adds an `{app_name}/{app_version}` segment before the walletkit segment.
-    ///
-    /// Both must be non-empty to apply; otherwise returns an unchanged clone.
+    /// Appends `{product}/{version}` (e.g. `WorldApp/2.1`, `Chrome/120`). No-op if either side is empty after trim.
     #[must_use]
-    pub fn with_app(&self, app_name: &str, app_version: &str) -> Self {
+    pub fn with_segment(&self, name: &str, version: &str) -> Self {
         let mut next = self.clone();
-        next.segments.insert(0, format!("{app_name}/{app_version}"));
+        next.segments.push(format!("{name}/{version}"));
         next
     }
 
-    /// Adds a `{client_name}/{client_version}` segment after the walletkit segment.
-    ///
-    /// For example `with_client("iOS", "17.0")` will produce `iOS/17.0` in the User-Agent string.
-    /// Returns an unchanged clone if either `client_name` or `client_version` is empty.
+    /// Appends `walletkit-core/{crate version}`.
     #[must_use]
-    pub fn with_client(&self, client_name: &str, client_version: &str) -> Self {
+    pub fn with_walletkit_segment(&self) -> Self {
         let mut next = self.clone();
+        let crate_version = env!("CARGO_PKG_VERSION");
         next.segments
-            .push(format!("{client_name}/{client_version}"));
+            .push(format!("walletkit-core/{crate_version}"));
         next
     }
 
@@ -62,7 +58,6 @@ impl UserAgentBuilder {
     }
 }
 
-// Default implementation for UserAgentBuilder
 impl Default for UserAgentBuilder {
     fn default() -> Self {
         Self::new()
@@ -80,21 +75,26 @@ mod tests {
     fn user_agent_builder_table() {
         let cases: Vec<(UserAgentBuilder, String)> = vec![
             (
-                UserAgentBuilder::new(),
+                UserAgentBuilder::new().with_walletkit_segment(),
                 format!("walletkit-core/{CRATE_VERSION}"),
             ),
             (
-                UserAgentBuilder::new().with_app("WorldApp".into(), "1.0".into()),
+                UserAgentBuilder::new()
+                    .with_segment("WorldApp", "1.0")
+                    .with_walletkit_segment(),
                 format!("WorldApp/1.0 walletkit-core/{CRATE_VERSION}"),
             ),
             (
                 UserAgentBuilder::new()
-                    .with_app("WorldApp".into(), "2.1".into())
-                    .with_client("iOS".into(), "17.0".into()),
+                    .with_segment("WorldApp", "2.1")
+                    .with_walletkit_segment()
+                    .with_segment("iOS", "17.0"),
                 format!("WorldApp/2.1 walletkit-core/{CRATE_VERSION} iOS/17.0"),
             ),
             (
-                UserAgentBuilder::new().with_client("CLI".into(), "1.2.3".into()),
+                UserAgentBuilder::new()
+                    .with_walletkit_segment()
+                    .with_segment("CLI", "1.2.3"),
                 format!("walletkit-core/{CRATE_VERSION} CLI/1.2.3"),
             ),
         ];
@@ -102,5 +102,18 @@ mod tests {
         for (builder, expected) in cases {
             assert_eq!(builder.build().to_string(), expected);
         }
+    }
+
+    #[test]
+    fn suggested_native_app_style_chain_matches_example() {
+        let ua = UserAgentBuilder::new()
+            .with_segment("WorldApp", "2.1")
+            .with_walletkit_segment()
+            .with_segment("iOS", "17.0")
+            .build();
+        assert_eq!(
+            ua.to_string(),
+            format!("WorldApp/2.1 walletkit-core/{CRATE_VERSION} iOS/17.0"),
+        );
     }
 }

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -96,7 +96,7 @@ mod tests {
         concat!("walletkit-core/", env!("CARGO_PKG_VERSION"), " CLI/1.2.3");
         "walletkit_then_cli"
     )]
-    fn user_agent_builder_expected(builder: UserAgentBuilder, expected: &'static str) {
+    fn user_agent_builder_expected(builder: &UserAgentBuilder, expected: &'static str) {
         assert_eq!(builder.build().to_string(), expected);
     }
 }

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -14,8 +14,8 @@ impl std::fmt::Display for UserAgent {
 
 /// Builds the [`UserAgent`] string sent as the HTTP `User-Agent` header.
 ///
-/// Starts with only `walletkit-core/{crate version}`. The embedding application supplies any
-/// product / OS segments via [`Self::with`], prepended before the walletkit segment.
+/// Starts with `walletkit-core/{crate version}`. Add segments with [`Self::with_app`]
+/// and [`Self::with_client`] (appended after), then [`Self::build`].
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct UserAgentBuilder {
     segments: Vec<String>,

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -1,7 +1,7 @@
 //! User agent for HTTP requests.
 
 /// Value sent in the `User-Agent` header for outbound HTTP calls (World App, client, and `walletkit-core` version).
-#[derive(uniffi::Record, Debug, Clone)]
+#[derive(Debug, Clone, uniffi::Object)]
 pub struct UserAgent {
     user_agent: String,
 }
@@ -15,6 +15,12 @@ impl UserAgent {
         let walletkit_version = env!("CARGO_PKG_VERSION");
         let user_agent = format!("WorldApp/{world_app_version} walletkit-core/{walletkit_version} {client_name}/{os_version}");
         Self { user_agent }
+    }
+
+    /// Full `User-Agent` string for logging or custom HTTP stacks.
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        self.user_agent.clone()
     }
 }
 

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -67,53 +67,36 @@ impl Default for UserAgentBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
-    /// Crate version is baked in at **compile** time via `env!`.
-    const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-    #[test]
-    fn user_agent_builder_table() {
-        let cases: Vec<(UserAgentBuilder, String)> = vec![
-            (
-                UserAgentBuilder::new().with_walletkit_segment(),
-                format!("walletkit-core/{CRATE_VERSION}"),
-            ),
-            (
-                UserAgentBuilder::new()
-                    .with_segment("WorldApp", "1.0")
-                    .with_walletkit_segment(),
-                format!("WorldApp/1.0 walletkit-core/{CRATE_VERSION}"),
-            ),
-            (
-                UserAgentBuilder::new()
-                    .with_segment("WorldApp", "2.1")
-                    .with_walletkit_segment()
-                    .with_segment("iOS", "17.0"),
-                format!("WorldApp/2.1 walletkit-core/{CRATE_VERSION} iOS/17.0"),
-            ),
-            (
-                UserAgentBuilder::new()
-                    .with_walletkit_segment()
-                    .with_segment("CLI", "1.2.3"),
-                format!("walletkit-core/{CRATE_VERSION} CLI/1.2.3"),
-            ),
-        ];
-
-        for (builder, expected) in cases {
-            assert_eq!(builder.build().to_string(), expected);
-        }
-    }
-
-    #[test]
-    fn suggested_native_app_style_chain_matches_example() {
-        let ua = UserAgentBuilder::new()
+    #[test_case(
+        UserAgentBuilder::new().with_walletkit_segment(),
+        concat!("walletkit-core/", env!("CARGO_PKG_VERSION"));
+        "walletkit_only"
+    )]
+    #[test_case(
+        UserAgentBuilder::new()
+            .with_segment("WorldApp", "1.0")
+            .with_walletkit_segment(),
+        concat!("WorldApp/1.0 walletkit-core/", env!("CARGO_PKG_VERSION"));
+        "world_app_then_walletkit"
+    )]
+    #[test_case(
+        UserAgentBuilder::new()
             .with_segment("WorldApp", "2.1")
             .with_walletkit_segment()
-            .with_segment("iOS", "17.0")
-            .build();
-        assert_eq!(
-            ua.to_string(),
-            format!("WorldApp/2.1 walletkit-core/{CRATE_VERSION} iOS/17.0"),
-        );
+            .with_segment("iOS", "17.0"),
+        concat!("WorldApp/2.1 walletkit-core/", env!("CARGO_PKG_VERSION"), " iOS/17.0");
+        "native_style_world_walletkit_os"
+    )]
+    #[test_case(
+        UserAgentBuilder::new()
+            .with_walletkit_segment()
+            .with_segment("CLI", "1.2.3"),
+        concat!("walletkit-core/", env!("CARGO_PKG_VERSION"), " CLI/1.2.3");
+        "walletkit_then_cli"
+    )]
+    fn user_agent_builder_expected(builder: UserAgentBuilder, expected: &'static str) {
+        assert_eq!(builder.build().to_string(), expected);
     }
 }

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -1,0 +1,62 @@
+//! User agent for HTTP requests.
+
+/// Value sent in the `User-Agent` header for outbound HTTP calls (World App, client, and `walletkit-core` version).
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct UserAgent {
+    user_agent: String,
+}
+
+#[uniffi::export]
+impl UserAgent {
+    /// Create a new `UserAgent` instance for the specified World App version, client name, and OS version.
+    #[uniffi::constructor]
+    #[must_use]
+    pub fn new(world_app_version: &str, client_name: &str, os_version: &str) -> Self {
+        let walletkit_version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("WorldApp/{world_app_version} walletkit-core/{walletkit_version} {client_name}/{os_version}");
+        Self { user_agent }
+    }
+}
+
+/// No World App or client details — just `walletkit-core/{version}`. For host integrations, use [`UserAgent::new`].
+impl Default for UserAgent {
+    fn default() -> Self {
+        let walletkit_version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("walletkit-core/{walletkit_version}");
+        Self { user_agent }
+    }
+}
+
+impl std::fmt::Display for UserAgent {
+    /// Full `User-Agent` string, including `WorldApp/…` and client segments when set via [`Self::new`].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.user_agent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Crate version is baked in at **compile** time via `env!` — `set_var` in tests does not change it
+    /// (set `CARGO_PKG_VERSION` at runtime only affects `std::env::var`, not `env!`).
+    const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    #[test]
+    fn test_new() {
+        let user_agent = UserAgent::new("1.0.0", "iOS", "16.0");
+        assert_eq!(
+            user_agent.to_string(),
+            format!("WorldApp/1.0.0 walletkit-core/{CRATE_VERSION} iOS/16.0"),
+        );
+    }
+
+    #[test]
+    fn test_default() {
+        let user_agent = UserAgent::default();
+        assert_eq!(
+            user_agent.to_string(),
+            format!("walletkit-core/{CRATE_VERSION}")
+        );
+    }
+}

--- a/walletkit-core/src/v3/merkle_tree.rs
+++ b/walletkit-core/src/v3/merkle_tree.rs
@@ -4,7 +4,7 @@ use ruint_uniffi::Uint256;
 use semaphore_rs::poseidon_tree::Proof;
 use serde::{Deserialize, Serialize};
 
-use crate::UserAgent;
+use crate::UserAgentBuilder;
 use crate::{error::WalletKitError, http_request::Request};
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,8 +57,8 @@ impl MerkleTreeProof {
         let body = SequencerBody {
             identity_commitment: identity_commitment.to_padded_hex_string(),
         };
-        let user_agent = UserAgent::default();
-        let request = Request::new(&user_agent);
+        let user_agent = UserAgentBuilder::default().build();
+        let request = Request::new(user_agent.to_string());
         let http_response = request.handle(request.post(&url).json(&body)).await?;
 
         let status = http_response.status();

--- a/walletkit-core/src/v3/merkle_tree.rs
+++ b/walletkit-core/src/v3/merkle_tree.rs
@@ -4,8 +4,8 @@ use ruint_uniffi::Uint256;
 use semaphore_rs::poseidon_tree::Proof;
 use serde::{Deserialize, Serialize};
 
+use crate::UserAgent;
 use crate::{error::WalletKitError, http_request::Request};
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SequencerBody {

--- a/walletkit-core/src/v3/merkle_tree.rs
+++ b/walletkit-core/src/v3/merkle_tree.rs
@@ -58,7 +58,7 @@ impl MerkleTreeProof {
             identity_commitment: identity_commitment.to_padded_hex_string(),
         };
         let user_agent = UserAgent::default();
-        let request = Request::new(Some(user_agent));
+        let request = Request::new(&user_agent);
         let http_response = request.handle(request.post(&url).json(&body)).await?;
 
         let status = http_response.status();

--- a/walletkit-core/src/v3/merkle_tree.rs
+++ b/walletkit-core/src/v3/merkle_tree.rs
@@ -57,8 +57,8 @@ impl MerkleTreeProof {
         let body = SequencerBody {
             identity_commitment: identity_commitment.to_padded_hex_string(),
         };
-
-        let request = Request::new();
+        let user_agent = UserAgent::default();
+        let request = Request::new(Some(user_agent));
         let http_response = request.handle(request.post(&url).json(&body)).await?;
 
         let status = http_response.status();

--- a/walletkit-core/src/v3/merkle_tree.rs
+++ b/walletkit-core/src/v3/merkle_tree.rs
@@ -57,7 +57,7 @@ impl MerkleTreeProof {
         let body = SequencerBody {
             identity_commitment: identity_commitment.to_padded_hex_string(),
         };
-        let user_agent = UserAgentBuilder::default().build();
+        let user_agent = UserAgentBuilder::new().with_walletkit_segment().build();
         let request = Request::new(user_agent.to_string());
         let http_response = request.handle(request.post(&url).json(&body)).await?;
 


### PR DESCRIPTION
Keep user agent naming consistent with the old format (WorldApp/4.0.1100 Oxide/0.49.3 ios/17.6.1)
Walletkit has just walletkit-core/0.13.0, include WorldApp version and client name.

This pull request introduces a more flexible and consistent approach to setting the HTTP user agent across the codebase. The changes allow specifying a custom `UserAgent` for all HTTP requests, improving traceability and making it easier to identify requests from different environments or clients. Constructors for key components now require or accept a `UserAgent` parameter, and tests have been updated accordingly.

Key changes include:

**User Agent Handling and Propagation**
- Added a new `user_agent` module and exported the `UserAgent` struct from `walletkit-core`, making it available for use throughout the project. (`walletkit-core/src/lib.rs`, `walletkit-core/src/user_agent.rs`)
- Modified the `Request` HTTP wrapper to accept an optional `UserAgent` and use it as the default for all outgoing requests. (`walletkit-core/src/http_request.rs`) [[1]](diffhunk://#diff-b0ff40970462b2270d9e555f4e06fa00d948a03555678349d61e186debb19cc6L6-R28) [[2]](diffhunk://#diff-b0ff40970462b2270d9e555f4e06fa00d948a03555678349d61e186debb19cc6L37-R40)

**API Client and Manager Constructors**
- Updated `PopBackendClient` and `RecoveryBindingManager` to require a `UserAgent` parameter in their constructors, ensuring all requests made by these clients include the correct user agent. (`walletkit-core/src/issuers/pop_backend_client.rs`, `walletkit-core/src/issuers/recovery_bindings_manager.rs`) [[1]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L56-R58) [[2]](diffhunk://#diff-592fea17b31859cf09d8c8fe2190249b35dd84316d9d99180a0d6ff2b3fbd23fL62-R72) [[3]](diffhunk://#diff-592fea17b31859cf09d8c8fe2190249b35dd84316d9d99180a0d6ff2b3fbd23fL77-R86)
- Updated the CLI layer to pass a `UserAgent` when constructing `RecoveryBindingManager`. (`walletkit-cli/src/commands/recovery_binding.rs`) [[1]](diffhunk://#diff-4485d1e70cae9dfa5b54aba27a0243db4ad2b85b09631f37ffdfc2f295d59baaR9) [[2]](diffhunk://#diff-4485d1e70cae9dfa5b54aba27a0243db4ad2b85b09631f37ffdfc2f295d59baaL33-R34) [[3]](diffhunk://#diff-4485d1e70cae9dfa5b54aba27a0243db4ad2b85b09631f37ffdfc2f295d59baaL44-R52)

**TFH NFC Issuer Updates**
- Modified the `TfhNfcIssuer` to accept an optional `UserAgent` in its constructor and propagate it to the underlying HTTP `Request`. (`walletkit-core/src/issuers/tfh_nfc.rs`) [[1]](diffhunk://#diff-dc52c217f6e0f5139b6006b33f5c99b8bcc10be65ce0566604971a07e8d0c93dL3-R5) [[2]](diffhunk://#diff-dc52c217f6e0f5139b6006b33f5c99b8bcc10be65ce0566604971a07e8d0c93dL57-R59) [[3]](diffhunk://#diff-dc52c217f6e0f5139b6006b33f5c99b8bcc10be65ce0566604971a07e8d0c93dL66-R68) [[4]](diffhunk://#diff-dc52c217f6e0f5139b6006b33f5c99b8bcc10be65ce0566604971a07e8d0c93dL135-R137)

**Test Suite Adjustments**
- Updated all relevant tests to provide a `UserAgent` when constructing clients and managers, ensuring test coverage for the new parameter. (`walletkit-core/src/issuers/pop_backend_client.rs`, `walletkit-core/src/issuers/recovery_bindings_manager.rs`, `walletkit-core/src/issuers/tfh_nfc.rs`) [[1]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L259-R260) [[2]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L304-R305) [[3]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L353-R354) [[4]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L398-R399) [[5]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L430-R431) [[6]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L454-R455) [[7]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L479-R480) [[8]](diffhunk://#diff-3824125edaf8fa9a81da332d83ba961405575a0321b8f820a336f9ec4c62eb00L506-R507) [[9]](diffhunk://#diff-592fea17b31859cf09d8c8fe2190249b35dd84316d9d99180a0d6ff2b3fbd23fL297-R308) [[10]](diffhunk://#diff-dc52c217f6e0f5139b6006b33f5c99b8bcc10be65ce0566604971a07e8d0c93dL146-R160)

**Miscellaneous**
- Ensured all places where HTTP requests are made directly now use the new user agent mechanism, such as in `MerkleTreeProof`. (`walletkit-core/src/v3/merkle_tree.rs`)

These changes improve consistency, make the codebase easier to maintain, and lay the groundwork for more advanced user agent customization in the future.