### PR TITLE
chore: release walletkit 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,7 +7803,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "uniffi",
 ]
@@ -8033,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "uniffi",
  "walletkit-core",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "alloy",
  "alloy-core",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-db"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "cc",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 license = "MIT"
 edition = "2021"
 authors = ["World Contributors"]
@@ -39,8 +39,8 @@ world-id-core = { version = "0.10.0", default-features = false }
 world-id-proof = { version = "0.10.0", default-features = false }
 
 # internal
-walletkit-core = { version = "0.15.1", path = "walletkit-core", default-features = false }
-walletkit-db = { version = "0.15.1", path = "walletkit-db" }
+walletkit-core = { version = "0.15.2", path = "walletkit-core", default-features = false }
+walletkit-db = { version = "0.15.2", path = "walletkit-db" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/walletkit/CHANGELOG.md
+++ b/walletkit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/worldcoin/walletkit/compare/v0.15.1...v0.15.2) - 2026-04-28
+
+### Other
+
+- bump release version to republish Swift and Kotlin FFI artifacts
+
 ## [0.15.1](https://github.com/worldcoin/walletkit/compare/v0.15.0...v0.15.1) - 2026-04-28
 
 ### Fixed


### PR DESCRIPTION
This PR ...

- bumps WalletKit workspace packages from 0.15.1 to 0.15.2
- updates the lockfile and changelog for the patch release
- intentionally creates a new published release event so the Swift/Kotlin FFI release workflow can run with the Noir setup merged in #375

Context:

The 0.15.1 Rust crates were already published, but the downstream Swift/Kotlin FFI release failed before #375 because the FFI workflow did not install Noir. Re-running the Release workflow did not create anything new because release-plz reported the packages were already up to date/published and the post-release workflow-only fix was not a releasable package change. This explicit patch bump gives release-plz a new version to publish and should trigger the existing `release.published` flow for FFI artifacts.