### PR TITLE
fix: add nargo to release-plz workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Install nargo
+      - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
+
       - name: Run release-plz
         uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5.127 (https://github.com/release-plz/action/releases/tag/v0.5.127)
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that aligns release with existing CI tooling; no application or security logic changes.
> 
> **Overview**
> Adds a **nargo** install step to the production **release** workflow so **release-plz** can build crates that depend on the Noir toolchain, matching the setup already used in **CI**.
> 
> The step uses **noir-lang/noirup** (pinned commit) with toolchain **v1.0.0-beta.11**, as required by **provekit**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71559292547b209df9f232ba6de5b720d481eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->