### PR TITLE
Simplify the test_credential_vault_on_disk_format_guard test

### DIFF
--- a/walletkit-core/src/storage/credential_vault/tests.rs
+++ b/walletkit-core/src/storage/credential_vault/tests.rs
@@ -493,68 +493,6 @@ fn test_vault_integrity_check() {
 }
 
 #[test]
-fn test_credential_vault_on_disk_format_guard() {
-    // On-disk format guard. Stores a credential via the public API and
-    // asserts that the row lands in `blob_objects` with a frozen
-    // content_id, then reopens the vault and reads the payload back
-    // byte-for-byte. Catches:
-    //   - changes to `compute_content_id` (hash domain, kind-tag wiring)
-    //   - changes to `BlobKind::CredentialBlob` (= 0x01)
-    //   - schema or cipher drift in `credential_records`
-    let path = temp_vault_path();
-    let lock_path = temp_lock_path();
-    let key = SecretBox::init_with(|| [0xA5u8; 32]);
-    let credential_bytes = b"on-disk-guard-credential-payload".to_vec();
-    let blinding = sample_blinding_factor();
-
-    let credential_id = {
-        let db = CredentialVault::new(&path, &key).expect("create vault");
-        db.store_credential(
-            42,
-            blinding.clone(),
-            1_700_000_000,
-            1_800_000_000,
-            credential_bytes.clone(),
-            None,
-            1_700_000_001,
-        )
-        .expect("store credential")
-    };
-
-    // SHA-256(b"worldid:blob" || [BlobKind::CredentialBlob as u8 = 0x01]
-    // || credential_bytes). Reproducible via:
-    //   printf 'worldid:blob\x01on-disk-guard-credential-payload' \
-    //     | shasum -a 256
-    let expected_cid_hex =
-        "9281febbd42d05857b399f8481d6842f1e3e4b78401081ca7f0d0fb3a80e9264";
-
-    let db = CredentialVault::new(&path, &key).expect("reopen vault");
-    let stored_cid_hex: String = db
-        .vault.connection()
-        .query_row(
-            "SELECT lower(hex(credential_blob_cid)) FROM credential_records WHERE credential_id = ?1",
-            params![i64::try_from(credential_id).unwrap()],
-            |row| Ok(row.column_text(0)),
-        )
-        .map_err(|err| map_db_err(&err))
-        .expect("fetch cid");
-    assert_eq!(
-        stored_cid_hex, expected_cid_hex,
-        "credential_blob content_id drifted — schema, kind tag, or hash domain changed"
-    );
-
-    let (fetched_blob, fetched_blinding) = db
-        .fetch_credential_and_blinding_factor(42, 1_700_000_500)
-        .expect("fetch credential")
-        .expect("credential present");
-    assert_eq!(fetched_blob, credential_bytes);
-    assert_eq!(fetched_blinding, blinding);
-
-    cleanup_vault_files(&path);
-    cleanup_lock_file(&lock_path);
-}
-
-#[test]
 fn test_list_credentials_round_trips_genesis_issued_at() {
     let path = temp_vault_path();
     let lock_path = temp_lock_path();

--- a/walletkit-db/src/blobs.rs
+++ b/walletkit-db/src/blobs.rs
@@ -142,7 +142,10 @@ fn check_cid_len(cid: &[u8]) -> StoreResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_content_id;
+    use super::{compute_content_id, delete, ensure_schema, get, put};
+    use crate::params;
+    use crate::tests::init_sqlite;
+    use crate::Connection;
 
     #[test]
     fn test_compute_content_id_byte_stable() {
@@ -159,5 +162,37 @@ mod tests {
 
         let cid2 = compute_content_id(2, b"hello");
         assert_ne!(cid, cid2, "kind tag must affect content id");
+    }
+
+    #[test]
+    fn test_put_get_delete_round_trip() {
+        init_sqlite();
+
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        ensure_schema(&conn).expect("ensure schema");
+
+        let cid = put(&conn, 7, b"payload", 1000).expect("put");
+        assert_eq!(
+            hex::encode(cid),
+            "1b108fbc2839877f0df50296ab8db5254efe9bb85864c2fc1ac9285a0f55081d"
+        );
+        assert_eq!(cid, compute_content_id(7, b"payload"));
+
+        let stored = get(&conn, &cid).expect("get").expect("present");
+        assert_eq!(stored.as_slice(), b"payload");
+
+        let duplicate_cid = put(&conn, 7, b"payload", 2000).expect("put duplicate");
+        assert_eq!(duplicate_cid, cid);
+        let row_count = conn
+            .query_row(
+                "SELECT COUNT(*) FROM blob_objects WHERE content_id = ?1",
+                params![cid.as_ref()],
+                |row| Ok(row.column_i64(0)),
+            )
+            .expect("count rows");
+        assert_eq!(row_count, 1);
+
+        delete(&conn, &cid).expect("delete");
+        assert!(get(&conn, &cid).expect("get after delete").is_none());
     }
 }


### PR DESCRIPTION
Removes the test_credential_vault_on_disk_format_guard and ensures the variants it was testing are upheld with simpler tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; format contracts are still enforced via frozen hashes and blob round-trip assertions.
> 
> **Overview**
> **Removes** the credential-vault integration test `test_credential_vault_on_disk_format_guard`, which stored a credential through the full vault API, asserted a frozen `credential_blob_cid` in `credential_records`, and round-tripped the payload via `fetch_credential_and_blinding_factor`.
> 
> **Adds** `test_put_get_delete_round_trip` in `walletkit-db`’s `blobs` module so on-disk format guarantees live next to `put` / `get` / `delete`: frozen content id for a sample kind/payload, `get` byte equality, `INSERT OR IGNORE` deduplication on duplicate `put`, and delete clearing the row. Hash stability remains covered by the existing `test_compute_content_id_byte_stable`; credential vault behavior for blobs still has higher-level tests (e.g. content-id deduplication).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213ee2ee9004073c75b7676c8698080a9477cc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->