### PR TITLE
chore: release walletkit 0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8186,7 +8186,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "uniffi",
 ]
@@ -8416,7 +8416,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "uniffi",
  "walletkit-core",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-cli"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "alloy",
  "alloy-core",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-db"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "cc",
  "ciborium",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-testkit"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "alloy",
  "alloy-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 license = "MIT"
 edition = "2021"
 authors = ["World Contributors"]
@@ -78,8 +78,8 @@ world-id-core = { version = "0.12.0", default-features = false }
 world-id-proof = { version = "0.12.0", default-features = false }
 
 # internal
-walletkit-core = { version = "0.20.1", path = "crates/walletkit-core", default-features = false }
-walletkit-db = { version = "0.20.1", path = "crates/walletkit-db" }
+walletkit-core = { version = "0.20.2", path = "crates/walletkit-core", default-features = false }
+walletkit-db = { version = "0.20.2", path = "crates/walletkit-db" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/walletkit/CHANGELOG.md
+++ b/crates/walletkit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/worldcoin/walletkit/compare/v0.20.1...v0.20.2) - 2026-07-15
+
+### Other
+
+- bump release version to republish Swift and Kotlin FFI artifacts
+
 ## [0.20.1](https://github.com/worldcoin/walletkit/compare/v0.20.0...v0.20.1) - 2026-07-15
 
 ### Other


### PR DESCRIPTION
## Summary

- bump the WalletKit workspace to 0.20.2
- republish Swift and Kotlin FFI artifacts after the 0.20.1 Swift build failed because nargo was missing
- update the changelog and lockfile

The nargo installation fix is already on `main` in #445.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application or library code changes—only version metadata, lockfile, and changelog for a republish release.
> 
> **Overview**
> Bumps the WalletKit workspace from **0.20.1** to **0.20.2** in `Cargo.toml`, `Cargo.lock`, and internal `walletkit-core` / `walletkit-db` dependency pins so all crates (`walletkit`, `walletkit-cli`, `walletkit-core`, `walletkit-db`, `walletkit-testkit`, `uniffi-bindgen`) align on the new version.
> 
> Adds a **0.20.2** changelog entry noting the release is to **republish Swift and Kotlin FFI artifacts** after the 0.20.1 Swift build failed (missing `nargo`); the build fix is already on `main` separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccce4c55395b5da9c8bf16d006fa74fdf3702dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->