### PR TITLE
refactor: default Authenticator to direct service endpoints, add OHTTP opt-in constructors

### DIFF
--- a/walletkit-cli/src/commands/auth.rs
+++ b/walletkit-cli/src/commands/auth.rs
@@ -37,14 +37,25 @@ pub async fn register_and_poll(
     } else {
         let env = resolve_environment(cli)?;
         let region = resolve_region(cli)?;
-        InitializingAuthenticator::register_with_defaults(
-            seed,
-            cli.rpc_url.clone(),
-            &env,
-            region,
-            recovery_address.map(String::from),
-        )
-        .await
+        if cli.ohttp_defaults {
+            InitializingAuthenticator::register_with_ohttp_defaults(
+                seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                recovery_address.map(String::from),
+            )
+            .await
+        } else {
+            InitializingAuthenticator::register_with_defaults(
+                seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                recovery_address.map(String::from),
+            )
+            .await
+        }
     };
 
     let init_auth = match result {
@@ -119,14 +130,25 @@ async fn run_register(cli: &Cli, recovery_address: Option<&str>) -> eyre::Result
     } else {
         let env = resolve_environment(cli)?;
         let region = resolve_region(cli)?;
-        InitializingAuthenticator::register_with_defaults(
-            &seed,
-            cli.rpc_url.clone(),
-            &env,
-            region,
-            recovery_address.map(String::from),
-        )
-        .await
+        if cli.ohttp_defaults {
+            InitializingAuthenticator::register_with_ohttp_defaults(
+                &seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                recovery_address.map(String::from),
+            )
+            .await
+        } else {
+            InitializingAuthenticator::register_with_defaults(
+                &seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                recovery_address.map(String::from),
+            )
+            .await
+        }
     };
 
     let init_auth = match result {

--- a/walletkit-cli/src/commands/mod.rs
+++ b/walletkit-cli/src/commands/mod.rs
@@ -58,6 +58,10 @@ pub struct Cli {
     )]
     pub config: Option<PathBuf>,
 
+    /// Route default-config init/register through OHTTP (opt-in).
+    #[arg(long, global = true, conflicts_with = "config")]
+    pub ohttp_defaults: bool,
+
     /// RPC URL for World Chain.
     #[arg(long, env = "WORLDCHAIN_RPC_URL", global = true)]
     pub rpc_url: Option<String>,
