### PR TITLE
Split recovery binding 404 into distinct eligibility errors

### DIFF
--- a/crates/walletkit-core/src/error.rs
+++ b/crates/walletkit-core/src/error.rs
@@ -176,6 +176,15 @@ pub enum WalletKitError {
     #[error("debug_report_not_found")]
     DebugReportNotFound,
 
+    /// The `PoP` backend has no identity for the credential's `sub`, so the recovery binding
+    /// was attempted before the credential refresh that associates the `sub` with a signup.
+    #[error("identity_not_found")]
+    IdentityNotFound,
+
+    /// The identity exists but has no successful capture to check recovery eligibility against.
+    #[error("no_successful_capture_found")]
+    NoSuccessfulCaptureFound,
+
     /// The user is not eligible for recovery
     #[error("not_eligible_for_recovery")]
     NotEligibleForRecovery,

--- a/crates/walletkit-core/src/error.rs
+++ b/crates/walletkit-core/src/error.rs
@@ -176,12 +176,11 @@ pub enum WalletKitError {
     #[error("debug_report_not_found")]
     DebugReportNotFound,
 
-    /// The `PoP` backend has no identity for the credential's `sub`, so the recovery binding
-    /// was attempted before the credential refresh that associates the `sub` with a signup.
+    /// The backend has no identity for the credential's `sub`
     #[error("identity_not_found")]
     IdentityNotFound,
 
-    /// The identity exists but has no successful capture to check recovery eligibility against.
+    /// The identity has no successful capture to check recovery eligibility against
     #[error("no_successful_capture_found")]
     NoSuccessfulCaptureFound,
 

--- a/crates/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/crates/walletkit-core/src/issuers/pop_backend_client.rs
@@ -27,6 +27,12 @@ struct ChallengeResponse {
     challenge: String,
 }
 
+/// Error body returned by the recovery binding endpoints, carrying the sentinel error name.
+#[derive(Deserialize)]
+struct RecoveryBindingErrorResponse {
+    error: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, uniffi::Record)]
 pub struct RecoveryBindingResponse {
     #[serde(rename = "recoveryAgent")]
@@ -64,7 +70,9 @@ impl PopBackendClient {
     ///
     /// # Errors
     ///
-    /// * [`WalletKitError::DebugReportNotFound`] — HTTP 404 Not Found.
+    /// * [`WalletKitError::IdentityNotFound`], [`WalletKitError::NoSuccessfulCaptureFound`],
+    ///   [`WalletKitError::DebugReportNotFound`]: HTTP 404 Not Found, split by the body's
+    ///   `error` field (see [`eligibility_error`]).
     /// * [`WalletKitError::NotEligibleForRecovery`] — HTTP 412 Precondition Failed.
     /// * [`WalletKitError::NetworkError`] — any other non-success status; the response body is in
     ///   `error` and the HTTP status in `status`. This includes conflicts (e.g. HTTP 409) and
@@ -88,7 +96,7 @@ impl PopBackendClient {
         let response_status = response.status();
         match response_status {
             reqwest::StatusCode::CREATED | reqwest::StatusCode::OK => Ok(()),
-            reqwest::StatusCode::NOT_FOUND => Err(WalletKitError::DebugReportNotFound),
+            reqwest::StatusCode::NOT_FOUND => Err(eligibility_error(response).await),
             reqwest::StatusCode::PRECONDITION_FAILED => {
                 Err(WalletKitError::NotEligibleForRecovery)
             }
@@ -221,10 +229,31 @@ impl PopBackendClient {
     }
 }
 
+/// Maps a 404 from `POST /api/v1/recovery-binding` to the eligibility failure that caused it.
+///
+/// The backend returns 404 for three distinct causes (missing identity, no successful capture,
+/// missing debug report) and distinguishes them only by the `error` field of the body. Only the
+/// first is repairable by the caller (refreshing the credential associates the `sub` with a
+/// signup), so collapsing them leaves callers retrying the two that cannot be repaired.
+/// Unrecognized bodies keep the historical [`WalletKitError::DebugReportNotFound`] mapping.
+async fn eligibility_error(response: reqwest::Response) -> WalletKitError {
+    match response
+        .json::<RecoveryBindingErrorResponse>()
+        .await
+        .map(|body| body.error)
+        .as_deref()
+    {
+        Ok("IdentityNotFound") => WalletKitError::IdentityNotFound,
+        Ok("NoSuccessfulCaptureFound") => WalletKitError::NoSuccessfulCaptureFound,
+        _ => WalletKitError::DebugReportNotFound,
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
     use super::*;
+    use test_case::test_case;
 
     #[tokio::test]
     async fn test_register_recovery_agent_success() {
@@ -272,18 +301,28 @@ mod tests {
         drop(server);
     }
 
+    #[test_case("{\"error\":\"IdentityNotFound\"}", "identity_not_found")]
+    #[test_case(
+        "{\"error\":\"NoSuccessfulCaptureFound\"}",
+        "no_successful_capture_found"
+    )]
+    #[test_case("{\"error\":\"DebugReportNotFound\"}", "debug_report_not_found")]
+    #[test_case("{\"error\":\"SomethingNewFromTheBackend\"}", "debug_report_not_found")]
+    #[test_case("not json at all", "debug_report_not_found")]
     #[tokio::test]
-    async fn test_register_recovery_agent_no_debug_report() {
+    async fn test_register_recovery_agent_404_maps_to_eligibility_error(
+        response_body: &str,
+        expected_error: &str,
+    ) {
         let mut server = mockito::Server::new_async().await;
         let url = server.url();
 
-        let recovery_agent = "0x1234567890abcdef".to_string();
         let request = ManageRecoveryBindingRequest {
             sub: "test-sub-123".to_string(),
             leaf_index: 42,
             signature: "0x1234567890abcdef".to_string(),
             nonce: "0x1234567890abcdef1".to_string(),
-            recovery_agent: recovery_agent.clone(),
+            recovery_agent: "0x1234567890abcdef".to_string(),
         };
 
         let mock = server
@@ -298,7 +337,7 @@ mod tests {
             .match_header("X-Auth-Signature", "security_token")
             .match_header("X-Auth-Challenge", "challenge")
             .with_status(404)
-            .with_body("{\"error\":\"DebugReportNotFound\"}")
+            .with_body(response_body)
             .create_async()
             .await;
 
@@ -313,12 +352,8 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_err(), "Expected error but got success");
-        let err = result.unwrap_err();
-        assert!(
-            matches!(err, WalletKitError::DebugReportNotFound),
-            "Expected DebugReportNotFound error, got: {err:?}"
-        );
+        let err = result.expect_err("Expected error but got success");
+        assert_eq!(err.to_string(), expected_error);
         mock.assert_async().await;
         drop(server);
     }

--- a/crates/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/crates/walletkit-core/src/issuers/pop_backend_client.rs
@@ -229,14 +229,9 @@ impl PopBackendClient {
     }
 }
 
-/// Maps a 404 from `POST /api/v1/recovery-binding` to the eligibility failure that caused it.
+/// Maps a 404 from `POST /api/v1/recovery-binding` to the eligibility failure named in the body.
 ///
-/// The backend returns 404 for three distinct causes (missing identity, no successful capture,
-/// missing debug report) and distinguishes them only by the `error` field of the body, whose value
-/// is the sentinel name from signup-service `shared/recoveryeligibility/checker.go`. Only the
-/// first is repairable by the caller (refreshing the credential associates the `sub` with a
-/// signup), so collapsing them leaves callers retrying the two that cannot be repaired.
-/// Unrecognized bodies keep the historical [`WalletKitError::DebugReportNotFound`] mapping.
+/// An unrecognized body keeps the historical [`WalletKitError::DebugReportNotFound`] mapping.
 async fn eligibility_error(response: reqwest::Response) -> WalletKitError {
     match response
         .json::<RecoveryBindingErrorResponse>()

--- a/crates/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/crates/walletkit-core/src/issuers/pop_backend_client.rs
@@ -301,13 +301,13 @@ mod tests {
         drop(server);
     }
 
-    #[test_case("{\"error\":\"IdentityNotFound\"}", "identity_not_found")]
+    #[test_case(r#"{"error":"IdentityNotFound"}"#, "identity_not_found")]
     #[test_case(
-        "{\"error\":\"NoSuccessfulCaptureFound\"}",
+        r#"{"error":"NoSuccessfulCaptureFound"}"#,
         "no_successful_capture_found"
     )]
-    #[test_case("{\"error\":\"DebugReportNotFound\"}", "debug_report_not_found")]
-    #[test_case("{\"error\":\"SomethingNewFromTheBackend\"}", "debug_report_not_found")]
+    #[test_case(r#"{"error":"DebugReportNotFound"}"#, "debug_report_not_found")]
+    #[test_case(r#"{"error":"SomethingNewFromTheBackend"}"#, "debug_report_not_found")]
     #[test_case("not json at all", "debug_report_not_found")]
     #[tokio::test]
     async fn test_register_recovery_agent_404_maps_to_eligibility_error(

--- a/crates/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/crates/walletkit-core/src/issuers/pop_backend_client.rs
@@ -71,8 +71,8 @@ impl PopBackendClient {
     /// # Errors
     ///
     /// * [`WalletKitError::IdentityNotFound`], [`WalletKitError::NoSuccessfulCaptureFound`],
-    ///   [`WalletKitError::DebugReportNotFound`]: HTTP 404 Not Found, split by the body's
-    ///   `error` field (see [`eligibility_error`]).
+    ///   [`WalletKitError::DebugReportNotFound`]: HTTP 404 Not Found, split by the `error`
+    ///   field of the response body. An unrecognized body maps to `DebugReportNotFound`.
     /// * [`WalletKitError::NotEligibleForRecovery`] — HTTP 412 Precondition Failed.
     /// * [`WalletKitError::NetworkError`] — any other non-success status; the response body is in
     ///   `error` and the HTTP status in `status`. This includes conflicts (e.g. HTTP 409) and

--- a/crates/walletkit-core/src/issuers/pop_backend_client.rs
+++ b/crates/walletkit-core/src/issuers/pop_backend_client.rs
@@ -232,7 +232,8 @@ impl PopBackendClient {
 /// Maps a 404 from `POST /api/v1/recovery-binding` to the eligibility failure that caused it.
 ///
 /// The backend returns 404 for three distinct causes (missing identity, no successful capture,
-/// missing debug report) and distinguishes them only by the `error` field of the body. Only the
+/// missing debug report) and distinguishes them only by the `error` field of the body, whose value
+/// is the sentinel name from signup-service `shared/recoveryeligibility/checker.go`. Only the
 /// first is repairable by the caller (refreshing the credential associates the `sub` with a
 /// signup), so collapsing them leaves callers retrying the two that cannot be repaired.
 /// Unrecognized bodies keep the historical [`WalletKitError::DebugReportNotFound`] mapping.

--- a/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -103,12 +103,8 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the challenge fetch, signing, or backend request fails,
     /// or if the user is not eligible for recovery ([`WalletKitError::NotEligibleForRecovery`]).
-    /// or if the backend has no identity for `sub` ([`WalletKitError::IdentityNotFound`]), which
-    /// means the credential refresh that associates `sub` with a signup has not completed, so a
-    /// retry only succeeds after it does.
-    /// or if the identity has no successful capture ([`WalletKitError::NoSuccessfulCaptureFound`])
-    /// or no debug report ([`WalletKitError::DebugReportNotFound`]); neither is repairable by
-    /// retrying the bind.
+    /// or if the user fails the eligibility check ([`WalletKitError::IdentityNotFound`],
+    /// [`WalletKitError::NoSuccessfulCaptureFound`], [`WalletKitError::DebugReportNotFound`]).
     /// or if any other unexpected error occurs ([`WalletKitError::NetworkError`]).
     pub async fn bind_recovery_agent(
         &self,

--- a/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -103,7 +103,12 @@ impl RecoveryBindingManager {
     ///
     /// Returns an error if the challenge fetch, signing, or backend request fails,
     /// or if the user is not eligible for recovery ([`WalletKitError::NotEligibleForRecovery`]).
-    /// or if the debug report is not found ([`WalletKitError::DebugReportNotFound`]).
+    /// or if the backend has no identity for `sub` ([`WalletKitError::IdentityNotFound`]), which
+    /// means the credential refresh that associates `sub` with a signup has not completed, so a
+    /// retry only succeeds after it does.
+    /// or if the identity has no successful capture ([`WalletKitError::NoSuccessfulCaptureFound`])
+    /// or no debug report ([`WalletKitError::DebugReportNotFound`]); neither is repairable by
+    /// retrying the bind.
     /// or if any other unexpected error occurs ([`WalletKitError::NetworkError`]).
     pub async fn bind_recovery_agent(
         &self,


### PR DESCRIPTION
Motivation: `POST /api/v1/recovery-binding` returns 404 for three different eligibility failures and distinguishes them only in the response body, which WalletKit discarded. Clients could not tell the one repairable case (the credential refresh associating `sub` with a signup has not completed) from the two that retrying can never fix, so a stuck cohort on Android has been re-attempting the bind on every app open, each attempt also pulling a fresh challenge.

The 404 body is now parsed into `IdentityNotFound`, `NoSuccessfulCaptureFound` and the existing `DebugReportNotFound`. Unrecognized bodies keep the previous `DebugReportNotFound` mapping, so behaviour only changes where the backend told us something more specific.

Note for FFI consumers: two new `WalletKitError` variants means exhaustive `when` / `switch` over the enum needs the new arms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds UniFFI-visible error variants and changes how bind failures are classified, which affects client retry and error UX but not auth or payment paths.
> 
> **Overview**
> **Recovery agent bind** no longer treats every `POST /api/v1/recovery-binding` **404** as `DebugReportNotFound`. The client now reads the JSON `error` field and surfaces **`IdentityNotFound`** and **`NoSuccessfulCaptureFound`** as new **`WalletKitError`** variants; unknown or unparseable bodies still map to **`DebugReportNotFound`**.
> 
> `RecoveryBindingManager` / **`PopBackendClient`** docs and unit tests were updated to cover the new mapping. **FFI consumers** must handle the two new enum cases in exhaustive `when` / `switch` over **`WalletKitError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34e80ee5b892ffe579086b69c2e4aec6f202b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->