### PR TITLE
fix: add nargo to swift release workflow

### DIFF
--- a/.github/workflows/release-swift-kotlin.yml
+++ b/.github/workflows/release-swift-kotlin.yml
@@ -49,6 +49,12 @@ jobs:
           targets: aarch64-apple-ios-sim,aarch64-apple-ios,x86_64-apple-ios
           components: rustfmt
 
+      # Install nargo
+      - uses: noir-lang/noirup@7dbe69ccc78877f0200ffa5a40836c953d2cfd8f # v0.1.4
+        with:
+          # See https://github.com/worldfnd/provekit, a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
+
       # Includes temporary downstream UniFFI callback vtable patch:
       # https://github.com/mozilla/uniffi-rs/pull/2821
       - name: Build the project (iOS, with temporary UniFFI ASan workaround)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that mirrors existing CI nargo setup; no runtime or application code is modified.
> 
> **Overview**
> The **Swift release** job in `release-swift-kotlin.yml` now installs **nargo** via pinned `noirup` (`v1.0.0-beta.11`) immediately after Rust setup and before `./swift/build_swift.sh`, matching the pattern already used in CI.
> 
> This aligns release iOS builds with provekit’s required Noir toolchain so release builds that use `compress-zkeys` / `embed-zkeys` don’t fail for a missing `nargo` on the runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a220065a969f864a06f52a56a7441eb3c379e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->