### PR TITLE
fix: borrow plaintext in Keystore::seal to avoid un-zeroized copy

### DIFF
--- a/walletkit-core/src/storage/keys.rs
+++ b/walletkit-core/src/storage/keys.rs
@@ -58,14 +58,19 @@ impl StorageKeys {
 
 // Trait-object bridge from walletkit-core's uniffi-annotated traits onto
 // walletkit-db's plain-Rust trait surface. Required because Rust's orphan
-// rule prevents a blanket impl across crates; the wrappers are pure
-// delegation since both trait shapes already use `Vec<u8>` / `String`.
+// rule prevents a blanket impl across crates. `Keystore::seal` borrows its
+// plaintext (see walletkit-db/src/traits.rs); `Ks::seal` is the single
+// point where the secret is copied into an owned `Vec<u8>`, because
+// `DeviceKeystore` is a uniffi callback interface and those only support
+// pass-by-value parameters (no `&[u8]`). That copy — and any further copy
+// the foreign (Swift/Kotlin/etc.) implementation makes on its own side — is
+// outside Rust's control; this is an accepted uniffi limitation, not a bug.
 
 struct Ks<'a>(&'a dyn DeviceKeystore);
 impl walletkit_db::Keystore for Ks<'_> {
-    fn seal(&self, aad: Vec<u8>, pt: Vec<u8>) -> walletkit_db::StoreResult<Vec<u8>> {
+    fn seal(&self, aad: &[u8], pt: &[u8]) -> walletkit_db::StoreResult<Vec<u8>> {
         self.0
-            .seal(aad, pt)
+            .seal(aad.to_vec(), pt.to_vec())
             .map_err(|e| walletkit_db::StoreError::Keystore(e.to_string()))
     }
     fn open_sealed(

--- a/walletkit-db/src/envelope.rs
+++ b/walletkit-db/src/envelope.rs
@@ -107,15 +107,14 @@ pub fn init_or_open_envelope_key(
         let mut k_intermediate = Zeroizing::new([0u8; 32]);
         getrandom::fill(k_intermediate.as_mut())
             .map_err(|err| StoreError::Crypto(format!("rng failure: {err}")))?;
-        // TODO: `keystore.seal(_, Vec<u8>)` requires the plaintext as an
-        // owned heap allocation because the trait shape matches
-        // walletkit-core's uniffi `DeviceKeystore` so the adapter stays
-        // zero-copy. That `Vec<u8>` is NOT zeroized on drop — key bytes
-        // can linger in the allocator's freelist. Improve by either
-        // (a) changing the trait to take a stack reference and updating
-        // the host bridges, or (b) wrapping the `to_vec()` result in
-        // `Zeroizing` and ensuring `Keystore` impls don't clone it.
-        let wrapped = keystore.seal(ad.to_vec(), k_intermediate.to_vec())?;
+        // `keystore.seal` borrows the plaintext, so `k_intermediate` is
+        // never copied into an un-zeroized `Vec<u8>` at this layer. A
+        // `Keystore` bridging to an owned-only interface (e.g. a uniffi
+        // callback like walletkit-core's `DeviceKeystore`) still needs one
+        // owned copy to cross that boundary; that is an accepted,
+        // uniffi-imposed limitation (callback interfaces only support
+        // pass-by-value), not something fixable from this layer.
+        let wrapped = keystore.seal(ad, k_intermediate.as_slice())?;
         let envelope = KeyEnvelope::new(wrapped, now);
         let bytes = envelope.serialize()?;
         blob_store.write_atomic(filename.to_string(), bytes)?;
@@ -193,7 +192,7 @@ mod tests {
     }
 
     impl Keystore for XorKeystore {
-        fn seal(&self, _ad: Vec<u8>, plaintext: Vec<u8>) -> StoreResult<Vec<u8>> {
+        fn seal(&self, _ad: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>> {
             Ok(plaintext
                 .iter()
                 .enumerate()

--- a/walletkit-db/src/traits.rs
+++ b/walletkit-db/src/traits.rs
@@ -1,9 +1,13 @@
 //! Interfaces for consumer-supplied platform integrations.
 //!
-//! Argument shapes (`Vec<u8>`, owned `String`) mirror `WalletKit`'s existing
-//! uniffi-annotated traits so consumers can bridge with a thin newtype that
-//! just delegates and maps errors. (A blanket impl across crates is blocked
-//! by Rust's orphan rule, so consumers do need a small wrapper.)
+//! Argument shapes (`Vec<u8>`, owned `String`) mostly mirror `WalletKit`'s
+//! existing uniffi-annotated traits so consumers can bridge with a thin
+//! newtype that just delegates and maps errors. (A blanket impl across
+//! crates is blocked by Rust's orphan rule, so consumers do need a small
+//! wrapper.) `Keystore::seal` is the one exception: it borrows its
+//! plaintext so the secret is never owned by this crate longer than
+//! necessary; a bridge to an owned-only interface (e.g. a uniffi callback)
+//! still needs one copy at that boundary.
 
 use crate::error::StoreResult;
 
@@ -16,11 +20,15 @@ pub trait Keystore: Send + Sync {
     /// Seals plaintext under the device-bound key, authenticating `aad`
     /// (additional authenticated data).
     ///
+    /// `plaintext` is borrowed rather than owned so that callers holding it
+    /// in a zeroizing buffer (e.g. `Zeroizing<[u8; 32]>`) never have to
+    /// hand ownership of an un-zeroized copy to this trait.
+    ///
     /// # Errors
     ///
     /// Returns an error if the keystore refuses the operation or the seal
     /// fails.
-    fn seal(&self, aad: Vec<u8>, plaintext: Vec<u8>) -> StoreResult<Vec<u8>>;
+    fn seal(&self, aad: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>>;
 
     /// Opens ciphertext under the device-bound key, verifying `aad`. The
     /// same `aad` supplied at seal time must be supplied here or the open


### PR DESCRIPTION
## Summary

`walletkit_db::Keystore::seal` took its plaintext as an owned `Vec<u8>`. On first-time key generation, `init_or_open_envelope_key` called `k_intermediate.to_vec()` to satisfy that signature, creating a copy of the 32-byte master key (`K_intermediate`) that was never zeroized on drop and could linger in freed heap memory.

`seal` now borrows `&[u8]` for both `aad` and `plaintext`, so `k_intermediate` (already held in a `Zeroizing` buffer) is passed by reference and never copied into an un-zeroized owned buffer at this layer.

The `Ks` bridge in `walletkit-core` (which adapts `Keystore` onto the uniffi-exported `DeviceKeystore` trait) still makes one owned copy to cross into `DeviceKeystore::seal`. That is unavoidable: uniffi callback interfaces only support pass-by-value parameters (no `&[u8]`), confirmed against the current uniffi docs. This matches the known limitation already discussed on the report (further copies inside the foreign Swift/Kotlin/etc. implementation are outside Rust's control regardless of this change).

## Scope note

This only changes `Keystore::seal`'s parameter types (not `open_sealed`, whose `aad`/`ciphertext` aren't sensitive) and does not touch `DeviceKeystore` (walletkit-core's uniffi trait), since uniffi does not support borrowed parameters for foreign trait implementations.

`walletkit-db` is published (`publish = true`); this is a breaking change to `Keystore::seal`'s signature for any external implementer, worth a minor version bump at the next release.

## Linear

SEC-2260

## Test plan

- [x] `cargo test -p walletkit-db -p walletkit-core --lib` (140 tests passed)
- [x] `cargo clippy -p walletkit-db -p walletkit-core --lib --tests` (clean)
- [x] `rustfmt --check` on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cryptographic key-handling and breaks the public `Keystore::seal` API; behavior is safer at the Rust layer but foreign keystore paths still copy secrets.
> 
> **Overview**
> **`walletkit_db::Keystore::seal`** now takes **`&[u8]`** for `aad` and `plaintext` instead of owned **`Vec<u8>`**, so first-time envelope creation in **`init_or_open_envelope_key`** can pass the intermediate key from a **`Zeroizing`** buffer without **`to_vec()`** and an extra heap copy that was not zeroized on drop.
> 
> The **`Ks`** adapter in **walletkit-core** still **`to_vec()`**s at the uniffi **`DeviceKeystore`** boundary (pass-by-value only); docs and comments spell that out as an accepted limitation. **`open_sealed`** and **`DeviceKeystore`** are unchanged. Test **`XorKeystore`** and trait docs are updated for the new signature.
> 
> **Breaking** for anyone implementing **`Keystore`** outside this repo (**`walletkit-db`** is published).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795124506a82bab13831147f2c7a35ffd300b1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->