### PR TITLE
fix: force software sha2 for android i686 builds

### DIFF
--- a/walletkit-core/Cargo.toml
+++ b/walletkit-core/Cargo.toml
@@ -42,7 +42,7 @@ secrecy = "0.10"
 semaphore-rs = { version = "0.5", optional = true }
 serde = "1"
 serde_json = "1"
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.10", optional = true, features = ["force-soft"] }
 strum = { version = "0.27", features = ["derive"] }
 subtle = "2"
 thiserror = "2"


### PR DESCRIPTION
This PR ...

- Enables `sha2/force-soft` in `walletkit-core` so Android `i686` release builds do not link the non-PIC `sha2-asm` x86 object into `libwalletkit_core.so`.
- Addresses the Kotlin release failure where `i686-linux-android` hit `R_386_32` relocation errors during linking.
- Validated with `CROSS_NO_WARNINGS=0 cross build -p walletkit --target i686-linux-android --release --locked --features compress-zkeys,v3`.