### PR TITLE
feat: support core session proofs

### DIFF
--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -542,9 +542,10 @@ impl Authenticator {
         ))
         .await?;
 
-        // Cache session seed if returned
+        // Cache session seed if returned. Create-session requests do not carry a
+        // session_id, so use the session_id generated in the proof response.
         if let Some(seed) = result.session_id_r_seed {
-            if let Some(session_id) = proof_request.0.session_id {
+            if let Some(session_id) = result.proof_response.session_id {
                 if let Err(err) =
                     self.store
                         .store_session_seed(session_id.oprf_seed, seed, now)

--- a/walletkit-core/src/error.rs
+++ b/walletkit-core/src/error.rs
@@ -185,6 +185,10 @@ pub enum WalletKitError {
         /// The error message from the OHTTP layer
         error: String,
     },
+
+    /// The session proof action or session OPRF seed is not valid for the session OPRF module.
+    #[error("invalid_action_for_session")]
+    InvalidActionSession,
 }
 
 impl From<reqwest::Error> for WalletKitError {
@@ -231,6 +235,7 @@ impl From<WorldIdRequestAuthError> for WalletKitError {
             }
             WorldIdRequestAuthError::InvalidTimestamp => Self::InvalidTimestamp,
             WorldIdRequestAuthError::RpSignatureExpired => Self::RpSignatureExpired,
+            WorldIdRequestAuthError::InvalidActionSession => Self::InvalidActionSession,
             _ => Self::ProofGeneration {
                 error: error.to_string(),
             },
@@ -336,6 +341,7 @@ mod tests {
             }
             WalletKitError::InvalidTimestamp => Some("invalid_timestamp"),
             WalletKitError::RpSignatureExpired => Some("rp_signature_expired"),
+            WalletKitError::InvalidActionSession => Some("invalid_action_for_session"),
             _ => None,
         }
     }
@@ -365,6 +371,10 @@ mod tests {
             (
                 WorldIdRequestAuthError::RpSignatureExpired,
                 "rp_signature_expired",
+            ),
+            (
+                WorldIdRequestAuthError::InvalidActionSession,
+                "invalid_action_for_session",
             ),
         ];
 

--- a/walletkit-core/src/requests.rs
+++ b/walletkit-core/src/requests.rs
@@ -17,10 +17,12 @@ impl ProofRequest {
     /// Returns an error if the JSON is invalid or cannot be parsed.
     #[uniffi::constructor]
     pub fn from_json(json: &str) -> Result<Self, WalletKitError> {
-        let core_request: CoreProofRequest =
-            serde_json::from_str(json).map_err(|e| WalletKitError::Generic {
-                error: format!("invalid proof request json: {e}"),
-            })?;
+        let core_request = CoreProofRequest::from_json(json).map_err(|e| {
+            WalletKitError::InvalidInput {
+                attribute: "proof_request".to_string(),
+                reason: format!("invalid proof request json: {e}"),
+            }
+        })?;
         Ok(Self(core_request))
     }
 
@@ -101,5 +103,93 @@ impl From<CoreProofRequest> for ProofRequest {
 impl From<CoreProofResponse> for ProofResponse {
     fn from(core_response: CoreProofResponse) -> Self {
         Self(core_response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::signers::{local::PrivateKeySigner, SignerSync};
+    use alloy_core::primitives::U160;
+    use serde_json::Value;
+    use taceo_oprf::types::OprfKeyId;
+    use world_id_core::{
+        primitives::{rp::RpId, FieldElement},
+        requests::{ProofType, RequestItem, RequestVersion},
+    };
+
+    use super::*;
+
+    fn test_signature() -> alloy::signers::Signature {
+        let signer = PrivateKeySigner::from_bytes(&[1u8; 32].into())
+            .expect("test signer should be valid");
+        signer
+            .sign_message_sync(b"test")
+            .expect("test signature should sign")
+    }
+
+    fn base_core_request(proof_type: ProofType) -> CoreProofRequest {
+        CoreProofRequest {
+            id: "test_request".to_string(),
+            version: RequestVersion::V1,
+            proof_type,
+            created_at: 1_700_000_000,
+            expires_at: 1_700_000_300,
+            rp_id: RpId::new(1),
+            oprf_key_id: OprfKeyId::new(U160::from(1)),
+            session_id: None,
+            action: Some(FieldElement::from(1u64)),
+            signature: test_signature(),
+            nonce: FieldElement::from(2u64),
+            requests: vec![RequestItem {
+                identifier: "credential".to_string(),
+                issuer_schema_id: 1,
+                signal: None,
+                genesis_issued_at_min: None,
+                expires_at_min: None,
+            }],
+            constraints: None,
+        }
+    }
+
+    #[test]
+    fn from_json_defaults_missing_proof_type_to_uniqueness() {
+        let core_request = base_core_request(ProofType::Uniqueness);
+        let mut value =
+            serde_json::to_value(core_request).expect("request should serialize");
+        value
+            .as_object_mut()
+            .expect("request should be an object")
+            .remove("proof_type");
+
+        let json =
+            serde_json::to_string(&value).expect("request json should serialize");
+        let request = ProofRequest::from_json(&json).expect("request should parse");
+
+        assert_eq!(request.0.proof_type, ProofType::Uniqueness);
+    }
+
+    #[test]
+    fn from_json_rejects_invalid_proof_type_fields() {
+        let mut value = serde_json::to_value(base_core_request(ProofType::Uniqueness))
+            .expect("request should serialize");
+        let object = value.as_object_mut().expect("request should be an object");
+        object.insert(
+            "proof_type".to_string(),
+            Value::String("session".to_string()),
+        );
+        object.remove("action");
+
+        let json =
+            serde_json::to_string(&value).expect("request json should serialize");
+        let error = ProofRequest::from_json(&json)
+            .expect_err("session request needs session_id");
+
+        match error {
+            WalletKitError::InvalidInput { attribute, reason } => {
+                assert_eq!(attribute, "proof_request");
+                assert!(reason.contains("session_id"));
+            }
+            other => panic!("expected invalid input error, got {other:?}"),
+        }
     }
 }

--- a/walletkit-core/tests/proof_generation_integration.rs
+++ b/walletkit-core/tests/proof_generation_integration.rs
@@ -461,16 +461,44 @@ async fn e2e_session_proof() -> Result<()> {
         constraints: None,
     };
 
-    // Use the core authenticator to generate a session ID (calls OPRF)
-    let (session_id, session_id_r_seed) = core_authenticator
-        .build_session_id(&init_request, None, None)
+    let init_proof_request: walletkit_core::requests::ProofRequest =
+        init_request.into();
+    let init_proof_response = authenticator
+        .generate_proof(&init_proof_request, Some(now))
         .await
-        .wrap_err("generate_session_id failed")?;
+        .wrap_err("generate_proof (create session) failed")?;
+    let init_response: world_id_core::requests::ProofResponse =
+        init_proof_response.into_inner();
+    assert!(
+        init_response.error.is_none(),
+        "proof response contains error"
+    );
+    assert_eq!(init_response.responses.len(), 1);
 
-    // Cache the r_seed so generate_proof finds it
-    store
-        .store_session_seed(session_id.oprf_seed, session_id_r_seed, now)
-        .wrap_err("store_session_seed failed")?;
+    let init_response_item = &init_response.responses[0];
+    assert!(
+        init_response_item.is_session(),
+        "create-session response should contain a session proof"
+    );
+    assert!(
+        init_response_item.session_nullifier.is_some(),
+        "create-session response should have a session_nullifier"
+    );
+    assert!(
+        init_response_item.nullifier.is_none(),
+        "create-session response should not have a uniqueness nullifier"
+    );
+
+    let session_id = init_response
+        .session_id
+        .expect("create-session response should include session_id");
+    let cached_seed = store
+        .get_session_seed(session_id.oprf_seed, now)
+        .wrap_err("get_session_seed failed")?;
+    assert!(
+        cached_seed.is_some(),
+        "create-session should cache session_id_r_seed"
+    );
 
     eprintln!(
         "Phase 4 complete: session created (commitment={:?})",


### PR DESCRIPTION
This PR adds support for session proofs:
- Uses `ProofRequest::from_json` which includes `proof_type` validation
- Caches oprf seed from `proof_response` because in the `CreateSession` path there is not session_id in the request 