### PR TITLE
chore: remove broken readme

### DIFF
--- a/crates/walletkit/README.md
+++ b/crates/walletkit/README.md
@@ -1,1 +1,0 @@
-../README.md

--- a/crates/walletkit/src/lib.rs
+++ b/crates/walletkit/src/lib.rs
@@ -1,4 +1,8 @@
-#![doc = include_str!("../README.md")]
+//! WalletKit is the reference implementation for World ID clients.
+//!
+//! It provides the Rust API and UniFFI bindings used by mobile applications
+//! to interact with World ID. The public API is re-exported from
+//! [`walletkit_core`].
 
 extern crate walletkit_core;
 walletkit_core::uniffi_reexport_scaffolding!();

--- a/crates/walletkit/src/lib.rs
+++ b/crates/walletkit/src/lib.rs
@@ -1,6 +1,6 @@
-//! WalletKit is the reference implementation for World ID clients.
+//! `WalletKit` is the reference implementation for World ID clients.
 //!
-//! It provides the Rust API and UniFFI bindings used by mobile applications
+//! It provides the Rust API and `UniFFI` bindings used by mobile applications
 //! to interact with World ID. The public API is re-exported from
 //! [`walletkit_core`].
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Removes **`crates/walletkit/README.md`**, which only pointed at a parent README and was not a usable doc source.
> 
> **`walletkit`’s `lib.rs`** no longer uses `#![doc = include_str!("../README.md")]`. Crate-level rustdoc now describes WalletKit as the World ID client reference implementation, UniFFI bindings for mobile, and re-exports from **`walletkit_core`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0fd2f95a0ef211e790804fadff997e591d2f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->