### PR TITLE
[POP-3811] support World ID walletkit user agents

### DIFF
--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -1,5 +1,10 @@
 //! User agent for HTTP requests.
 
+const WORLD_APP_USER_AGENT_PRODUCT: &str = "WorldApp";
+const WORLD_ID_APP_USER_AGENT_PRODUCT: &str = "WorldID";
+const WORLD_ID_ANDROID_CLIENT_NAME: &str = "android-id";
+const WORLD_ID_IOS_CLIENT_NAME: &str = "ios-id";
+
 /// Represents a User-Agent string.
 #[derive(Debug, Clone, uniffi::Object)]
 pub struct UserAgent(pub String);
@@ -41,6 +46,19 @@ impl UserAgentBuilder {
         next
     }
 
+    /// Appends the app product segment for the client name.
+    ///
+    /// Uses `WorldID/{app_version}` for World ID app clients (`android-id` / `ios-id`),
+    /// and `WorldApp/{app_version}` for all other clients.
+    #[must_use]
+    pub fn with_app_segment_for_client(
+        &self,
+        app_version: &str,
+        client_name: &str,
+    ) -> Self {
+        self.with_segment(user_agent_product_for_client(client_name), app_version)
+    }
+
     /// Appends `walletkit-core/{crate version}`.
     #[must_use]
     pub fn with_walletkit_segment(&self) -> Self {
@@ -49,6 +67,12 @@ impl UserAgentBuilder {
         next.segments
             .push(format!("walletkit-core/{crate_version}"));
         next
+    }
+
+    /// Appends `{client_name}/{os_version}` to match the app client suffix convention.
+    #[must_use]
+    pub fn with_client_segment(&self, client_name: &str, os_version: &str) -> Self {
+        self.with_segment(client_name, os_version)
     }
 
     /// Finalizes the header value as [`UserAgent`].
@@ -61,6 +85,15 @@ impl UserAgentBuilder {
 impl Default for UserAgentBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn user_agent_product_for_client(client_name: &str) -> &'static str {
+    match client_name {
+        WORLD_ID_ANDROID_CLIENT_NAME | WORLD_ID_IOS_CLIENT_NAME => {
+            WORLD_ID_APP_USER_AGENT_PRODUCT
+        }
+        _ => WORLD_APP_USER_AGENT_PRODUCT,
     }
 }
 
@@ -95,6 +128,38 @@ mod tests {
             .with_segment("CLI", "1.2.3"),
         concat!("walletkit-core/", env!("CARGO_PKG_VERSION"), " CLI/1.2.3");
         "walletkit_then_cli"
+    )]
+    #[test_case(
+        &UserAgentBuilder::new()
+            .with_app_segment_for_client("4.0.2500", "android")
+            .with_walletkit_segment()
+            .with_client_segment("android", "15"),
+        concat!("WorldApp/4.0.2500 walletkit-core/", env!("CARGO_PKG_VERSION"), " android/15");
+        "world_app_android_client"
+    )]
+    #[test_case(
+        &UserAgentBuilder::new()
+            .with_app_segment_for_client("4.0.2500", "ios")
+            .with_walletkit_segment()
+            .with_client_segment("ios", "26.4.2"),
+        concat!("WorldApp/4.0.2500 walletkit-core/", env!("CARGO_PKG_VERSION"), " ios/26.4.2");
+        "world_app_ios_client"
+    )]
+    #[test_case(
+        &UserAgentBuilder::new()
+            .with_app_segment_for_client("1.0.100", "android-id")
+            .with_walletkit_segment()
+            .with_client_segment("android-id", "15"),
+        concat!("WorldID/1.0.100 walletkit-core/", env!("CARGO_PKG_VERSION"), " android-id/15");
+        "world_id_android_client"
+    )]
+    #[test_case(
+        &UserAgentBuilder::new()
+            .with_app_segment_for_client("1.0.100", "ios-id")
+            .with_walletkit_segment()
+            .with_client_segment("ios-id", "26.4.2"),
+        concat!("WorldID/1.0.100 walletkit-core/", env!("CARGO_PKG_VERSION"), " ios-id/26.4.2");
+        "world_id_ios_client"
     )]
     fn user_agent_builder_expected(builder: &UserAgentBuilder, expected: &'static str) {
         assert_eq!(builder.build().to_string(), expected);

--- a/walletkit-core/src/user_agent.rs
+++ b/walletkit-core/src/user_agent.rs
@@ -17,6 +17,15 @@ impl std::fmt::Display for UserAgent {
     }
 }
 
