### PR TITLE
feat(swift): add make_local_swift_package.sh to build and patch WorldApp for local development

### DIFF
--- a/swift/Package.swift.template
+++ b/swift/Package.swift.template
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WalletKit",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "WalletKit",
+            targets: ["WalletKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.7.0")),
+    ],
+    targets: [
+        .target(
+            name: "WalletKit",
+            dependencies: [
+                "walletkit_coreFFI",
+                .product(name: "BigInt", package: "BigInt"),
+            ],
+            path: "Sources/WalletKit"
+        ),
+        <binary_target>
+    ]
+)

--- a/swift/archive_swift.sh
+++ b/swift/archive_swift.sh
@@ -4,6 +4,8 @@ set -e
 # Creates the dynamic Package.swift file for release.
 # Usage: ./archive_swift.sh --asset-url <URL> --checksum <CHECKSUM> --release-version <VERSION>
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Initialize variables
 ASSET_URL=""
 CHECKSUM=""
@@ -56,44 +58,19 @@ echo "   Checksum: $CHECKSUM"
 echo "   Release Version: $RELEASE_VERSION"
 echo ""
 
-cat > Package.swift << EOF
-// swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+awk -v url="$ASSET_URL" -v checksum="$CHECKSUM" '
+/<binary_target>/ {
+    print "        .binaryTarget("
+    print "            name: \"walletkit_coreFFI\","
+    print "            url: \"" url "\","
+    print "            checksum: \"" checksum "\""
+    print "        )"
+    next
+}
+{ print }
+' "$SCRIPT_DIR/Package.swift.template" > Package.swift
 
-// Release version: $RELEASE_VERSION
-
-import PackageDescription
-
-let package = Package(
-    name: "WalletKit",
-    platforms: [
-        .iOS(.v13)
-    ],
-    products: [
-        .library(
-            name: "WalletKit",
-            targets: ["WalletKit"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMajor(from: "5.7.0")),
-    ],
-    targets: [
-        .target(
-            name: "WalletKit",
-            dependencies: [
-                "walletkit_coreFFI",
-                .product(name: "BigInt", package: "BigInt"),
-            ],
-            path: "Sources/WalletKit"
-        ),
-        .binaryTarget(
-            name: "walletkit_coreFFI",
-            url: "$ASSET_URL",
-            checksum: "$CHECKSUM"
-        )
-    ]
-)
-EOF
+echo "// Release version: $RELEASE_VERSION" >> Package.swift
 
 swiftlint lint --autocorrect Package.swift
 

--- a/swift/local_swift.sh
+++ b/swift/local_swift.sh
@@ -8,7 +8,7 @@ set -e
 
 PROJECT_ROOT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE_PATH="$PROJECT_ROOT_PATH/swift" # The base path for the Swift build
-LOCAL_BUILD_PATH="$BASE_PATH/local_build" # Local build artifacts directory
+LOCAL_BUILD_PATH="$BASE_PATH/local_build/walletkit-swift" # Local build artifacts directory
 FRAMEWORK="WalletKit.xcframework"
 
 echo "Building $FRAMEWORK for local iOS development"
@@ -26,42 +26,16 @@ bash "$BASE_PATH/build_swift.sh" "$LOCAL_BUILD_PATH"
 
 echo "Creating Package.swift for local development..."
 
-# Create Package.swift for local development
-cat > $LOCAL_BUILD_PATH/Package.swift << EOF
-// swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
-import PackageDescription
-
-let package = Package(
-    name: "WalletKit",
-    platforms: [
-        .iOS(.v13)
-    ],
-    products: [
-        .library(
-            name: "WalletKit",
-            targets: ["WalletKit"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.4.0"),
-    ],
-    targets: [
-        .target(
-            name: "WalletKit",
-            dependencies: [
-                "walletkit_coreFFI",
-                .product(name: "BigInt", package: "BigInt"),
-            ],
-            path: "Sources/WalletKit"
-        ),
-        .binaryTarget(
-            name: "walletkit_coreFFI",
-            path: "WalletKit.xcframework"
-        )
-    ]
-)
-EOF
+awk -v path="$FRAMEWORK" '
+/<binary_target>/ {
+    print "        .binaryTarget("
+    print "            name: \"walletkit_coreFFI\","
+    print "            path: \"" path "\""
+    print "        )"
+    next
+}
+{ print }
+' "$BASE_PATH/Package.swift.template" > "$LOCAL_BUILD_PATH/Package.swift"
 
 echo ""
 echo "✅ Swift package built successfully!"

--- a/swift/make_local_swift_package.sh
+++ b/swift/make_local_swift_package.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load local env overrides if present
+[[ -f "$PROJECT_ROOT/.env" ]] && source "$PROJECT_ROOT/.env"
+
+WORLD_APP_PATH="${1:-$WORLD_APP_PATH}"
+
+if [ -z "$WORLD_APP_PATH" ]; then
+  echo "Error: Missing path to the WorldApp project. This is used to find and update the Package.swift that references walletkit-swift."
+  echo "Usage: $0 /Path/To/WorldApp"
+  echo "Or set WORLD_APP_PATH in .env"
+  exit 1
+fi
+
+LOCAL_BUILD_PATH="$SCRIPT_DIR/local_build/walletkit-swift"
+
+echo "Building the WalletKit Swift package..."
+bash "$SCRIPT_DIR/local_swift.sh"
+
+echo "Finding Package.swift files that reference walletkit-swift..."
+PACKAGE_FILES=$(grep -rl "worldcoin/walletkit-swift" "$WORLD_APP_PATH" --include="Package.swift" --exclude-dir=".build" --exclude-dir=".claude" || true)
+
+if [ -z "$PACKAGE_FILES" ]; then
+  echo "Warning: No Package.swift found referencing worldcoin/walletkit-swift in $WORLD_APP_PATH"
+  exit 1
+fi
+
+while IFS= read -r pkg_file; do
+  echo "Patching $pkg_file..."
+  sed -i '' "s|\.package(url: \"https://github.com/worldcoin/walletkit-swift\", exact: \"[^\"]*\")|.package(path: \"$LOCAL_BUILD_PATH\")|" "$pkg_file"
+done <<< "$PACKAGE_FILES"
+
+echo "Done! In Xcode, make sure package resolution succeeds (via the Issue Navigator). You can get opaque build failures if the package isn't where the app expects it to be."


### PR DESCRIPTION
## Summary
- Adds `make_local_swift_package.sh`: one command to build walletkit-swift locally and patch WorldApp's `Package.swift` to reference the local build instead of the remote release
- Supporting changes: extract `Package.swift` into a shared template (`Package.swift.template`) so both `archive_swift.sh` and `local_swift.sh` generate it consistently

## Test plan
- [ ] Run `./swift/make_local_swift_package.sh /Path/To/WorldApp` and verify WorldApp's Package.swift is patched to `local_build/walletkit-swift`
- [ ] Open WorldApp in Xcode, resolve packages, and confirm it picks up the local walletkit build