### PR TITLE
use eyre context terminology

### DIFF
--- a/crates/walletkit-cli/src/commands/auth.rs
+++ b/crates/walletkit-cli/src/commands/auth.rs
@@ -1,7 +1,7 @@
 //! `walletkit auth` subcommands — authenticator lifecycle and registration.
 
 use clap::Subcommand;
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::error::WalletKitError;
 use walletkit_core::{InitializingAuthenticator, RecoveryData, RegistrationStatus};
 
@@ -65,11 +65,11 @@ pub async fn register_and_poll(
         {
             return Ok(RegisterOutcome::AlreadyRegistered);
         }
-        Err(e) => return Err(e).wrap_err("registration failed"),
+        Err(e) => return Err(e).context("registration failed"),
     };
 
     loop {
-        let status = init_auth.poll_status().await.wrap_err("poll failed")?;
+        let status = init_auth.poll_status().await.context("poll failed")?;
 
         match &status {
             RegistrationStatus::Finalized => return Ok(RegisterOutcome::Finalized),
@@ -159,10 +159,10 @@ async fn run_register(cli: &Cli, recovery_address: Option<&str>) -> eyre::Result
             output::print_success("Already registered.", cli.json);
             return Ok(());
         }
-        Err(e) => return Err(e).wrap_err("registration failed"),
+        Err(e) => return Err(e).context("registration failed"),
     };
 