+#[uniffi::export]
+impl UserAgent {
+    /// Returns the header value for FFI consumers.
+    #[must_use]
+    pub fn header_value(&self) -> String {
+        self.0.clone()
+    }
+}
+
 /// Builds the [`UserAgent`] string sent as the HTTP `User-Agent` header.
 ///
 /// Starts empty; call [`Self::with_segment`] for arbitrary `name/version` tokens and
@@ -163,5 +172,23 @@ mod tests {
     )]
     fn user_agent_builder_expected(builder: &UserAgentBuilder, expected: &'static str) {
         assert_eq!(builder.build().to_string(), expected);
+    }
+
+    #[test]
+    fn user_agent_exposes_header_value_for_ffi_consumers() {
+        let user_agent = UserAgentBuilder::new()
+            .with_app_segment_for_client("1.0.100", "android-id")
+            .with_walletkit_segment()
+            .with_client_segment("android-id", "15")
+            .build();
+
+        assert_eq!(
+            user_agent.header_value(),
+            concat!(
+                "WorldID/1.0.100 walletkit-core/",
+                env!("CARGO_PKG_VERSION"),
+                " android-id/15"
+            )
+        );
     }
 }


### PR DESCRIPTION
**Description**
- Follow-up from Slack thread: https://tfh.slack.com/archives/C0520KUC44X/p1779960456778019?thread_ts=1779855740.827129&cid=C0520KUC44X
- Mirrors the approach from https://github.com/worldcoin/oxide/pull/1050: `android-id` / `ios-id` clients should produce `WorldID` user agents, while existing World App clients stay on `WorldApp`.
- Adds the Kotlin/Swift-accessible header value API needed for downstream apps to consume the WalletKit builder directly.
- Scope note: WalletKit can now build the correct header for downstream and WalletKit-owned clients, but `Authenticator.init_with_defaults` / `register_with_defaults` still cannot inject it into internal `world-id-core` indexer/gateway requests until `world-id-core` exposes a user-agent/client hook.

**Changes**
- Map `android-id` / `ios-id` client names to the `WorldID` user-agent product.
- Keep all other client names mapped to `WorldApp`.
- Add `UserAgentBuilder` helpers for app product selection and `client-name/os-version` suffixes.
- Expose `UserAgent.header_value()` for FFI consumers so Android/iOS can pass the exact built header value.
- Add user-agent coverage for World App and World ID Android/iOS formats, plus FFI header value access.

**Downstream validation**
- Published `org.world:walletkit:0.19.1-SNAPSHOT` locally and integrated it in `wld-android`.
- Added Android instrumentation coverage confirming:
  - World App client `android` -> `WorldApp/<app-version> walletkit-core/<version> android/<os-version>`
  - World ID App client `android-id` -> `WorldID/<app-version> walletkit-core/<version> android-id/<os-version>`
- Built, installed, and launched both `.dev` Android apps successfully on a connected Pixel 3 / Android 12 device.

**Testing Instructions**
- `cargo fmt --check`
- `cargo test -p walletkit-core user_agent --lib`
- `cargo clippy -p walletkit-core --lib --tests -- -D warnings`
- `RUSTUP_HOME=~/.rustup CARGO_HOME=~/.cargo ./kotlin/local_kotlin.sh 0.19.1-SNAPSHOT`
- Downstream Android: `./gradlew :walletKit:impl:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.world.walletkit.impl.WalletKitUserAgentInstrumentedTest`
- Downstream Android: `./gradlew :app:assembleDevDebug :worldIdApp:assembleDevDebug :app:installDevDebug :worldIdApp:installDevDebug`