### PR TITLE
feat: add identifier to testkit VerifyItemResult

### DIFF
--- a/crates/walletkit-testkit/src/proof.rs
+++ b/crates/walletkit-testkit/src/proof.rs
@@ -118,6 +118,8 @@ pub fn build_test_request(
 pub struct VerifyItemResult {
     /// Issuer schema ID of the verified credential.
     pub issuer_schema_id: u64,
+    /// RP-defined identifier of the response item that was verified.
+    pub identifier: String,
     /// `Ok(())` if the on-chain `verify`/`verifySession` call succeeded,
     /// `Err` with the failure details from the contract call otherwise.
     pub result: Result<(), String>,
@@ -220,6 +222,7 @@ pub async fn verify_proof_onchain(
 
         results.push(VerifyItemResult {
             issuer_schema_id: response_item.issuer_schema_id,
+            identifier: response_item.identifier.clone(),
             result: result.map_err(|e| format!("{e:#}")),
         });
     }


### PR DESCRIPTION
## Summary

`verify_proof_onchain` returns one `VerifyItemResult` per response item, but the result only carried `issuer_schema_id` and the verification outcome — not the response item's `identifier` (the RP-defined label for the item, e.g. `"orb"`, `"document"`). Callers that want to show which item passed or failed had to recover the identifier by positionally re-pairing the results with `proof_response.responses`, a coupling that silently mispairs or truncates if the result list ever diverges from the response list.