### PR TITLE
feat: expose credential sub proving for issuers

### DIFF
--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -24,7 +24,7 @@ name = "walletkit_core"
 alloy-core = { workspace = true }
 alloy-primitives = { workspace = true }
 backon = "1.6"
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.22" }
 ctor = "0.2"
 hex = "0.4"
 hkdf = { version = "0.12", optional = true }
@@ -60,7 +60,7 @@ world-id-core = { workspace = true, features = [
   "zstd-compress-zkeys",
 ] }
 world-id-proof = { workspace = true }
-ciborium = { version = "0.2.2", optional = true }
+ciborium = { version = "0.2.2" }
 walletkit-db = { workspace = true, optional = true }
 
 
@@ -95,9 +95,8 @@ default = ["issuers", "storage"]
 # using it requires proper handling to ensure decompression is done once and cached. By default walletkit-swift and walletkit-android
 # ship with compressed keys. But this is disabled for tests.
 compress-zkeys = ["world-id-core/compress-zkeys"]
-issuers = ["dep:base64"]
+issuers = []
 storage = [
-  "dep:ciborium",
   "dep:hkdf",
   "dep:rand",
   "dep:sha2",

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -903,8 +903,8 @@ mod storage_tests {
             Some(mock_server.url()),
             480,
             address!("0x969947cFED008bFb5e3F32a25A1A2CDdf64d46fe"),
-            "https://world-id-indexer.stage-crypto.worldcoin.org".to_string(),
-            "https://world-id-gateway.stage-crypto.worldcoin.org".to_string(),
+            "https://indexer.us.id-infra.worldcoin.dev".to_string(),
+            "https://gateway.id-infra.worldcoin.dev".to_string(),
             vec![],
             2,
         )

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -21,7 +21,10 @@ use world_id_core::{
 use world_id_core::CredentialInput;
 
 #[cfg(feature = "storage")]
-use crate::storage::{CredentialStore, StoragePaths};
+use crate::{
+    storage::{CredentialStore, StoragePaths},
+    OwnershipProof,
+};
 
 #[cfg(feature = "storage")]
 use crate::requests::{ProofRequest, ProofResponse};
@@ -550,6 +553,57 @@ impl Authenticator {
             .replay_guard_set(nullifier.verifiable_oprf_output.output.into(), now)?;
 
         Ok(result.proof_response.into())
+    }
+
+    /// Generates a WIP-103 Ownership Proof for Issuers.
+    ///
+    /// An Ownership Proof lets the user prove they own the credential `sub`
+    /// associated with a stored credential without revealing their `leaf_index`.
+    ///
+    /// # Security-critical usage constraint
+    /// This method **MUST only** be called as part of a direct
+    /// **user-initiated** action in the client. Callers **MUST NOT** expose this
+    /// method to issuer-triggered, backend-triggered, or unauthenticated request
+    /// flows.
+    ///
+    /// # Arguments
+    /// * `nonce` - A field element provided by the Issuer to prevent replay.
+    /// * `blinding_factor` - The credential blinding factor previously used to
+    ///   derive the credential `sub`.
+    /// * `sub` - The credential `sub` (commitment) to prove ownership of.
+    ///
+    /// # Errors
+    /// - Returns [`WalletKitError::InvalidInput`] if `blinding_factor` and
+    ///   `sub` are inconsistent with each other (i.e. `sub` was not derived
+    ///   from this authenticator's leaf index and the provided blinding factor).
+    /// - Returns a network error if the Merkle inclusion proof cannot be
+    ///   fetched from the indexer.
+    /// - Returns [`WalletKitError::ProofGeneration`] if the ZK proof fails.
+    pub async fn prove_credential_sub(
+        &self,
+        nonce: &FieldElement,
+        blinding_factor: &FieldElement,
+        sub: &FieldElement,
+    ) -> Result<OwnershipProof, WalletKitError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| WalletKitError::Generic {
+                error: format!("Critical. Unable to determine SystemTime: {e}"),
+            })?
+            .as_secs();
+
+        let inclusion_proof = self.fetch_inclusion_proof_with_cache(now).await?;
+        let proof = self
+            .inner
+            .prove_credential_sub(
+                nonce.0,
+                blinding_factor.0,
+                sub.0,
+                Some(inclusion_proof),
+            )
+            .await?;
+
+        Ok(OwnershipProof(proof))
     }
 }
 

