### PR TITLE
feat: expose init_with_config

### DIFF
--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -141,14 +141,9 @@ pub struct Authenticator {
     store: Arc<CredentialStore>,
 }
 
-/// Rust-only helpers that are intentionally not exported over UniFFI.
 impl Authenticator {
     /// Initializes a new Authenticator from a seed and an already-parsed
     /// [`Config`].
-    ///
-    /// This is a Rust-only helper (not exported over UniFFI) intended for
-    /// internal consumers such as `walletkit-cli` that already hold a typed
-    /// [`Config`] and don't need to parse it from a JSON string.
     ///
     /// # Errors
     /// See `CoreAuthenticator::init` for potential errors.

--- a/walletkit-core/src/authenticator/mod.rs
+++ b/walletkit-core/src/authenticator/mod.rs
@@ -141,6 +141,36 @@ pub struct Authenticator {
     store: Arc<CredentialStore>,
 }
 
+/// Rust-only helpers that are intentionally not exported over UniFFI.
+impl Authenticator {
+    /// Initializes a new Authenticator from a seed and an already-parsed
+    /// [`Config`].
+    ///
+    /// This is a Rust-only helper (not exported over UniFFI) intended for
+    /// internal consumers such as `walletkit-cli` that already hold a typed
+    /// [`Config`] and don't need to parse it from a JSON string.
+    ///
+    /// # Errors
+    /// See `CoreAuthenticator::init` for potential errors.
+    pub async fn init_with_config(
+        seed: &[u8],
+        config: Config,
+        materials: Arc<Groth16Materials>,
+        store: Arc<CredentialStore>,
+    ) -> Result<Self, WalletKitError> {
+        let authenticator = CoreAuthenticator::init(seed, config)
+            .await?
+            .with_proof_materials(
+                Arc::clone(&materials.query),
+                Arc::clone(&materials.nullifier),
+            );
+        Ok(Self {
+            inner: authenticator,
+            store,
+        })
+    }
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl Authenticator {
     /// Returns the packed account data for the holder's World ID.
@@ -363,16 +393,7 @@ impl Authenticator {
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
         let config = defaults::default_config(environment, rpc_url, region)?;
-        let authenticator = CoreAuthenticator::init(seed, config)
-            .await?
-            .with_proof_materials(
-                Arc::clone(&materials.query),
-                Arc::clone(&materials.nullifier),
-            );
-        Ok(Self {
-            inner: authenticator,
-            store,
-        })
+        Self::init_with_config(seed, config, materials, store).await
     }
 
     /// Initializes a new Authenticator from a seed using SDK defaults routed
@@ -395,16 +416,7 @@ impl Authenticator {
         store: Arc<CredentialStore>,
     ) -> Result<Self, WalletKitError> {
         let config = defaults::default_config_with_ohttp(environment, rpc_url, region)?;
-        let authenticator = CoreAuthenticator::init(seed, config)
-            .await?
-            .with_proof_materials(
-                Arc::clone(&materials.query),
-                Arc::clone(&materials.nullifier),
-            );
-        Ok(Self {
-            inner: authenticator,
-            store,
-        })
+        Self::init_with_config(seed, config, materials, store).await
     }
 
     /// Initializes a new Authenticator from a seed and config.
@@ -427,16 +439,7 @@ impl Authenticator {
                 attribute: "config".to_string(),
                 reason: "Invalid config".to_string(),
             })?;
-        let authenticator = CoreAuthenticator::init(seed, config)
-            .await?
-            .with_proof_materials(
-                Arc::clone(&materials.query),
-                Arc::clone(&materials.nullifier),
-            );
-        Ok(Self {
-            inner: authenticator,
-            store,
-        })
+        Self::init_with_config(seed, config, materials, store).await
     }
 
     /// Generates a proof for the given proof request.


### PR DESCRIPTION
Exposes `init_with_config`, that allows to intialize an authenticator when the caller already has a typed `Config`.