### PR TITLE
Ignore RUSTSEC-2026-0173 for unmaintained proc-macro-error2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -46,4 +46,5 @@ ignore = [
   "RUSTSEC-2025-0141", # Unmaintained `bincode`, feature complete for now (2026-01-15)
   "RUSTSEC-2026-0097", # Unsoundness in `rand` 0.8.5 (transitive dep), only affects custom logger + `rand::rng()` which we don't use (2026-04-15)
   "RUSTSEC-2025-0057", # Unmaintained `fxhash` (2025-09-05)
+  "RUSTSEC-2026-0173", # Unmaintained `proc-macro-error2` (transitive via `alloy-sol-macro`) (2026-06-09)
 ]


### PR DESCRIPTION
## Motivation

CI fails on a new RUSTSEC advisory flagging `proc-macro-error2` as no longer maintained.

`proc-macro-error2` is a build-time proc-macro pulled in transitively via `alloy-sol-macro`; we can't drop it until alloy does. Adds it to the existing `[advisories].ignore` list in `deny.toml`, matching how other transitive unmaintained crates are handled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates cargo-deny advisory allowlisting; no runtime or application code changes.
> 
> **Overview**
> Adds **RUSTSEC-2026-0173** to `[advisories].ignore` in `deny.toml` so `cargo-deny` no longer fails CI on the unmaintained **`proc-macro-error2`** advisory.
> 
> The crate is a **transitive build-time** dependency (via **`alloy-sol-macro`**); the ignore follows the same pattern as other unmaintained transitive advisories already listed, with a short inline rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d40cc5eb1ca34f9fb224ab88edd6291591828f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->