### PR TITLE
fix: surface non-empty vault import destination

### DIFF
--- a/walletkit-core/src/storage/credential_storage.rs
+++ b/walletkit-core/src/storage/credential_storage.rs
@@ -330,7 +330,8 @@ impl CredentialStore {
     ///
     /// # Errors
     ///
-    /// Returns an error if the store is not initialized or the import fails.
+    /// Returns an error if the store is not initialized, the destination vault
+    /// already contains backup data, or the import fails.
     pub fn import_vault_from_backup(&self, backup_bytes: &[u8]) -> StorageResult<()> {
         let inner = self.lock_inner()?;
         inner.cleanup_stale_backup_files();
@@ -1264,9 +1265,17 @@ mod tests {
 
         let bytes = store.export_vault_for_backup().expect("export vault");
 
-        // Importing into a non-empty vault should fail.
+        // Importing into a non-empty vault should fail with a typed error so
+        // hosts can decide whether to treat the restore as best-effort.
         let result = store.import_vault_from_backup(&bytes);
-        assert!(result.is_err(), "import into non-empty vault should fail");
+        assert!(
+            matches!(
+                result,
+                Err(StorageError::VaultImportDestinationNotEmpty { ref table })
+                    if table == "credential_records"
+            ),
+            "expected non-empty destination error, got: {result:?}"
+        );
 
         // Verify existing data is unchanged after the failed import.
         let (cred, bf) = store

--- a/walletkit-core/src/storage/credential_vault/mod.rs
+++ b/walletkit-core/src/storage/credential_vault/mod.rs
@@ -15,7 +15,9 @@ use crate::storage::error::{StorageError, StorageResult};
 use crate::storage::types::{BlobKind, CredentialRecord};
 use schema::{ensure_schema, VAULT_SCHEMA_VERSION};
 use secrecy::SecretBox;
-use walletkit_db::{blobs, cipher, params, DbError, Row, StepResult, Value, Vault};
+use walletkit_db::{
+    blobs, cipher, params, Connection, DbError, Row, StepResult, Value, Vault,
+};
 
 /// Tables included in plaintext vault backups, in order.
 ///
@@ -384,9 +386,26 @@ impl CredentialVault {
     /// Returns an error if the import fails.
     pub fn import_plaintext(&self, source: &Path) -> StorageResult<()> {
         let conn = self.vault.connection();
+        ensure_backup_destination_empty(conn)?;
         cipher::import_plaintext_copy(conn, source, BACKUP_TABLES)
             .map_err(|e| map_db_err(&e))
     }
+}
+
+fn ensure_backup_destination_empty(conn: &Connection) -> StorageResult<()> {
+    for table in BACKUP_TABLES {
+        let count: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), &[], |row| {
+                Ok(row.column_i64(0))
+            })
+            .map_err(|err| map_db_err(&err))?;
+        if count > 0 {
+            return Err(StorageError::VaultImportDestinationNotEmpty {
+                table: (*table).to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn map_record(row: &Row<'_, '_>) -> StorageResult<CredentialRecord> {

--- a/walletkit-core/src/storage/error.rs
+++ b/walletkit-core/src/storage/error.rs
@@ -40,6 +40,13 @@ pub enum StorageError {
     #[error("vault db error: {0}")]
     VaultDb(String),
 
+    /// Import failed because the destination vault already contains data.
+    #[error("vault import destination is not empty: {table}")]
+    VaultImportDestinationNotEmpty {
+        /// Destination table that already contains rows.
+        table: String,
+    },
+
     /// Errors coming from the cache database.
     #[error("cache db error: {0}")]
     CacheDb(String),


### PR DESCRIPTION
**Description**
- WalletKit backup import currently reports a non-empty destination as a generic vault database error from the lower-level SQLite copy guard.
- For incident recovery flows, host apps need to distinguish this expected restore-state condition from fatal backup corruption or database failures without parsing the error message string.

**Changes**
- Add `StorageError::VaultImportDestinationNotEmpty { table }` for vault backup imports into a destination that already has rows.
- Preflight backup import destination tables before calling the lower-level plaintext copy guard.
- Update the backup import test to assert the typed error while preserving the existing data-integrity check.

**Testing Instructions**
- `cargo fmt --all --check`
- `cargo test -p walletkit-core import_vault_backup`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to backup import error handling and an early guard; no changes to encryption, credential writes, or successful restore paths.
> 
> **Overview**
> Vault backup import now returns **`StorageError::VaultImportDestinationNotEmpty { table }`** when the destination already has rows in backup tables (`credential_records`, `blob_objects`), instead of a generic vault DB error from the SQLite copy path.
> 
> **`CredentialVault::import_plaintext`** runs a preflight **`ensure_backup_destination_empty`** before **`cipher::import_plaintext_copy`**. Public **`import_vault_from_backup`** docs note this case. The non-empty-vault test asserts the typed error and still checks data is unchanged after a failed import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b244bb6bf572affca83035bb327819d6a8e5c445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->