@@ -230,16 +234,29 @@ pub async fn init_authenticator(
     } else {
         let env = resolve_environment(cli)?;
         let region = resolve_region(cli)?;
-        Authenticator::init_with_defaults(
-            &seed,
-            cli.rpc_url.clone(),
-            &env,
-            region,
-            materials.clone(),
-            store.clone(),
-        )
-        .await
-        .wrap_err("authenticator init failed")?
+        if cli.ohttp_defaults {
+            Authenticator::init_with_ohttp_defaults(
+                &seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                materials.clone(),
+                store.clone(),
+            )
+            .await
+            .wrap_err("authenticator init failed")?
+        } else {
+            Authenticator::init_with_defaults(
+                &seed,
+                cli.rpc_url.clone(),
+                &env,
+                region,
+                materials.clone(),
+                store.clone(),
+            )
+            .await
+            .wrap_err("authenticator init failed")?
+        }
     };
 
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -394,8 +394,7 @@ impl Authenticator {
         materials: Arc<Groth16Materials>,
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
-        let config =
-            defaults::default_config_with_ohttp(environment, rpc_url, region)?;
+        let config = defaults::default_config_with_ohttp(environment, rpc_url, region)?;
         let authenticator = CoreAuthenticator::init(seed, config)
             .await?
             .with_proof_materials(
@@ -725,8 +724,7 @@ impl InitializingAuthenticator {
         let recovery_address =
             Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
 
-        let config =
-            defaults::default_config_with_ohttp(environment, rpc_url, region)?;
+        let config = defaults::default_config_with_ohttp(environment, rpc_url, region)?;
 
         let initializing_authenticator =
             CoreAuthenticator::register(seed, config, recovery_address).await?;

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -1,8 +1,8 @@
 //! The Authenticator is the main component with which users interact with the World ID Protocol.
 
 use crate::{
-    defaults::DefaultConfig, error::WalletKitError,
-    primitives::ParseFromForeignBinding, Environment, FieldElement, Region,
+    defaults, error::WalletKitError, primitives::ParseFromForeignBinding, Environment,
+    FieldElement, Region,
 };
 use alloy_core::primitives::Address;
 use ruint::aliases::U256;
@@ -362,7 +362,40 @@ impl Authenticator {
         materials: Arc<Groth16Materials>,
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
-        let config = Config::from_environment(environment, rpc_url, region)?;
+        let config = defaults::default_config(environment, rpc_url, region)?;
+        let authenticator = CoreAuthenticator::init(seed, config)
+            .await?
+            .with_proof_materials(
+                Arc::clone(&materials.query),
+                Arc::clone(&materials.nullifier),
+            );
+        Ok(Self {
+            inner: authenticator,
+            store,
+        })
+    }
+
+    /// Initializes a new Authenticator from a seed using SDK defaults routed
+    /// through the OHTTP relay. Opt-in alternative to
+    /// [`Authenticator::init_with_defaults`].
+    ///
+    /// The user's World ID must already be registered in the `WorldIDRegistry`,
+    /// otherwise a [`WalletKitError::AccountDoesNotExist`] error will be returned.
+    ///
+    /// # Errors
+    /// See `CoreAuthenticator::init` for potential errors.
+    #[uniffi::constructor]
+    #[tracing::instrument(target = "walletkit_latency", name = "rpc_init", skip_all)]
+    pub async fn init_with_ohttp_defaults(
+        seed: &[u8],
+        rpc_url: Option<String>,
+        environment: &Environment,
+        region: Option<Region>,
+        materials: Arc<Groth16Materials>,
+        store: Arc<CredentialStore>,
+    ) -> Result<Self, WalletKitError> {
+        let config =
+            defaults::default_config_with_ohttp(environment, rpc_url, region)?;
         let authenticator = CoreAuthenticator::init(seed, config)
             .await?
             .with_proof_materials(
@@ -659,7 +692,41 @@ impl InitializingAuthenticator {
         let recovery_address =
             Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
 
-        let config = Config::from_environment(environment, rpc_url, region)?;
+        let config = defaults::default_config(environment, rpc_url, region)?;
+
+        let initializing_authenticator =
+            CoreAuthenticator::register(seed, config, recovery_address).await?;
+
+        Ok(Self(initializing_authenticator))
+    }
+
+    /// Registers a new World ID using SDK defaults routed through the OHTTP
+    /// relay. Opt-in alternative to
+    /// [`InitializingAuthenticator::register_with_defaults`].
+    ///
+    /// This returns immediately and does not wait for registration to complete.
+    /// The returned `InitializingAuthenticator` can be used to poll the registration status.
+    ///
+    /// # Errors
+    /// See `CoreAuthenticator::register` for potential errors.
+    #[uniffi::constructor]
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "gateway_register",
+        skip_all
+    )]
+    pub async fn register_with_ohttp_defaults(
+        seed: &[u8],
+        rpc_url: Option<String>,
+        environment: &Environment,
+        region: Option<Region>,
+        recovery_address: Option<String>,
+    ) -> Result<Self, WalletKitError> {
+        let recovery_address =
+            Address::parse_from_ffi_optional(recovery_address, "recovery_address")?;
+
+        let config =
+            defaults::default_config_with_ohttp(environment, rpc_url, region)?;
 
         let initializing_authenticator =
             CoreAuthenticator::register(seed, config, recovery_address).await?;

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -148,11 +148,10 @@ pub fn default_config(
     build_config(environment, rpc_url, region, indexer, gateway)
 }
 
-/// Builds a [`Config`] for the given [`Environment`] using OHTTP service
-/// endpoints. Opt-in alternative to [`default_config`] for consumers that
-/// want their indexer/gateway traffic to flow through the Cloudflare OHTTP
-/// relay.
+/// Builds a [`Config`] for the given [`Environment`] using OHTTP endpoints.
 ///
+/// Opt-in alternative to [`default_config`] for consumers that want their
+/// indexer/gateway traffic to flow through the Cloudflare OHTTP relay.
 /// The indexer endpoint follows the caller's region; the gateway endpoint is
 /// always pinned to the US OHTTP relay because the `world-id-gateway` is
 /// centralised in the US cluster.
@@ -167,8 +166,7 @@ pub fn default_config_with_ohttp(
     region: Option<Region>,
 ) -> Result<Config, WalletKitError> {
     let region = region.unwrap_or_default();
-    let indexer =
-        ohttp_endpoint(indexer_url(region, environment), region, environment);
+    let indexer = ohttp_endpoint(indexer_url(region, environment), region, environment);
     let gateway = ohttp_endpoint(gateway_url(environment), Region::Us, environment);
     build_config(environment, rpc_url, region, indexer, gateway)
 }
@@ -218,8 +216,8 @@ mod tests {
                         assert_eq!(relay_url, &ohttp_relay_url(*region, env));
                         assert_eq!(key_config_base64, ohttp_key_config(*region, env));
                     }
-                    other => panic!(
-                        "indexer should be Ohttp for env={env:?} region={region:?}, got {other:?}"
+                    direct @ ServiceEndpoint::Direct { .. } => panic!(
+                        "indexer should be Ohttp for env={env:?} region={region:?}, got {direct:?}"
                     ),
                 }
             }
@@ -246,8 +244,8 @@ mod tests {
                             ohttp_key_config(Region::Us, env)
                         );
                     }
-                    other => panic!(
-                        "gateway should be Ohttp for env={env:?} region={region:?}, got {other:?}"
+                    direct @ ServiceEndpoint::Direct { .. } => panic!(
+                        "gateway should be Ohttp for env={env:?} region={region:?}, got {direct:?}"
                     ),
                 }
             }

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -265,6 +265,22 @@ mod tests {
     }
 
     #[test]
+    fn default_config_with_ohttp_defaults_region_when_not_specified() {
+        let with_default =
+            default_config_with_ohttp(&Environment::Staging, None, None).unwrap();
+        let with_explicit_default = default_config_with_ohttp(
+            &Environment::Staging,
+            None,
+            Some(Region::default()),
+        )
+        .unwrap();
+        assert_eq!(
+            with_default.indexer_url(),
+            with_explicit_default.indexer_url(),
+        );
+    }
+
+    #[test]
     fn both_builders_round_trip_through_config_json() {
         for env in ALL_ENVS {
             for region in ALL_REGIONS {

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -57,22 +57,6 @@ fn gateway_url(environment: &Environment) -> String {
     }
 }
 
-/// Build a [`Config`] from well-known defaults for a given [`Environment`].
-pub trait DefaultConfig {
-    /// Returns a config populated with the default URLs and addresses for the given environment.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`WalletKitError`] if the configuration cannot be constructed (e.g. invalid RPC URL).
-    fn from_environment(
-        environment: &Environment,
-        rpc_url: Option<String>,
-        region: Option<Region>,
-    ) -> Result<Self, WalletKitError>
-    where
-        Self: Sized;
-}
-
 fn ohttp_relay_url(region: Region, environment: &Environment) -> String {
     let path = match environment {
         Environment::Staging => format!("{region}-world-id-stage"),
@@ -121,36 +105,70 @@ fn ohttp_endpoint(
     )
 }
 
-impl DefaultConfig for Config {
-    fn from_environment(
-        environment: &Environment,
-        rpc_url: Option<String>,
-        region: Option<Region>,
-    ) -> Result<Self, WalletKitError> {
-        let region = region.unwrap_or_default();
+fn build_config(
+    environment: &Environment,
+    rpc_url: Option<String>,
+    region: Region,
+    indexer: ServiceEndpoint,
+    gateway: ServiceEndpoint,
+) -> Result<Config, WalletKitError> {
+    let (chain_id, registry_address) = match environment {
+        // Staging also runs on World Chain Mainnet.
+        Environment::Staging => (480, STAGING_WORLD_ID_REGISTRY),
+        Environment::Production => (480, WORLD_ID_REGISTRY),
+    };
 
-        let indexer =
-            ohttp_endpoint(indexer_url(region, environment), region, environment);
-        // The world-id-gateway is centralized in the US cluster — only the
-        // US OHTTP relay/gateway is configured to forward to it. Route
-        // gateway traffic through US regardless of the user's region.
-        let gateway = ohttp_endpoint(gateway_url(environment), Region::Us, environment);
+    Config::new(
+        rpc_url,
+        chain_id,
+        registry_address,
+        indexer,
+        gateway,
+        oprf_node_urls(region, environment),
+        3,
+    )
+    .map_err(WalletKitError::from)
+}
 
-        let (chain_id, registry_address) = match environment {
-            // Staging also runs on World Chain Mainnet.
-            Environment::Staging => (480, STAGING_WORLD_ID_REGISTRY),
-            Environment::Production => (480, WORLD_ID_REGISTRY),
-        };
+/// Builds a [`Config`] for the given [`Environment`] using direct (non-OHTTP)
+/// service endpoints — the default for SDK consumers.
+///
+/// # Errors
+///
+/// Returns [`WalletKitError`] if the configuration cannot be constructed
+/// (e.g. invalid RPC URL).
+pub fn default_config(
+    environment: &Environment,
+    rpc_url: Option<String>,
+    region: Option<Region>,
+) -> Result<Config, WalletKitError> {
+    let region = region.unwrap_or_default();
+    let indexer = ServiceEndpoint::direct(indexer_url(region, environment));
+    let gateway = ServiceEndpoint::direct(gateway_url(environment));
+    build_config(environment, rpc_url, region, indexer, gateway)
+}
 
-        Self::new(
-            rpc_url,
-            chain_id,
-            registry_address,
-            indexer,
-            gateway,
-            oprf_node_urls(region, environment),
-            3,
-        )
-        .map_err(WalletKitError::from)
-    }
+/// Builds a [`Config`] for the given [`Environment`] using OHTTP service
+/// endpoints. Opt-in alternative to [`default_config`] for consumers that
+/// want their indexer/gateway traffic to flow through the Cloudflare OHTTP
+/// relay.
+///
+/// The indexer endpoint follows the caller's region; the gateway endpoint is
+/// always pinned to the US OHTTP relay because the `world-id-gateway` is
+/// centralised in the US cluster.
+///
+/// # Errors
+///
+/// Returns [`WalletKitError`] if the configuration cannot be constructed
+/// (e.g. invalid RPC URL).
+pub fn default_config_with_ohttp(
+    environment: &Environment,
+    rpc_url: Option<String>,
+    region: Option<Region>,
+) -> Result<Config, WalletKitError> {
+    let region = region.unwrap_or_default();
+    let indexer =
+        ohttp_endpoint(indexer_url(region, environment), region, environment);
+    let gateway = ohttp_endpoint(gateway_url(environment), Region::Us, environment);
+    build_config(environment, rpc_url, region, indexer, gateway)
 }

--- a/walletkit-core/src/defaults.rs
+++ b/walletkit-core/src/defaults.rs
@@ -172,3 +172,129 @@ pub fn default_config_with_ohttp(
     let gateway = ohttp_endpoint(gateway_url(environment), Region::Us, environment);
     build_config(environment, rpc_url, region, indexer, gateway)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_ENVS: &[Environment] = &[Environment::Staging, Environment::Production];
+    const ALL_REGIONS: &[Region] = &[Region::Us, Region::Eu, Region::Ap];
+
+    #[test]
+    fn default_config_builds_direct_endpoints_for_every_env_and_region() {
+        for env in ALL_ENVS {
+            for region in ALL_REGIONS {
+                let config = default_config(env, None, Some(*region))
+                    .expect("default_config should succeed");
+
+                assert!(
+                    matches!(config.indexer(), ServiceEndpoint::Direct { .. }),
+                    "indexer should be Direct for env={env:?} region={region:?}"
+                );
+                assert!(
+                    matches!(config.gateway(), ServiceEndpoint::Direct { .. }),
+                    "gateway should be Direct for env={env:?} region={region:?}"
+                );
+                assert_eq!(config.indexer_url(), indexer_url(*region, env));
+                assert_eq!(config.gateway_url(), gateway_url(env));
+            }
+        }
+    }
+
+    #[test]
+    fn default_config_with_ohttp_builds_ohttp_endpoints_with_region_specific_relays() {
+        for env in ALL_ENVS {
+            for region in ALL_REGIONS {
+                let config = default_config_with_ohttp(env, None, Some(*region))
+                    .expect("default_config_with_ohttp should succeed");
+
+                match config.indexer() {
+                    ServiceEndpoint::Ohttp {
+                        url,
+                        relay_url,
+                        key_config_base64,
+                    } => {
+                        assert_eq!(url, &indexer_url(*region, env));
+                        assert_eq!(relay_url, &ohttp_relay_url(*region, env));
+                        assert_eq!(key_config_base64, ohttp_key_config(*region, env));
+                    }
+                    other => panic!(
+                        "indexer should be Ohttp for env={env:?} region={region:?}, got {other:?}"
+                    ),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn default_config_with_ohttp_pins_gateway_to_us_relay_regardless_of_region() {
+        for env in ALL_ENVS {
+            for region in ALL_REGIONS {
+                let config = default_config_with_ohttp(env, None, Some(*region))
+                    .expect("default_config_with_ohttp should succeed");
+
+                match config.gateway() {
+                    ServiceEndpoint::Ohttp {
+                        url,
+                        relay_url,
+                        key_config_base64,
+                    } => {
+                        assert_eq!(url, &gateway_url(env));
+                        assert_eq!(relay_url, &ohttp_relay_url(Region::Us, env));
+                        assert_eq!(
+                            key_config_base64,
+                            ohttp_key_config(Region::Us, env)
+                        );
+                    }
+                    other => panic!(
+                        "gateway should be Ohttp for env={env:?} region={region:?}, got {other:?}"
+                    ),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn default_config_defaults_region_when_not_specified() {
+        let with_default = default_config(&Environment::Staging, None, None).unwrap();
+        let with_explicit_default =
+            default_config(&Environment::Staging, None, Some(Region::default()))
+                .unwrap();
+        assert_eq!(
+            with_default.indexer_url(),
+            with_explicit_default.indexer_url(),
+        );
+    }
+
+    #[test]
+    fn both_builders_round_trip_through_config_json() {
+        for env in ALL_ENVS {
+            for region in ALL_REGIONS {
+                let direct = default_config(env, None, Some(*region)).unwrap();
+                let direct_json = serde_json::to_string(&direct).unwrap();
+                let direct_parsed = Config::from_json(&direct_json).unwrap();
+                assert!(matches!(
+                    direct_parsed.indexer(),
+                    ServiceEndpoint::Direct { .. }
+                ));
+                assert!(matches!(
+                    direct_parsed.gateway(),
+                    ServiceEndpoint::Direct { .. }
+                ));
+
+                let ohttp =
+                    default_config_with_ohttp(env, None, Some(*region)).unwrap();
+                let ohttp_json = serde_json::to_string(&ohttp).unwrap();
+                let ohttp_parsed = Config::from_json(&ohttp_json).unwrap();
+                assert!(matches!(
+                    ohttp_parsed.indexer(),
+                    ServiceEndpoint::Ohttp { .. }
+                ));
+                assert!(matches!(
+                    ohttp_parsed.gateway(),
+                    ServiceEndpoint::Ohttp { .. }
+                ));
+            }
+        }
+    }
+}

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -33,9 +33,7 @@ use alloy::sol;
 use alloy_core::primitives::U160;
 use eyre::{Context as _, Result};
 use taceo_oprf::types::OprfKeyId;
-use walletkit_core::{
-    defaults::DefaultConfig, Authenticator, Environment, Groth16Materials,
-};
+use walletkit_core::{defaults, Authenticator, Environment, Groth16Materials};
 use world_id_core::primitives::{rp::RpId, FieldElement, Nullifier};
 use world_id_core::{
     requests::{ProofRequest, ProofType, RequestItem, RequestVersion},
@@ -116,7 +114,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let seed = [7u8; 32];
     let recovery_address = alloy::primitives::Address::ZERO;
 
-    let config = world_id_core::primitives::Config::from_environment(
+    let config = defaults::default_config(
         &Environment::Staging,
         Some(rpc_url.clone()),
         None,
@@ -337,7 +335,7 @@ async fn e2e_session_proof() -> Result<()> {
     let seed = [7u8; 32];
     let recovery_address = alloy::primitives::Address::ZERO;
 
-    let config = world_id_core::primitives::Config::from_environment(
+    let config = defaults::default_config(
         &Environment::Staging,
         Some(rpc_url.clone()),
         None,

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -114,12 +114,9 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     let seed = [7u8; 32];
     let recovery_address = alloy::primitives::Address::ZERO;
 
-    let config = defaults::default_config(
-        &Environment::Staging,
-        Some(rpc_url.clone()),
-        None,
-    )
-    .wrap_err("failed to build staging config")?;
+    let config =
+        defaults::default_config(&Environment::Staging, Some(rpc_url.clone()), None)
+            .wrap_err("failed to build staging config")?;
     let query_material = Arc::new(
         world_id_core::proof::load_embedded_query_material()
             .wrap_err("failed to load embedded query material")?,
@@ -335,12 +332,9 @@ async fn e2e_session_proof() -> Result<()> {
     let seed = [7u8; 32];
     let recovery_address = alloy::primitives::Address::ZERO;
 
-    let config = defaults::default_config(
-        &Environment::Staging,
-        Some(rpc_url.clone()),
-        None,
-    )
-    .wrap_err("failed to build staging config")?;
+    let config =
+        defaults::default_config(&Environment::Staging, Some(rpc_url.clone()), None)
+            .wrap_err("failed to build staging config")?;
     let query_material = Arc::new(
         world_id_core::proof::load_embedded_query_material()
             .wrap_err("failed to load embedded query material")?,


### PR DESCRIPTION
## Summary

- Drops the single-impl `DefaultConfig` trait in `walletkit-core/src/defaults.rs` and replaces it with two free functions: `defaults::default_config` (direct service endpoints) and `defaults::default_config_with_ohttp` (OHTTP-routed endpoints).
- `Authenticator::init_with_defaults` and `InitializingAuthenticator::register_with_defaults` now build direct endpoints by default. New sibling constructors `init_with_ohttp_defaults` / `register_with_ohttp_defaults` give callers an explicit opt-in path that reuses the embedded OHTTP key configs and Cloudflare relay URLs.
- Migrates the two `proof_generation_integration` call sites off `Config::from_environment` to the new free function.
- Adds ohttp support to `walletkit-cli`

## Motivation

After PR #729 in `world-id-protocol` landed `ServiceEndpoint::Direct` / `Ohttp` cleanly, OHTTP-on-default no longer needs to be a hidden behaviour of the SDK defaults — it can be an explicit opt-in. This makes the default safer (no surprise traffic through the OHTTP relay), keeps OHTTP one method call away for callers that want it, and removes the awkward extension-trait pretense around a single-impl `DefaultConfig`.

iOS impact: `world-app-ios` currently uses `Authenticator.initWithDefaults` / `InitializingAuthenticator.registerWithDefaults`. To preserve OHTTP, iOS must switch its call sites to `initWithOhttpDefaults` / `registerWithOhttpDefaults` when it bumps walletkit — both old and new are on the FFI surface, so the version bump is the only forcing function. Android (`wld-android`, walletkit `0.12.0`) is pre-OHTTP, change is invisible.

## Test plan

- [x] `cargo test -p walletkit-core --all-features` — 149 lib + 2 e2e tests pass (run outside sandbox; mockito-bound tests need raw socket binds)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] 5 new tests in `defaults::tests` cover both builders across `Environment` × `Region`, the US-pin gateway invariant on the OHTTP path, the `Region::default()` fallback, and JSON round-tripping through `Config::from_json`.