-    let status = init_auth.poll_status().await.wrap_err("poll failed")?;
+    let status = init_auth.poll_status().await.context("poll failed")?;
     let status_str = format!("{status:?}");
 
     if cli.json {
@@ -204,7 +204,7 @@ fn run_recovery_data(cli: &Cli) -> eyre::Result<()> {
     let seed = resolve_seed(cli)?;
 
     let material =
-        RecoveryData::from_seed(&seed).wrap_err("failed to derive recovery data")?;
+        RecoveryData::from_seed(&seed).context("failed to derive recovery data")?;
     let data = serde_json::json!({
         "authenticator_address": material.authenticator_address,
         "authenticator_pubkey": material.authenticator_pubkey,
@@ -264,7 +264,7 @@ pub async fn run(cli: &Cli, action: &AuthCommand) -> eyre::Result<()> {
             let remote = authenticator
                 .get_packed_account_data_remote()
                 .await
-                .wrap_err("remote fetch failed")?;
+                .context("remote fetch failed")?;
             let local = authenticator.packed_account_data();
             let matches = remote.to_string() == local.to_string();
 

--- a/crates/walletkit-cli/src/commands/credential.rs
+++ b/crates/walletkit-cli/src/commands/credential.rs
@@ -3,7 +3,7 @@
 use std::io::Read;
 
 use clap::{Subcommand, ValueEnum};
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::{Credential, FieldElement};
 use walletkit_testkit::env::TestEnv;
 use walletkit_testkit::issuer::import_credential;
@@ -85,7 +85,7 @@ fn read_file_or_stdin(path: &str) -> eyre::Result<Vec<u8>> {
         Ok(buf)
     } else {
         let meta =
-            std::fs::metadata(path).wrap_err_with(|| format!("cannot read {path}"))?;
+            std::fs::metadata(path).with_context(|| format!("cannot read {path}"))?;
         eyre::ensure!(
             meta.len() <= MAX_INPUT_BYTES,
             "input file too large (max 10 MiB)"
@@ -103,11 +103,11 @@ async fn run_import(
     let (authenticator, store) = init_authenticator(cli).await?;
 
     let cred_bytes = read_file_or_stdin(credential)?;
-    let cred = Credential::from_bytes(cred_bytes).wrap_err("invalid credential")?;
+    let cred = Credential::from_bytes(cred_bytes).context("invalid credential")?;
 
     let bf = blinding_factor
         .map(|hex| {
-            FieldElement::try_from_hex_string(hex).wrap_err("invalid blinding factor")
+            FieldElement::try_from_hex_string(hex).context("invalid blinding factor")
         })
         .transpose()?;
 
@@ -116,7 +116,7 @@ async fn run_import(
             use base64::Engine;
             base64::engine::general_purpose::STANDARD
                 .decode(b64)
-                .wrap_err("invalid base64 associated_data")
+                .context("invalid base64 associated_data")
         })
         .transpose()?;
 
@@ -151,7 +151,7 @@ async fn run_list(cli: &Cli, issuer_schema_id: Option<u64>) -> eyre::Result<()> 
     let now = now_secs();
     let records = store
         .list_credentials(issuer_schema_id, now)
-        .wrap_err("list credentials failed")?;
+        .context("list credentials failed")?;
 
     if cli.json {
         let items: Vec<serde_json::Value> = records
@@ -191,7 +191,7 @@ async fn run_show(cli: &Cli, issuer_schema_id: u64) -> eyre::Result<()> {
     let now = now_secs();
     let result = store
         .get_credential(issuer_schema_id, now)
-        .wrap_err("get credential failed")?;
+        .context("get credential failed")?;
 
     match result {
         Some((cred, bf)) => {
@@ -282,7 +282,7 @@ async fn run_derive_sub(
 ) -> eyre::Result<()> {
     let supplied_blinding_factor = blinding_factor
         .map(|value| {
-            FieldElement::try_from_hex_string(value).wrap_err("invalid blinding factor")
+            FieldElement::try_from_hex_string(value).context("invalid blinding factor")
         })
         .transpose()?;
     let (authenticator, _store) = init_authenticator(cli).await?;
@@ -291,7 +291,7 @@ async fn run_derive_sub(
         None => authenticator
             .generate_credential_blinding_factor_remote(issuer_schema_id)
             .await
-            .wrap_err("blinding factor generation failed")?,
+            .context("blinding factor generation failed")?,
     };
     let sub = authenticator.compute_credential_sub(&blinding_factor);
     let blinding_factor = blinding_factor.to_hex_string();
@@ -346,7 +346,7 @@ pub async fn run(cli: &Cli, action: &CredentialCommand) -> eyre::Result<()> {
             let (_authenticator, store) = init_authenticator(cli).await?;
             store
                 .delete_credential(*credential_id)
-                .wrap_err("delete credential failed")?;
+                .context("delete credential failed")?;
             output::print_success(
                 &format!("Credential {credential_id} deleted."),
                 cli.json,

--- a/crates/walletkit-cli/src/commands/mod.rs
+++ b/crates/walletkit-cli/src/commands/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use alloy_core::primitives::Address;
 use clap::{Parser, Subcommand};
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::authenticator::artifacts::caching::CachingZkArtifacts;
 use world_id_core::primitives::Config;
 
@@ -154,7 +154,7 @@ fn resolve_root(cli: &Cli) -> eyre::Result<PathBuf> {
 fn resolve_seed(cli: &Cli) -> eyre::Result<Vec<u8>> {
     if let Some(ref hex_seed) = cli.seed {
         let bytes = hex::decode(hex_seed.trim_start_matches("0x"))
-            .wrap_err("invalid hex seed")?;
+            .context("invalid hex seed")?;
         eyre::ensure!(
             bytes.len() == 32,
             "seed must be exactly 32 bytes, got {}",
@@ -176,9 +176,9 @@ fn resolve_seed(cli: &Cli) -> eyre::Result<Vec<u8>> {
         let seed_path = root.join("seed");
         if seed_path.exists() {
             let hex_str = std::fs::read_to_string(&seed_path)
-                .wrap_err("failed to read seed file")?;
+                .context("failed to read seed file")?;
             let bytes =
-                hex::decode(hex_str.trim()).wrap_err("invalid hex in seed file")?;
+                hex::decode(hex_str.trim()).context("invalid hex in seed file")?;
             eyre::ensure!(
                 bytes.len() == 32,
                 "seed file must contain exactly 32 bytes, got {}",
@@ -217,7 +217,7 @@ fn resolve_region(cli: &Cli) -> eyre::Result<Option<walletkit_core::Region>> {
 pub fn resolve_config(cli: &Cli) -> eyre::Result<Option<String>> {
     match &cli.authenticator_config {
         Some(path) => {
-            let json = std::fs::read_to_string(path).wrap_err_with(|| {
+            let json = std::fs::read_to_string(path).with_context(|| {
                 format!(
                     "failed to read authenticator config file {}",
                     path.display()
@@ -237,7 +237,7 @@ pub fn resolve_config(cli: &Cli) -> eyre::Result<Option<String>> {
 /// `--environment` / `--region` are invalid, or if default config construction fails.
 fn resolve_built_config(cli: &Cli) -> eyre::Result<Config> {
     if let Some(config_json) = resolve_config(cli)? {
-        Config::from_json(&config_json).wrap_err("invalid authenticator config JSON")
+        Config::from_json(&config_json).context("invalid authenticator config JSON")
     } else {
         let environment = resolve_environment(cli)?;
         let region = resolve_region(cli)?;
@@ -254,7 +254,7 @@ fn resolve_built_config(cli: &Cli) -> eyre::Result<Config> {
                 region,
             )
         }
-        .wrap_err("failed to build World ID config")
+        .context("failed to build World ID config")
     }
 }
 
@@ -273,7 +273,7 @@ fn resolve_verifier_address(
     config: &Config,
 ) -> eyre::Result<Address> {
     if let Some(addr) = verifier_address {
-        return addr.parse::<Address>().wrap_err("invalid verifier address");
+        return addr.parse::<Address>().context("invalid verifier address");
     }
 
     let registry = *config.registry_address();
@@ -320,18 +320,18 @@ pub async fn init_authenticator(
     let authenticator = if let Some(ref config) = config_json {
         Authenticator::init(&seed, config, artifacts.clone(), store.clone())
             .await
-            .wrap_err("authenticator init failed")?
+            .context("authenticator init failed")?
     } else {
         let config = resolve_built_config(cli)?;
         Authenticator::init_with_config(&seed, config, artifacts.clone(), store.clone())
             .await
-            .wrap_err("authenticator init failed")?
+            .context("authenticator init failed")?
     };
 
     let now = now_secs();
     authenticator
         .init_storage(now)
-        .wrap_err("storage init failed")?;
+        .context("storage init failed")?;
 
     Ok((Arc::new(authenticator), store))
 }

--- a/crates/walletkit-cli/src/commands/proof.rs
+++ b/crates/walletkit-cli/src/commands/proof.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine as _};
 use clap::Subcommand;
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::requests::ProofRequest;
 use walletkit_testkit::env::TestEnv;
 use walletkit_testkit::issuer::issue_faux_credential;
@@ -119,7 +119,7 @@ fn read_file_or_stdin(path: &str) -> eyre::Result<String> {
         Ok(buf)
     } else {
         let meta =
-            std::fs::metadata(path).wrap_err_with(|| format!("cannot read {path}"))?;
+            std::fs::metadata(path).with_context(|| format!("cannot read {path}"))?;
         eyre::ensure!(
             meta.len() <= MAX_INPUT_BYTES,
             "input file too large (max 10 MiB)"
@@ -149,16 +149,16 @@ async fn run_generate(cli: &Cli, request: &str, now: Option<u64>) -> eyre::Resul
 
     let json_str = read_file_or_stdin(request)?;
     let proof_request =
-        ProofRequest::from_json(&json_str).wrap_err("invalid proof request")?;
+        ProofRequest::from_json(&json_str).context("invalid proof request")?;
 
     let response = authenticator
         .generate_proof(&proof_request, Some(ts))
         .await
-        .wrap_err("proof generation failed")?;
+        .context("proof generation failed")?;
 
     let response_json = response
         .to_json()
-        .wrap_err("response serialization failed")?;
+        .context("response serialization failed")?;
 
     if cli.json {
         let parsed: serde_json::Value = serde_json::from_str(&response_json)?;
@@ -214,9 +214,9 @@ async fn run_verify(
     let response_json = read_file_or_stdin(response_path)?;
 
     let proof_request: CoreProofRequest =
-        CoreProofRequest::from_json(&request_json).wrap_err("invalid proof request")?;
+        CoreProofRequest::from_json(&request_json).context("invalid proof request")?;
     let proof_response: CoreProofResponse =
-        serde_json::from_str(&response_json).wrap_err("invalid proof response")?;
+        serde_json::from_str(&response_json).context("invalid proof response")?;
 
     let env = cli_test_env(cli, verifier_address)?;
     let results = verify_proof_onchain(&env, &proof_request, &proof_response).await?;
@@ -314,11 +314,11 @@ async fn run_test(
     let ts = now_secs();
     let walletkit_request =
         ProofRequest::from_json(&serde_json::to_string(&proof_request)?)
-            .wrap_err("invalid proof request")?;
+            .context("invalid proof request")?;
     let proof_response = authenticator
         .generate_proof(&walletkit_request, Some(ts))
         .await
-        .wrap_err("proof generation failed")?;
+        .context("proof generation failed")?;
 
     if !cli.json {
         eprintln!("Verifying proof on-chain...");
@@ -351,9 +351,10 @@ async fn run_test(
 }
 
 fn parse_field_element(value: &str, label: &str) -> eyre::Result<FieldElement> {
-    value.trim().parse::<FieldElement>().wrap_err_with(|| {
-        format!("invalid {label}: expected 32-byte hex field element")
-    })
+    value
+        .trim()
+        .parse::<FieldElement>()
+        .with_context(|| format!("invalid {label}: expected 32-byte hex field element"))
 }
 
 fn run_verify_ownership(
@@ -365,9 +366,9 @@ fn run_verify_ownership(
     let b64 = read_file_or_stdin(proof_path)?;
     let bytes = BASE64_URL_SAFE_NO_PAD
         .decode(b64.trim())
-        .wrap_err("invalid base64 ownership proof")?;
+        .context("invalid base64 ownership proof")?;
     let proof: OwnershipProof = ciborium::from_reader(&bytes[..])
-        .wrap_err("failed to decode ownership proof CBOR")?;
+        .context("failed to decode ownership proof CBOR")?;
 
     let nonce_fe = parse_field_element(nonce, "--nonce")?;
     let sub_fe = parse_field_element(sub, "--sub")?;

--- a/crates/walletkit-cli/src/commands/recovery_agent.rs
+++ b/crates/walletkit-cli/src/commands/recovery_agent.rs
@@ -1,7 +1,7 @@
 //! `walletkit recovery-agent` subcommands — recovery agent management (WIP-102).
 
 use clap::Subcommand;
-use eyre::WrapErr as _;
+use eyre::Context;
 
 use crate::output;
 
@@ -27,7 +27,7 @@ pub async fn run(cli: &Cli, action: &RecoveryAgentCommand) -> eyre::Result<()> {
             let request_id = authenticator
                 .update_recovery_agent(new_recovery_agent.clone())
                 .await
-                .wrap_err("update recovery agent failed")?;
+                .context("update recovery agent failed")?;
 
             let data = serde_json::json!({ "request_id": request_id });
             if cli.json {
@@ -40,7 +40,7 @@ pub async fn run(cli: &Cli, action: &RecoveryAgentCommand) -> eyre::Result<()> {
             let request_id = authenticator
                 .revert_recovery_agent_update()
                 .await
-                .wrap_err("revert recovery agent update failed")?;
+                .context("revert recovery agent update failed")?;
 
             let data = serde_json::json!({ "request_id": request_id });
             if cli.json {

--- a/crates/walletkit-cli/src/commands/wallet.rs
+++ b/crates/walletkit-cli/src/commands/wallet.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use clap::Subcommand;
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::{
     authenticator::artifacts::caching::CachingZkArtifacts, storage::StoragePaths,
 };
@@ -172,11 +172,11 @@ fn run_doctor(cli: &Cli) -> eyre::Result<()> {
 
 async fn run_export(cli: &Cli, dest: &str) -> eyre::Result<()> {
     let (_authenticator, store) = init_authenticator(cli).await?;
-    let backup_bytes = store.export_vault_for_backup().wrap_err("export failed")?;
+    let backup_bytes = store.export_vault_for_backup().context("export failed")?;
 
     let backup_path = std::path::Path::new(dest).join("vault_backup.bin");
     std::fs::write(&backup_path, &backup_bytes)
-        .wrap_err("failed to write backup file")?;
+        .context("failed to write backup file")?;
 
     let backup_path = backup_path.display().to_string();
     if cli.json {
@@ -192,10 +192,10 @@ async fn run_export(cli: &Cli, dest: &str) -> eyre::Result<()> {
 
 async fn run_import(cli: &Cli, backup: &str) -> eyre::Result<()> {
     let (_authenticator, store) = init_authenticator(cli).await?;
-    let backup_bytes = std::fs::read(backup).wrap_err("failed to read backup file")?;
+    let backup_bytes = std::fs::read(backup).context("failed to read backup file")?;
     store
         .import_vault_from_backup(&backup_bytes)
-        .wrap_err("import failed")?;
+        .context("import failed")?;
 
     output::print_success("Vault imported successfully.", cli.json);
     Ok(())
@@ -210,7 +210,7 @@ async fn run_danger_clear(cli: &Cli, confirm: bool) -> eyre::Result<()> {
     let (_authenticator, store) = init_authenticator(cli).await?;
     let deleted = store
         .danger_delete_all_credentials()
-        .wrap_err("danger clear failed")?;
+        .context("danger clear failed")?;
 
     if cli.json {
         output::print_json_data(&serde_json::json!({ "deleted": deleted }), true);

--- a/crates/walletkit-core/tests/proof_generation_integration.rs
+++ b/crates/walletkit-core/tests/proof_generation_integration.rs
@@ -25,7 +25,7 @@ use walletkit_testkit::{
 };
 use world_id_core::primitives::FieldElement;
 
-use eyre::{Result, WrapErr as _};
+use eyre::{Context, Result};
 
 // Distinct seeds so these tests drive independent staging identities, both from
 // each other and from the `walletkit-testkit` e2e suite (which uses [7], [8], [9]).
@@ -52,7 +52,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
     init_tracing();
 
     let env = TestEnv::default_staging();
-    let root = TempDir::new().wrap_err("failed to create temp storage dir")?;
+    let root = TempDir::new().context("failed to create temp storage dir")?;
 
     let now = now_secs();
     let credential_type = CredentialType::Local {
@@ -70,7 +70,7 @@ async fn e2e_authenticator_generate_proof() -> Result<()> {
         None,
     )
     .await
-    .wrap_err("uniqueness flow should succeed")?;
+    .context("uniqueness flow should succeed")?;
 
     assert!(
         outcome.verified(),
@@ -91,7 +91,7 @@ async fn e2e_session_proof() -> Result<()> {
     init_tracing();
 
     let env = TestEnv::default_staging();
-    let root = TempDir::new().wrap_err("failed to create temp storage dir")?;
+    let root = TempDir::new().context("failed to create temp storage dir")?;
     let schema_id = env.local_issuer_schema_id;
 
     // Phase 1: register the account and initialize a filesystem-backed authenticator.
@@ -102,7 +102,7 @@ async fn e2e_session_proof() -> Result<()> {
         Some(Address::ZERO),
     )
     .await
-    .wrap_err("account setup failed")?;
+    .context("account setup failed")?;
 
     // Phase 2: issue a local-EdDSA credential to prove over.
     let now = now_secs();
@@ -114,7 +114,7 @@ async fn e2e_session_proof() -> Result<()> {
         now + CREDENTIAL_TTL_SECS,
     )
     .await
-    .wrap_err("credential issuance failed")?;
+    .context("credential issuance failed")?;
 
     // Phase 3: create a session and confirm the session seed is cached.
     let create_request = build_test_request(
@@ -125,11 +125,11 @@ async fn e2e_session_proof() -> Result<()> {
         ProofType::CreateSession,
         None,
     )
-    .wrap_err("failed to build create-session request")?;
+    .context("failed to build create-session request")?;
     let create_response = authenticator
         .generate_proof(&create_request.clone().into(), Some(now_secs()))
         .await
-        .wrap_err("generate_proof (create session) failed")?
+        .context("generate_proof (create session) failed")?
         .into_inner();
     assert!(create_response.error.is_none(), "create-session error");
     assert_eq!(create_response.responses.len(), 1);
@@ -151,7 +151,7 @@ async fn e2e_session_proof() -> Result<()> {
         .expect("create-session response should include session_id");
     let cached_seed = store
         .get_session_seed(session_id.oprf_seed, now)
-        .wrap_err("get_session_seed failed")?;
+        .context("get_session_seed failed")?;
     assert!(
         cached_seed.is_some(),
         "create-session should cache session_id_r_seed"
@@ -166,11 +166,11 @@ async fn e2e_session_proof() -> Result<()> {
         ProofType::Session,
         Some(session_id),
     )
-    .wrap_err("failed to build session request")?;
+    .context("failed to build session request")?;
     let session_response = authenticator
         .generate_proof(&session_request.clone().into(), Some(now_secs()))
         .await
-        .wrap_err("generate_proof (session) failed")?
+        .context("generate_proof (session) failed")?
         .into_inner();
     assert!(session_response.error.is_none(), "session proof error");
     assert_eq!(session_response.responses.len(), 1);
@@ -193,14 +193,14 @@ async fn e2e_session_proof() -> Result<()> {
     // Merkle root — both prove inclusion of the same on-chain account.
     let (credential, blinding_factor) = store
         .get_credential(schema_id, now)
-        .wrap_err("failed to retrieve issued credential")?
+        .context("failed to retrieve issued credential")?
         .ok_or_else(|| eyre::eyre!("issued credential missing from store"))?;
     let sub = credential.sub();
     let nonce = FieldElement::random(&mut OsRng).into();
     let ownership_proof = authenticator
         .prove_credential_sub(&nonce, &blinding_factor, &sub)
         .await
-        .wrap_err("ownership proof generation failed")?;
+        .context("ownership proof generation failed")?;
     assert_eq!(
         ownership_proof.merkle_root().to_u256(),
         session_item.proof.as_ethereum_representation()[4],

--- a/crates/walletkit-testkit/src/authenticator.rs
+++ b/crates/walletkit-testkit/src/authenticator.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use alloy::primitives::Address;
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::storage::CredentialStore;
 use walletkit_core::Authenticator;
 use world_id_core::Authenticator as CoreAuthenticator;
@@ -43,11 +43,11 @@ pub async fn init_authenticator(
         store.clone(),
     )
     .await
-    .wrap_err("authenticator init failed")?;
+    .context("authenticator init failed")?;
 
     authenticator
         .init_storage(now)
-        .wrap_err("storage init failed")?;
+        .context("storage init failed")?;
 
     Ok((authenticator, store))
 }
@@ -79,7 +79,7 @@ pub async fn register_account(
         artifacts,
     )
     .await
-    .wrap_err("account creation/init failed")?;
+    .context("account creation/init failed")?;
 
     Ok(core_authenticator.leaf_index())
 }

--- a/crates/walletkit-testkit/src/issuer.rs
+++ b/crates/walletkit-testkit/src/issuer.rs
@@ -1,7 +1,7 @@
 //! Test credential acquisition.
 use std::future::Future;
 
-use eyre::WrapErr as _;
+use eyre::Context;
 use walletkit_core::storage::CredentialStore;
 use walletkit_core::{Authenticator, Credential, FieldElement};
 use world_id_core::{
@@ -71,7 +71,7 @@ pub async fn import_credential(
         None => authenticator
             .generate_credential_blinding_factor_remote(credential.issuer_schema_id())
             .await
-            .wrap_err("blinding factor generation failed")?,
+            .context("blinding factor generation failed")?,
     };
 
     let credential_id = store
@@ -82,7 +82,7 @@ pub async fn import_credential(
             associated_data,
             now_secs(),
         )
-        .wrap_err("store credential failed")?;
+        .context("store credential failed")?;
 
     Ok(ImportedCredential {
         credential_id,
@@ -107,7 +107,7 @@ pub async fn issue_faux_credential(
     let blinding_factor = authenticator
         .generate_credential_blinding_factor_remote(env.faux_issuer_schema_id)
         .await
-        .wrap_err("blinding factor generation failed")?;
+        .context("blinding factor generation failed")?;
 
     let sub_hex = authenticator
         .compute_credential_sub(&blinding_factor)
@@ -119,7 +119,7 @@ pub async fn issue_faux_credential(
         .json(&serde_json::json!({ "sub": sub_hex }))
         .send()
         .await
-        .wrap_err("faux issuer request failed")?;
+        .context("faux issuer request failed")?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -130,21 +130,21 @@ pub async fn issue_faux_credential(
     let body: serde_json::Value = resp
         .json()
         .await
-        .wrap_err("failed to parse faux issuer response")?;
+        .context("failed to parse faux issuer response")?;
 
     let cred_value = body.get("credential").ok_or_else(|| {
         eyre::eyre!("faux issuer response missing 'credential' field")
     })?;
 
     let cred_bytes =
-        serde_json::to_vec(cred_value).wrap_err("failed to serialize credential")?;
+        serde_json::to_vec(cred_value).context("failed to serialize credential")?;
     let cred = Credential::from_bytes(cred_bytes)
-        .wrap_err("invalid credential from faux issuer")?;
+        .context("invalid credential from faux issuer")?;
     let expires_at = cred.expires_at();
 
     let credential_id = store
         .store_credential(&cred, &blinding_factor, expires_at, None, now_secs())
-        .wrap_err("store credential failed")?;
+        .context("store credential failed")?;
 
     Ok(IssuedCredential {
         credential_id,
@@ -177,7 +177,7 @@ pub async fn issue_local_credential(
     let bf = authenticator
         .generate_credential_blinding_factor_remote(env.local_issuer_schema_id)
         .await
-        .wrap_err("blinding factor generation failed")?;
+        .context("blinding factor generation failed")?;
 
     let mut credential = build_base_credential(
         env.local_issuer_schema_id,
@@ -187,13 +187,13 @@ pub async fn issue_local_credential(
         bf.0,
     );
     credential.issuer = issuer_public_key;
-    let credential_hash = credential.hash().wrap_err("failed to hash credential")?;
+    let credential_hash = credential.hash().context("failed to hash credential")?;
     credential.signature = Some(issuer_secret_key.sign(*credential_hash));
 
     let walletkit_credential: Credential = credential.into();
     let credential_id = store
         .store_credential(&walletkit_credential, &bf, expires_at, None, now_secs())
-        .wrap_err("store credential failed")?;
+        .context("store credential failed")?;
 
     Ok(IssuedCredential {
         credential_id,
@@ -223,14 +223,14 @@ where
     let bf = authenticator
         .generate_credential_blinding_factor_remote(schema_id)
         .await
-        .wrap_err("blinding factor generation failed")?;
+        .context("blinding factor generation failed")?;
     let sub = authenticator.compute_credential_sub(&bf);
     let credential = issue_credential(sub)
         .await
-        .wrap_err("Failed to issue credential")?;
+        .context("Failed to issue credential")?;
     let credential_id = store
         .store_credential(&credential, &bf, credential.expires_at(), None, now_secs())
-        .wrap_err("store credential failed")?;
+        .context("store credential failed")?;
 
     Ok(IssuedCredential {
         credential_id,

--- a/crates/walletkit-testkit/src/lib.rs
+++ b/crates/walletkit-testkit/src/lib.rs
@@ -52,10 +52,10 @@ pub async fn init_and_register_account(
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
     register_account(env, seed, recovery_address, root)
         .await
-        .wrap_err("account registration failed")?;
+        .context("account registration failed")?;
     let (authenticator, store) = init_authenticator(env, seed, root, now)
         .await
-        .wrap_err("authenticator initialization failed")?;
+        .context("authenticator initialization failed")?;
 
     Ok((authenticator, store))
 }
@@ -179,11 +179,11 @@ pub async fn generate_and_verify_test_proof(
     let (authenticator, store) =
         init_and_register_account(env, seed, root, Some(Address::ZERO))
             .await
-            .wrap_err("account setup failed")?;
+            .context("account setup failed")?;
 
     let credential_id = issue_credential(env, credential_type, &authenticator, &store)
         .await
-        .wrap_err("credential issuance failed")?
+        .context("credential issuance failed")?
         .credential_id;
 
     let core_request = build_test_request(
@@ -194,19 +194,19 @@ pub async fn generate_and_verify_test_proof(
         proof_type,
         session_id,
     )
-    .wrap_err("failed to build proof request")?;
+    .context("failed to build proof request")?;
 
     let walletkit_request: walletkit_core::requests::ProofRequest =
         core_request.clone().into();
     let proof_response = authenticator
         .generate_proof(&walletkit_request, Some(now_secs()))
         .await
-        .wrap_err("proof generation failed")?;
+        .context("proof generation failed")?;
     let response = proof_response.into_inner();
 
     let mut results = verify_proof_onchain(env, &core_request, &response)
         .await
-        .wrap_err("on-chain verification failed")?;
+        .context("on-chain verification failed")?;
     eyre::ensure!(
         results.len() == 1,
         "expected exactly one verification result, got {}",

--- a/crates/walletkit-testkit/src/proof.rs
+++ b/crates/walletkit-testkit/src/proof.rs
@@ -4,7 +4,7 @@ use alloy::providers::ProviderBuilder;
 use alloy::signers::{local::PrivateKeySigner, SignerSync};
 use alloy::sol;
 use alloy_core::primitives::U160;
-use eyre::WrapErr as _;
+use eyre::Context;
 use rand::rngs::OsRng;
 use uuid::Uuid;
 use world_id_core::primitives::{rp::RpId, FieldElement, OprfKeyId, SessionId};
@@ -68,7 +68,7 @@ pub fn build_test_request(
     let expires_at = created_at + expires_in;
 
     let signer = PrivateKeySigner::from_bytes(&env.rp_signing_key.into())
-        .wrap_err("failed to create RP signer")?;
+        .context("failed to create RP signer")?;
 
     let action =
         (proof_type == ProofType::Uniqueness).then(|| FieldElement::from(1u64));
@@ -78,7 +78,7 @@ pub fn build_test_request(
         expires_at,
         action.map(|action| *action),
     );
-    let signature = signer.sign_message_sync(&msg).wrap_err("signing failed")?;
+    let signature = signer.sign_message_sync(&msg).context("signing failed")?;
 
     let item_id = Uuid::new_v4().to_string();
 
@@ -109,7 +109,7 @@ pub fn build_test_request(
     };
     request
         .validate_proof_type()
-        .wrap_err("inconsistent proof_type / session_id combination")?;
+        .context("inconsistent proof_type / session_id combination")?;
     Ok(request)
 }
 
@@ -144,7 +144,7 @@ pub async fn verify_proof_onchain(
     }
     proof_request
         .validate_response(proof_response)
-        .wrap_err("proof response does not match proof request")?;
+        .context("proof response does not match proof request")?;
 
     let provider = ProviderBuilder::new().connect_http(env.rpc_url.parse()?);
     let verifier_contract = IWorldIDVerifier::new(env.world_id_verifier, &provider);

--- a/xtask/src/kotlin/build.rs
+++ b/xtask/src/kotlin/build.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use eyre::{bail, Result, WrapErr as _};
+use eyre::{bail, Context, Result};
 use xshell::{cmd, Shell};
 
 const DEFAULT_CARGO_FEATURES: &str = "compress-zkeys,embed-zkeys,v3";
@@ -84,7 +84,7 @@ fn build_native_libraries(sh: &Shell) -> Result<()> {
             "cargo build -p walletkit --release --locked --target {rust_target} --features {features}"
         )
         .run()
-        .wrap_err_with(|| format!("failed to build WalletKit for {rust_target}"))?;
+        .with_context(|| format!("failed to build WalletKit for {rust_target}"))?;
     }
 
     Ok(())
@@ -106,7 +106,7 @@ fn copy_native_libraries(sh: &Shell, artifacts_dir: Option<&Path>) -> Result<()>
         let destination = destination_dir.join("libwalletkit.so");
 
         sh.create_dir(&destination_dir)?;
-        sh.copy_file(&source, &destination).wrap_err_with(|| {
+        sh.copy_file(&source, &destination).with_context(|| {
             format!(
                 "failed to copy {} to {}",
                 source.display(),
@@ -147,7 +147,7 @@ fn generate_bindings(sh: &Shell) -> Result<()> {
         "cargo run -p uniffi-bindgen --locked -- generate {library} --library --language kotlin --no-format --out-dir {KOTLIN_SOURCE_DIR}"
     )
     .run()
-    .wrap_err("failed to generate Kotlin bindings")
+    .context("failed to generate Kotlin bindings")
 }
 
 #[cfg(test)]

--- a/xtask/src/kotlin/local.rs
+++ b/xtask/src/kotlin/local.rs
@@ -1,6 +1,6 @@
 //! Maven Local publishing.
 
-use eyre::{bail, Result, WrapErr as _};
+use eyre::{bail, Context, Result};
 use xshell::{cmd, Shell};
 
 use super::build;
@@ -21,7 +21,7 @@ pub(super) fn run(sh: &Shell, version: &str) -> Result<()> {
         "./gradlew :walletkit:publishToMavenLocal {version_property}"
     )
     .run()
-    .wrap_err("failed to publish WalletKit to Maven Local")?;
+    .context("failed to publish WalletKit to Maven Local")?;
 
     println!("Published org.world:walletkit:{version} to Maven Local.");
     Ok(())

--- a/xtask/src/kotlin/test.rs
+++ b/xtask/src/kotlin/test.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use eyre::{bail, Result, WrapErr as _};
+use eyre::{bail, Context, Result};
 use xshell::{cmd, Shell};
 
 const CARGO_FEATURES: &str = "compress-zkeys,embed-zkeys,v3";
@@ -33,11 +33,11 @@ fn build_host_bindings(sh: &Shell) -> Result<()> {
         "cargo build -p walletkit --release --locked --features {CARGO_FEATURES}"
     )
     .run()
-    .wrap_err("failed to build the host WalletKit library")?;
+    .context("failed to build the host WalletKit library")?;
 
     let library = host_library()?;
     sh.copy_file(&library, HOST_LIBRARIES_DIR)
-        .wrap_err_with(|| format!("failed to copy {}", library.display()))?;
+        .with_context(|| format!("failed to copy {}", library.display()))?;
 
     println!("Generating Kotlin test bindings...");
     cmd!(
@@ -45,7 +45,7 @@ fn build_host_bindings(sh: &Shell) -> Result<()> {
         "cargo run -p uniffi-bindgen --locked -- generate {library} --language kotlin --library --crate walletkit_core --out-dir {JAVA_SOURCE_DIR}"
     )
     .run()
-    .wrap_err("failed to generate Kotlin test bindings")
+    .context("failed to generate Kotlin test bindings")
 }
 
 fn host_library() -> Result<PathBuf> {
@@ -72,7 +72,7 @@ fn run_gradle_tests(sh: &Shell) -> Result<()> {
         "./gradlew --no-daemon walletkit-tests:test --info --continue"
     )
     .run()
-    .wrap_err("Kotlin/JVM tests failed")
+    .context("Kotlin/JVM tests failed")
 }
 
 fn ensure_java_home(sh: &Shell) {

--- a/xtask/src/swift/archive.rs
+++ b/xtask/src/swift/archive.rs
@@ -1,6 +1,6 @@
 //! Release Swift package manifest generation.
 
-use eyre::{ensure, Result, WrapErr as _};
+use eyre::{ensure, Context, Result};
 use xshell::{cmd, Shell};
 
 use super::package;
@@ -24,15 +24,15 @@ pub(super) fn run(
     println!("Creating release Package.swift for WalletKit {release_version}...");
     let template = sh
         .read_file(PACKAGE_TEMPLATE)
-        .wrap_err_with(|| format!("failed to read {PACKAGE_TEMPLATE}"))?;
+        .with_context(|| format!("failed to read {PACKAGE_TEMPLATE}"))?;
     let manifest =
         package::release_manifest(&template, asset_url, checksum, release_version)?;
     sh.write_file(RELEASE_MANIFEST, manifest)
-        .wrap_err_with(|| format!("failed to write {RELEASE_MANIFEST}"))?;
+        .with_context(|| format!("failed to write {RELEASE_MANIFEST}"))?;
 
     cmd!(sh, "swiftlint lint --autocorrect {RELEASE_MANIFEST}")
         .run()
-        .wrap_err("failed to lint the release Package.swift")?;
+        .context("failed to lint the release Package.swift")?;
 
     println!("Package.swift built successfully for version {release_version}.");
     Ok(())

--- a/xtask/src/swift/build.rs
+++ b/xtask/src/swift/build.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use eyre::{bail, Result, WrapErr as _};
+use eyre::{bail, Context, Result};
 use xshell::{cmd, Shell};
 
 const DEFAULT_CARGO_FEATURES: &str = "compress-zkeys,embed-zkeys,v3";
@@ -142,7 +142,7 @@ fn build_native_libraries(sh: &Shell) -> Result<()> {
             "cargo build --package {PACKAGE_NAME} --target {target} --release --locked --target-dir {TARGET_DIR} --features {features}"
         )
         .run()
-        .wrap_err_with(|| format!("failed to build WalletKit for {target}"))?;
+        .with_context(|| format!("failed to build WalletKit for {target}"))?;
     }
 
     Ok(())
@@ -169,10 +169,10 @@ fn create_universal_simulator_library(sh: &Shell) -> Result<()> {
         "lipo -create {arm_library} {intel_library} -output {output}"
     )
     .run()
-    .wrap_err("failed to create universal iOS simulator library")?;
+    .context("failed to create universal iOS simulator library")?;
     cmd!(sh, "lipo -info {output}")
         .run()
-        .wrap_err("failed to inspect universal iOS simulator library")
+        .context("failed to inspect universal iOS simulator library")
 }
 
 fn generate_bindings(sh: &Shell, sources_dir: &Path) -> Result<()> {
@@ -186,12 +186,12 @@ fn generate_bindings(sh: &Shell, sources_dir: &Path) -> Result<()> {
         "cargo run -p uniffi-bindgen --locked --target-dir {TARGET_DIR} -- generate {library} --library --crate walletkit_core --language swift --no-format --out-dir {bindings_dir}"
     )
     .run()
-    .wrap_err("failed to generate Swift bindings")?;
+    .context("failed to generate Swift bindings")?;
 
     let generated_source = bindings_dir.join("walletkit_core.swift");
     let destination = sources_dir.join("walletkit.swift");
     sh.copy_file(&generated_source, &destination)
-        .wrap_err_with(|| {
+        .with_context(|| {
             format!(
                 "failed to move {} to {}",
                 generated_source.display(),
@@ -214,7 +214,7 @@ fn copy_directory_contents(
 ) -> Result<()> {
     for source_path in sh
         .read_dir(source)
-        .wrap_err_with(|| format!("failed to read {}", source.display()))?
+        .with_context(|| format!("failed to read {}", source.display()))?
     {
         let file_name = source_path
             .file_name()
@@ -226,7 +226,7 @@ fn copy_directory_contents(
             copy_directory_contents(sh, &source_path, &destination_path)?;
         } else {
             sh.copy_file(&source_path, &destination_path)
-                .wrap_err_with(|| {
+                .with_context(|| {
                     format!(
                         "failed to copy {} to {}",
                         source_path.display(),
@@ -281,7 +281,7 @@ fn create_xcframework(sh: &Shell, framework_output: &Path) -> Result<()> {
         "xcodebuild -create-xcframework -framework {device_framework} -framework {simulator_framework} -output {framework_output}"
     )
     .run()
-    .wrap_err("failed to create WalletKit XCFramework")
+    .context("failed to create WalletKit XCFramework")
 }
 
 fn make_framework(
@@ -300,7 +300,7 @@ fn make_framework(
 
     let modulemap_contents = sh
         .read_file(modulemap)
-        .wrap_err_with(|| format!("failed to read {}", modulemap.display()))?;
+        .with_context(|| format!("failed to read {}", modulemap.display()))?;
     let framework_modulemap = modulemap_contents
         .lines()
         .map(|line| {

--- a/xtask/src/swift/local.rs
+++ b/xtask/src/swift/local.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use eyre::{Result, WrapErr as _};
+use eyre::{Context, Result};
 use xshell::Shell;
 
 use super::{build, package};
@@ -21,11 +21,11 @@ pub(super) fn run(sh: &Shell) -> Result<()> {
     println!("Creating Package.swift for local development...");
     let template = sh
         .read_file(PACKAGE_TEMPLATE)
-        .wrap_err_with(|| format!("failed to read {PACKAGE_TEMPLATE}"))?;
+        .with_context(|| format!("failed to read {PACKAGE_TEMPLATE}"))?;
     let manifest = package::local_manifest(&template, FRAMEWORK_NAME)?;
     let manifest_path = Path::new(LOCAL_BUILD_DIR).join("Package.swift");
     sh.write_file(&manifest_path, manifest)
-        .wrap_err_with(|| format!("failed to write {}", manifest_path.display()))?;
+        .with_context(|| format!("failed to write {}", manifest_path.display()))?;
 
     println!("Swift package built successfully.");
     println!("Package location: {LOCAL_BUILD_DIR}");

--- a/xtask/src/swift/test.rs
+++ b/xtask/src/swift/test.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use eyre::{bail, Result, WrapErr as _};
+use eyre::{bail, Context, Result};
 use xshell::{cmd, Shell};
 
 use super::build;
@@ -40,7 +40,7 @@ fn ensure_macos() -> Result<()> {
 fn ensure_simulator_sdk(sh: &Shell) -> Result<()> {
     let sdks = cmd!(sh, "xcodebuild -showsdks")
         .read()
-        .wrap_err("failed to list installed Xcode SDKs")?;
+        .context("failed to list installed Xcode SDKs")?;
     if !sdks.contains("iphonesimulator") {
         bail!("no iOS Simulator SDK is installed; available SDKs:\n{sdks}");
     }
@@ -79,7 +79,7 @@ fn copy_directory_contents(
 ) -> Result<()> {
     for source_path in sh
         .read_dir(source)
-        .wrap_err_with(|| format!("failed to read {}", source.display()))?
+        .with_context(|| format!("failed to read {}", source.display()))?
     {
         let file_name = source_path
             .file_name()
@@ -91,7 +91,7 @@ fn copy_directory_contents(
             copy_directory_contents(sh, &source_path, &destination_path)?;
         } else {
             sh.copy_file(&source_path, &destination_path)
-                .wrap_err_with(|| {
+                .with_context(|| {
                     format!(
                         "failed to copy {} to {}",
                         source_path.display(),
@@ -115,7 +115,7 @@ fn remove_derived_data(sh: &Shell) -> Result<()> {
 
     for path in sh
         .read_dir(&derived_data)
-        .wrap_err_with(|| format!("failed to read {}", derived_data.display()))?
+        .with_context(|| format!("failed to read {}", derived_data.display()))?
     {
         if path.file_name().is_some_and(|name| {
             name.to_string_lossy()
@@ -130,7 +130,7 @@ fn remove_derived_data(sh: &Shell) -> Result<()> {
 fn find_simulator(sh: &Shell) -> Result<String> {
     let devices = cmd!(sh, "xcrun simctl list devices available")
         .read()
-        .wrap_err("failed to list available iOS simulators")?;
+        .context("failed to list available iOS simulators")?;
 
     simulator_id(&devices, "iPhone 16")
         .or_else(|| simulator_id(&devices, "iPhone"))
@@ -172,13 +172,13 @@ fn prepare_simulator(sh: &Shell, simulator_id: &str) -> Result<()> {
         .run();
     cmd!(sh, "xcrun simctl erase {simulator_id}")
         .run()
-        .wrap_err("failed to erase iOS simulator")?;
+        .context("failed to erase iOS simulator")?;
     cmd!(sh, "xcrun simctl boot {simulator_id}")
         .run()
-        .wrap_err("failed to boot iOS simulator")?;
+        .context("failed to boot iOS simulator")?;
     cmd!(sh, "xcrun simctl bootstatus {simulator_id} -b")
         .run()
-        .wrap_err("iOS simulator failed to finish booting")
+        .context("iOS simulator failed to finish booting")
 }
 
 fn is_ci(sh: &Shell) -> bool {
@@ -197,7 +197,7 @@ fn run_tests(sh: &Shell, simulator_id: &str) -> Result<()> {
         "xcodebuild test -scheme WalletKitForeignTestPackage -destination {destination} -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO"
     )
     .run()
-    .wrap_err("Swift foreign-binding tests failed")
+    .context("Swift foreign-binding tests failed")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API rename with no logic or behavior changes; risk is limited to compile-time correctness, which rustc enforces.
> 
> **Overview**
> Standardizes **eyre** error context APIs repo-wide: imports change from `eyre::WrapErr as _` to `eyre::Context`, and call sites use `.context(...)` / `.with_context(|| ...)` instead of `.wrap_err(...)` / `.wrap_err_with(...)`.
> 
> Touched areas include **walletkit-cli** command modules (auth, credential, proof, wallet, recovery-agent, shared `mod.rs`), **walletkit-testkit** helpers and **proof_generation_integration** tests, and **xtask** Android/iOS build, test, local publish, and Swift archive flows. Error messages and control flow are unchanged; this is naming/API alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598ff0f17ceb73f7f30f57d72203eda29ee1743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->