--- a/walletkit-core/src/lib.rs
+++ b/walletkit-core/src/lib.rs
@@ -133,6 +133,9 @@ pub use user_agent::{UserAgent, UserAgentBuilder};
 /// Proof requests and responses in World ID v4.
 pub mod requests;
 
+mod proof;
+pub use proof::OwnershipProof;
+
 /// Credential issuers for World ID (NFC, etc.)
 #[cfg(feature = "issuers")]
 pub mod issuers;

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -1,0 +1,33 @@
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use world_id_core::primitives::OwnershipProof as CoreOwnershipProof;
+
+use crate::error::WalletKitError;
+
+/// A WIP-103 Ownership Proof available to foreign bindings
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct OwnershipProof(pub(crate) CoreOwnershipProof);
+
+#[uniffi::export]
+impl OwnershipProof {
+    /// Encodes the proof as raw bytes.
+    ///
+    /// # Errors
+    /// An encoding error is theoretically possible, should not happen in practice.
+    pub fn encode(&self) -> Result<Vec<u8>, WalletKitError> {
+        let mut buffer = Vec::new();
+        ciborium::into_writer(&self.0, &mut buffer).map_err(|_| {
+            WalletKitError::SerializationError {
+                error: "unexpected error serializing `OwnershipProof`".to_string(),
+            }
+        })?;
+        Ok(buffer)
+    }
+
+    /// Encodes the proof as base-64 encoded bytes.
+    ///
+    /// # Errors
+    /// An encoding error is theoretically possible, should not happen in practice.
+    pub fn encode_b64(&self) -> Result<String, WalletKitError> {
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(self.encode()?))
+    }
+}

--- a/walletkit-core/src/proof.rs
+++ b/walletkit-core/src/proof.rs
@@ -1,7 +1,7 @@
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use world_id_core::primitives::OwnershipProof as CoreOwnershipProof;
 
-use crate::error::WalletKitError;
+use crate::{error::WalletKitError, FieldElement};
 
 /// A WIP-103 Ownership Proof available to foreign bindings
 #[derive(Debug, Clone, uniffi::Object)]
@@ -29,5 +29,11 @@ impl OwnershipProof {
     /// An encoding error is theoretically possible, should not happen in practice.
     pub fn encode_b64(&self) -> Result<String, WalletKitError> {
         Ok(BASE64_URL_SAFE_NO_PAD.encode(self.encode()?))
+    }
+
+    /// The root hash of the Merkle root used for inclusion in the `WorldIDRegistry`.
+    #[must_use]
+    pub fn merkle_root(&self) -> FieldElement {
+        self.0.merkle_root.into()
     }
 }

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -549,5 +549,19 @@ async fn e2e_session_proof() -> Result<()> {
 
     eprintln!("Phase 5 complete: session proof generated");
 
+    // ----------------------------------------------------------------
+    // Ownership Proof Generation
+    // ----------------------------------------------------------------
+    let nonce = FieldElement::random(&mut OsRng).into();
+    let sub = credential.sub.into();
+    let ownership_proof = authenticator
+        .prove_credential_sub(&nonce, &blinding_factor, &sub)
+        .await
+        .expect("can generate a correct ownership proof");
+    assert_eq!(
+        ownership_proof.merkle_root().to_u256(),
+        response_item.proof.as_ethereum_representation()[4]
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Exposes WIP-103 Ownership Proof to prove ownership over a `sub` for a Credential.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new externally callable proof-generation API and serialization surface in a security-sensitive area (ZK/credential ownership), so misuse or incorrect wiring could have privacy/security impact despite the relatively small code change.
> 
> **Overview**
> Exposes WIP-103 *credential ownership proving* to SDK consumers by adding `Authenticator::prove_credential_sub` (storage feature) that fetches an inclusion proof and delegates to the core authenticator to generate an `OwnershipProof`.
> 
> Introduces a new UniFFI-exported `OwnershipProof` wrapper with CBOR and base64-url encoding helpers plus `merkle_root()` access, and updates integration tests to exercise ownership proof generation/consistency. Dependency/features are adjusted so `base64` and `ciborium` are always available (no longer gated by `issuers`/`storage`), and a staging URL update is applied in the storage test config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b29c8a8feb9729e5720eca4badc5beb6a579a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->