### PR TITLE
chore: bump world-id-protocol to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7194,6 +7194,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e971b7c52f9a91a499ed15580da6dbfd593c6ad9c6d519c6b72c7f0c421355"
 dependencies = [
+ "taceo-oprf-types",
+]
+
+[[package]]
+name = "taceo-oprf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72389c80580ec74d8ab188c723f6b0253885867ffac41213a31e4554b4fd0658"
+dependencies = [
  "taceo-oprf-client",
  "taceo-oprf-core",
  "taceo-oprf-types",
@@ -7201,9 +7210,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-client"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b593b9ad62eac8e01229d1c764d2ea204241adfbd7ef6e292ec4027dc9421fc7"
+checksum = "e3991b17184d2be29e13ae22ef982f9ea3d1111d67236805cd7729116235461c"
 dependencies = [
  "ark-ec",
  "ciborium",
@@ -7225,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d538b7fe97e0df8118f8b2a322f27d7e6585b4dfa1acc8da19196ade5696060"
+checksum = "c1409d82e88ad002d7946f6b5d37395a1d532133d9320b3284e27120ee1162db"
 dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
@@ -7247,9 +7256,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-types"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fcb204762878cb53c645ca08030c38c35146c2eec627d3b18aaac85bab707"
+checksum = "13304cda45c09c625f278b2f8e49de5f583e447a276804d41877bfcf5e89f68e"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -8224,7 +8233,7 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.27.2",
  "subtle",
- "taceo-oprf",
+ "taceo-oprf 0.13.0",
  "test-case",
  "thiserror 2.0.18",
  "tokio",
@@ -8971,9 +8980,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-authenticator"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3084544b704ff793fa2e7afc23f7bd2122a46573bd03b40c68dde243815cd"
+checksum = "8fed5aa94fe924d855a2ca40aadaae517315a2a24666d83092174b3c71a29456"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8995,7 +9004,7 @@ dependencies = [
  "taceo-ark-babyjubjub",
  "taceo-eddsa-babyjubjub",
  "taceo-groth16-material",
- "taceo-oprf",
+ "taceo-oprf 0.14.0",
  "taceo-poseidon2",
  "thiserror 2.0.18",
  "tokio",
@@ -9007,9 +9016,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-core"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3025419c521b306f2832402599bc0c04f3b36d72fb86627f84a923e39a383e95"
+checksum = "26f136a169a1e2decbbf741c208961446d2f3377a19c930634aebee39f0fb6d3"
 dependencies = [
  "taceo-eddsa-babyjubjub",
  "world-id-authenticator",
@@ -9020,9 +9029,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-primitives"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac72195188ba2f738d67b2de4e7a88b39f4537b949164e335e34a899d7148a7"
+checksum = "e19522e167d925e0c920671b41bb96edc82e7508f2d2730177c38c6cce2aa2c6"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9046,7 +9055,7 @@ dependencies = [
  "taceo-ark-serde-compat",
  "taceo-circom-types",
  "taceo-eddsa-babyjubjub",
- "taceo-oprf",
+ "taceo-oprf 0.14.0",
  "taceo-poseidon2",
  "thiserror 2.0.18",
  "url",
@@ -9055,9 +9064,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-proof"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3d18e19b2a64ee0d8e1e6e8c2a2ae3263afca198871a3fdfe0f12481487325"
+checksum = "098bb682b011c10c6a954927325470078000f771646df3264a079aba4b3295f9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -9077,7 +9086,7 @@ dependencies = [
  "taceo-eddsa-babyjubjub",
  "taceo-groth16-material",
  "taceo-groth16-sol",
- "taceo-oprf",
+ "taceo-oprf 0.14.0",
  "taceo-poseidon2",
  "tar",
  "thiserror 2.0.18",
@@ -9089,9 +9098,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-registries"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb73513f88d6565e9b8acf0ac0fdb53b737a79bbb01ee80077aff6b236ea551"
+checksum = "078bb8742f799133b9e5ff3eb1f4b3b1c9905ce479921be4c53ccb83467c1092"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ uniffi = { version = "0.31.0", features = [
   "tokio",
   "wasm-unstable-single-threaded",
 ] }
-world-id-core = { version = "0.10.2", default-features = false }
-world-id-proof = { version = "0.10.2", default-features = false }
+world-id-core = { version = "0.11.0", default-features = false }
+world-id-proof = { version = "0.11.0", default-features = false }
 
 # internal
 walletkit-core = { version = "0.18.0", path = "walletkit-core", default-features = false }

--- a/walletkit-cli/src/commands/proof.rs
+++ b/walletkit-cli/src/commands/proof.rs
@@ -12,8 +12,8 @@ use rand::rngs::OsRng;
 use walletkit_core::requests::ProofRequest;
 use world_id_core::primitives::{rp::RpId, FieldElement};
 use world_id_core::requests::{
-    ProofRequest as CoreProofRequest, ProofResponse as CoreProofResponse, RequestItem,
-    RequestVersion,
+    ProofRequest as CoreProofRequest, ProofResponse as CoreProofResponse, ProofType,
+    RequestItem, RequestVersion,
 };
 
 use crate::output;
@@ -363,6 +363,7 @@ fn build_test_request(
     Ok(CoreProofRequest {
         id: "test_request".to_string(),
         version: RequestVersion::V1,
+        proof_type: ProofType::Uniqueness,
         created_at,
         expires_at,
         rp_id,

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 use world_id_core::{
     api_types::{GatewayErrorCode, GatewayRequestState},
     primitives::{AuthenticatorPublicKeySet, Config},
-    Authenticator as CoreAuthenticator, AuthenticatorConfig,
-    Credential as CoreCredential, CredentialInput,
+    Authenticator as CoreAuthenticator, Credential as CoreCredential, CredentialInput,
     InitializingAuthenticator as CoreInitializingAuthenticator,
     OnchainKeyRepresentable, Signer,
 };
@@ -361,7 +360,7 @@ impl Authenticator {
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
         let config = Config::from_environment(environment, rpc_url, region)?;
-        let authenticator = CoreAuthenticator::init(seed, config.into())
+        let authenticator = CoreAuthenticator::init(seed, config)
             .await?
             .with_proof_materials(
                 Arc::clone(&materials.query),
@@ -388,7 +387,7 @@ impl Authenticator {
         materials: Arc<Groth16Materials>,
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
-        let config = AuthenticatorConfig::from_json(config).map_err(|_| {
+        let config = Config::from_json(config).map_err(|_| {
             WalletKitError::InvalidInput {
                 attribute: "config".to_string(),
                 reason: "Invalid config".to_string(),
@@ -658,8 +657,7 @@ impl InitializingAuthenticator {
         let recovery_address =
             Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
 
-        let config =
-            AuthenticatorConfig::from_environment(environment, rpc_url, region)?;
+        let config = Config::from_environment(environment, rpc_url, region)?;
 
         let initializing_authenticator =
             CoreAuthenticator::register(seed, config, recovery_address).await?;
@@ -688,7 +686,7 @@ impl InitializingAuthenticator {
         let recovery_address =
             Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
 
-        let config = AuthenticatorConfig::from_json(config).map_err(|_| {
+        let config = Config::from_json(config).map_err(|_| {
             WalletKitError::InvalidInput {
                 attribute: "config".to_string(),
                 reason: "Invalid config".to_string(),

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -290,6 +290,7 @@ impl Authenticator {
     /// - Returns [`WalletKitError::InvalidInput`] if `new_recovery_agent` is not
     ///   a valid address.
     /// - Returns a network error if the gateway request fails.
+    #[allow(deprecated)]
     pub async fn initiate_recovery_agent_update(
         &self,
         new_recovery_agent: String,
@@ -316,6 +317,7 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns a network error if the gateway request fails.
+    #[allow(deprecated)]
     pub async fn execute_recovery_agent_update(
         &self,
     ) -> Result<String, WalletKitError> {
@@ -333,6 +335,7 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns a network error if the gateway request fails.
+    #[allow(deprecated)]
     pub async fn cancel_recovery_agent_update(&self) -> Result<String, WalletKitError> {
         let request_id = self.inner.cancel_recovery_agent_update().await?;
 
@@ -387,12 +390,11 @@ impl Authenticator {
         materials: Arc<Groth16Materials>,
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
-        let config = Config::from_json(config).map_err(|_| {
-            WalletKitError::InvalidInput {
+        let config =
+            Config::from_json(config).map_err(|_| WalletKitError::InvalidInput {
                 attribute: "config".to_string(),
                 reason: "Invalid config".to_string(),
-            }
-        })?;
+            })?;
         let authenticator = CoreAuthenticator::init(seed, config)
             .await?
             .with_proof_materials(
@@ -686,12 +688,11 @@ impl InitializingAuthenticator {
         let recovery_address =
             Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
 
-        let config = Config::from_json(config).map_err(|_| {
-            WalletKitError::InvalidInput {
+        let config =
+            Config::from_json(config).map_err(|_| WalletKitError::InvalidInput {
                 attribute: "config".to_string(),
                 reason: "Invalid config".to_string(),
-            }
-        })?;
+            })?;
 
         let initializing_authenticator =
             CoreAuthenticator::register(seed, config, recovery_address).await?;

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -817,7 +817,7 @@ mod tests {
             cleanup_test_storage, temp_root_path, InMemoryStorageProvider,
         };
         use alloy::primitives::address;
-        use world_id_core::primitives::Config;
+        use world_id_core::primitives::{Config, ServiceEndpoint};
 
         let _ = rustls::crypto::ring::default_provider().install_default();
 
@@ -841,8 +841,12 @@ mod tests {
             Some(mock_server.url()),
             480,
             address!("0x969947cFED008bFb5e3F32a25A1A2CDdf64d46fe"),
-            "https://indexer.us.id-infra.worldcoin.dev".to_string(),
-            "https://gateway.id-infra.worldcoin.dev".to_string(),
+            ServiceEndpoint::direct(
+                "https://indexer.us.id-infra.worldcoin.dev".to_string(),
+            ),
+            ServiceEndpoint::direct(
+                "https://gateway.id-infra.worldcoin.dev".to_string(),
+            ),
             vec![],
             2,
         )

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -1,5 +1,5 @@
 use alloy_core::primitives::{address, Address};
-use world_id_core::{primitives::Config, AuthenticatorConfig, OhttpClientConfig};
+use world_id_core::primitives::{Config, ServiceEndpoint};
 
 use crate::{error::WalletKitError, Environment, Region};
 
@@ -48,6 +48,13 @@ fn indexer_url(region: Region, environment: &Environment) -> String {
         Environment::Production => "world.org",
     };
     format!("https://indexer.{region}.id-infra.{domain}")
+}
+
+fn gateway_url(environment: &Environment) -> String {
+    match environment {
+        Environment::Staging => "https://gateway.id-infra.worldcoin.dev".to_string(),
+        Environment::Production => "https://gateway.id-infra.world.org".to_string(),
+    }
 }
 
 /// Build a [`Config`] from well-known defaults for a given [`Environment`].
@@ -102,33 +109,16 @@ const fn ohttp_key_config(region: Region, environment: &Environment) -> &'static
     }
 }
 
-impl DefaultConfig for AuthenticatorConfig {
-    fn from_environment(
-        environment: &Environment,
-        rpc_url: Option<String>,
-        region: Option<Region>,
-    ) -> Result<Self, WalletKitError> {
-        let region = region.unwrap_or_default();
-        let config = Config::from_environment(environment, rpc_url, Some(region))?;
-
-        let ohttp_indexer = Some(OhttpClientConfig::new(
-            ohttp_relay_url(region, environment),
-            ohttp_key_config(region, environment).to_string(),
-        ));
-        // The world-id-gateway is centralized in the US cluster — only the
-        // US OHTTP relay/gateway is configured to forward to it. Route
-        // gateway traffic through US regardless of the user's region.
-        let ohttp_gateway = Some(OhttpClientConfig::new(
-            ohttp_relay_url(Region::Us, environment),
-            ohttp_key_config(Region::Us, environment).to_string(),
-        ));
-
-        Ok(Self {
-            config,
-            ohttp_indexer,
-            ohttp_gateway,
-        })
-    }
+fn ohttp_endpoint(
+    url: String,
+    region: Region,
+    environment: &Environment,
+) -> ServiceEndpoint {
+    ServiceEndpoint::ohttp(
+        url,
+        ohttp_relay_url(region, environment),
+        ohttp_key_config(region, environment).to_string(),
+    )
 }
 
 impl DefaultConfig for Config {
@@ -139,28 +129,27 @@ impl DefaultConfig for Config {
     ) -> Result<Self, WalletKitError> {
         let region = region.unwrap_or_default();
 
-        match environment {
-            Environment::Staging => Self::new(
-                rpc_url,
-                480, // Staging also runs on World Chain Mainnet
-                STAGING_WORLD_ID_REGISTRY,
-                indexer_url(region, environment),
-                "https://gateway.id-infra.worldcoin.dev".to_string(),
-                oprf_node_urls(region, environment),
-                3,
-            )
-            .map_err(WalletKitError::from),
+        let indexer = ohttp_endpoint(indexer_url(region, environment), region, environment);
+        // The world-id-gateway is centralized in the US cluster — only the
+        // US OHTTP relay/gateway is configured to forward to it. Route
+        // gateway traffic through US regardless of the user's region.
+        let gateway = ohttp_endpoint(gateway_url(environment), Region::Us, environment);
 
-            Environment::Production => Self::new(
-                rpc_url,
-                480,
-                WORLD_ID_REGISTRY,
-                indexer_url(region, environment),
-                "https://gateway.id-infra.world.org".to_string(),
-                oprf_node_urls(region, environment),
-                3,
-            )
-            .map_err(WalletKitError::from),
-        }
+        let (chain_id, registry_address) = match environment {
+            // Staging also runs on World Chain Mainnet.
+            Environment::Staging => (480, STAGING_WORLD_ID_REGISTRY),
+            Environment::Production => (480, WORLD_ID_REGISTRY),
+        };
+
+        Self::new(
+            rpc_url,
+            chain_id,
+            registry_address,
+            indexer,
+            gateway,
+            oprf_node_urls(region, environment),
+            3,
+        )
+        .map_err(WalletKitError::from)
     }
 }

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -129,7 +129,8 @@ impl DefaultConfig for Config {
     ) -> Result<Self, WalletKitError> {
         let region = region.unwrap_or_default();
 
-        let indexer = ohttp_endpoint(indexer_url(region, environment), region, environment);
+        let indexer =
+            ohttp_endpoint(indexer_url(region, environment), region, environment);
         // The world-id-gateway is centralized in the US cluster — only the
         // US OHTTP relay/gateway is configured to forward to it. Route
         // gateway traffic through US regardless of the user's region.

--- a/walletkit-core/src/proof_request_credential_constraints_check.rs
+++ b/walletkit-core/src/proof_request_credential_constraints_check.rs
@@ -190,7 +190,7 @@ mod tests {
     use world_id_core::{
         primitives::rp::RpId,
         requests::{
-            ConstraintExpr, ConstraintNode, ProofRequest as CoreProofRequest,
+            ConstraintExpr, ConstraintNode, ProofRequest as CoreProofRequest, ProofType,
             RequestItem, RequestVersion,
         },
         FieldElement as CoreFieldElement,
@@ -211,6 +211,7 @@ mod tests {
         let core = CoreProofRequest {
             id: "test".to_string(),
             version: RequestVersion::V1,
+            proof_type: ProofType::Uniqueness,
             created_at: 0,
             expires_at: u64::MAX,
             rp_id: RpId::new(1),

--- a/walletkit-core/src/proof_request_credential_constraints_check.rs
+++ b/walletkit-core/src/proof_request_credential_constraints_check.rs
@@ -190,8 +190,8 @@ mod tests {
     use world_id_core::{
         primitives::rp::RpId,
         requests::{
-            ConstraintExpr, ConstraintNode, ProofRequest as CoreProofRequest, ProofType,
-            RequestItem, RequestVersion,
+            ConstraintExpr, ConstraintNode, ProofRequest as CoreProofRequest,
+            ProofType, RequestItem, RequestVersion,
         },
         FieldElement as CoreFieldElement,
     };

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -131,14 +131,11 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
             .wrap_err("failed to load embedded nullifier material")?,
     );
 
-    let core_authenticator = CoreAuthenticator::init_or_register(
-        &seed,
-        config.into(),
-        Some(recovery_address),
-    )
-    .await
-    .wrap_err("account creation/init failed")?
-    .with_proof_materials(query_material, nullifier_material);
+    let core_authenticator =
+        CoreAuthenticator::init_or_register(&seed, config, Some(recovery_address))
+            .await
+            .wrap_err("account creation/init failed")?
+            .with_proof_materials(query_material, nullifier_material);
 
     let leaf_index = core_authenticator.leaf_index();
     eprintln!("Phase 1 complete: account ready (leaf_index={leaf_index})");
@@ -355,14 +352,11 @@ async fn e2e_session_proof() -> Result<()> {
             .wrap_err("failed to load embedded nullifier material")?,
     );
 
-    let core_authenticator = CoreAuthenticator::init_or_register(
-        &seed,
-        config.into(),
-        Some(recovery_address),
-    )
-    .await
-    .wrap_err("account creation/init failed")?
-    .with_proof_materials(query_material, nullifier_material);
+    let core_authenticator =
+        CoreAuthenticator::init_or_register(&seed, config, Some(recovery_address))
+            .await
+            .wrap_err("account creation/init failed")?
+            .with_proof_materials(query_material, nullifier_material);
 
     let leaf_index = core_authenticator.leaf_index();
     eprintln!("Phase 1 complete: account ready (leaf_index={leaf_index})");

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -38,7 +38,7 @@ use walletkit_core::{
 };
 use world_id_core::primitives::{rp::RpId, FieldElement, Nullifier};
 use world_id_core::{
-    requests::{ProofRequest, RequestItem, RequestVersion},
+    requests::{ProofRequest, ProofType, RequestItem, RequestVersion},
     Authenticator as CoreAuthenticator, EdDSAPrivateKey,
 };
 
@@ -235,6 +235,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let proof_request_core = ProofRequest {
         id: "staging_test_request".to_string(),
         version: RequestVersion::V1,
+        proof_type: ProofType::Uniqueness,
         created_at,
         expires_at,
         rp_id,
@@ -455,6 +456,7 @@ async fn e2e_session_proof() -> Result<()> {
     let init_request = ProofRequest {
         id: "session_init_request".to_string(),
         version: RequestVersion::V1,
+        proof_type: ProofType::CreateSession,
         created_at,
         expires_at,
         rp_id,
@@ -506,6 +508,7 @@ async fn e2e_session_proof() -> Result<()> {
     let session_proof_request_core = ProofRequest {
         id: "session_proof_request".to_string(),
         version: RequestVersion::V1,
+        proof_type: ProofType::Session,
         created_at,
         expires_at,
         rp_id,


### PR DESCRIPTION
Bumps `world-id-core` and `world-id-proof` from `0.10.2` to `0.11.0`, adapting to the breaking `Config` API from https://github.com/worldcoin/world-id-protocol/pull/729.

## What changes

- `Cargo.toml`: bump `world-id-core` and `world-id-proof` to `0.11.0`.
- `walletkit-core/src/defaults.rs`: drop the `AuthenticatorConfig` impl (the type was removed upstream) and rewrite `impl DefaultConfig for Config` to build a `Config` directly with `ServiceEndpoint::Ohttp { url, relay_url, key_config_base64 }` for both indexer (per-region) and gateway (US-pinned).
- `walletkit-core/src/authenticator/mod.rs`: pass `Config` directly into `CoreAuthenticator::{init, register}`; replace `AuthenticatorConfig::{from_environment, from_json}` with `Config::{from_environment, from_json}` in the four affected constructors.
- Tests + walletkit-cli: thread the new `ServiceEndpoint` and `ProofType` through fixtures that construct `Config` / `ProofRequest` directly.

## Notable side effect: OHTTP regression fix

Walletkit `0.17.0` regressed `Authenticator::init_with_defaults` so that OHTTP was silently dropped from the default config (`From<Config> for AuthenticatorConfig` set `ohttp_indexer`/`ohttp_gateway` to `None`). The upstream refactor removes `AuthenticatorConfig` and the lossy `From<Config>` seam outright, so `init_with_defaults` once again ships OHTTP for the default config.

## Wire-level break for JSON-init callers

`Authenticator::init(seed, config: &str, ...)` and `register(seed, config: &str, ...)` consume JSON. The upstream `Config::from_json` shape differs from the old `AuthenticatorConfig::from_json`:

- Old: top-level `indexer_url` / `gateway_url` flat strings + optional `ohttp_indexer` / `ohttp_gateway` objects.
- New: top-level `indexer` / `gateway` as internally-tagged enum objects: `{"type":"direct","url":...}` or `{"type":"ohttp","url":...,"relay_url":...,"key_config_base64":...}`.

Consumer impact:

- iOS uses `init_with_defaults` / `register_with_defaults` exclusively — no impact.
- Android staging passes an explicit JSON config without OHTTP fields. Will need a producer-side update on the next Android walletkit bump; tracked outside this PR.

## ProofType (no walletkit work needed)

world-id-protocol v0.11.0 also adds a `proof_type: ProofType` field on `ProofRequest` (PRs #711 / #712). The field has `#[serde(default)]` with `ProofType::Uniqueness` as the default, so existing RP JSON payloads deserialise unchanged. Walletkit's `Authenticator::generate_proof` already delegates to the core authenticator, which now branches on `proof_type` internally — for uniqueness requests behaviour is identical. Tests that construct `ProofRequest` directly (not via JSON) are updated to set the field explicitly.

## Supress deprecation warnings for recovery agent update flow authenticator methods
- Add `#[allow(deprecated)]` to recovery agent update methods

## Out of scope

- Default-flip from OHTTP to direct + explicit-opt-in OHTTP constructor — follow-up PR.
