### PR TITLE
Expose caching ZK artifacts as an artifact source

### DIFF
--- a/crates/walletkit-core/src/authenticator/artifacts/caching.rs
+++ b/crates/walletkit-core/src/authenticator/artifacts/caching.rs
@@ -16,6 +16,8 @@ use world_id_proof::{
 
 use crate::{error::WalletKitError, storage::StoragePaths};
 
+use super::WalletKitZkArtifactSource;
+
 /// A crate specific source for ZK Artifacts
 ///
 /// Loads ZK Artifacts from embedded data & caches the resulting artifacts (for the Query &
@@ -33,6 +35,17 @@ impl CachingZkArtifacts {
     pub fn new(storage_paths: Arc<StoragePaths>) -> Self {
         let inner = CachingZkArtifactsInner::new(storage_paths).cached();
         Self(inner)
+    }
+
+    /// Returns this caching implementation as a WalletKit ZK artifact source.
+    ///
+    /// This explicit conversion is required by foreign-language bindings, which do not preserve
+    /// Rust blanket trait implementations as class inheritance.
+    #[must_use]
+    pub fn as_zk_artifact_source(
+        self: Arc<Self>,
+    ) -> Arc<dyn WalletKitZkArtifactSource> {
+        self
     }
 
     /// Preloads the nullifier & query materials and caches them to the filesystem.

--- a/crates/walletkit-core/src/authenticator/artifacts/caching.rs
+++ b/crates/walletkit-core/src/authenticator/artifacts/caching.rs
@@ -37,7 +37,7 @@ impl CachingZkArtifacts {
         Self(inner)
     }
 
-    /// Returns this caching implementation as a WalletKit ZK artifact source.
+    /// Returns this caching implementation as a `WalletKit` ZK artifact source.
     ///
     /// This explicit conversion is required by foreign-language bindings, which do not preserve
     /// Rust blanket trait implementations as class inheritance.

--- a/crates/walletkit-core/src/authenticator/artifacts/embedded.rs
+++ b/crates/walletkit-core/src/authenticator/artifacts/embedded.rs
@@ -10,6 +10,8 @@ use world_id_proof::{
     CircomGroth16Material,
 };
 
+use super::WalletKitZkArtifactSource;
+
 /// A wrapper around `world_id_proof::artifacts::EmbeddedZkArtifacts`
 ///
 /// that can be constructed by crate consumers
@@ -29,6 +31,17 @@ impl EmbeddedZkArtifacts {
     #[must_use]
     pub fn new() -> Self {
         Self(CachedZkArtifactSource::new(CoreEmbeddedZkArtifacts))
+    }
+
+    /// Returns this caching implementation as a `WalletKit` ZK artifact source.
+    ///
+    /// This explicit conversion is required by foreign-language bindings, which do not preserve
+    /// Rust blanket trait implementations as class inheritance.
+    #[must_use]
+    pub fn as_zk_artifact_source(
+        self: Arc<Self>,
+    ) -> Arc<dyn WalletKitZkArtifactSource> {
+        self
     }
 }
 


### PR DESCRIPTION
## What changed

- add `CachingZkArtifacts.as_zk_artifact_source`
- return the exported `WalletKitZkArtifactSource` trait object required by UniFFI consumers

## Why

Rust blanket trait implementations are not represented as Swift or Kotlin class inheritance. The generated mobile bindings therefore could construct and preload `CachingZkArtifacts`, but could not pass it to authenticator initializers accepting `WalletKitZkArtifactSource`.

## Impact

Swift and Kotlin consumers can now call `asZkArtifactSource()` after preloading and pass the result to authenticator initialization.

## Validation

- `cargo +nightly fmt --all -- --check`
- `nix develop --command cargo check -p walletkit-core --all-features`
- regenerated Swift and Kotlin UniFFI bindings and verified `asZkArtifactSource()` returns `WalletKitZkArtifactSource`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small FFI surface addition with no change to ZK loading, caching, or authenticator logic beyond how types are passed across bindings.
> 
> **Overview**
> Adds **`as_zk_artifact_source()`** on **`CachingZkArtifacts`** and **`EmbeddedZkArtifacts`**, returning **`Arc<dyn WalletKitZkArtifactSource>`** so Swift and Kotlin can pass preloaded/cached sources into authenticator setup.
> 
> UniFFI does not surface Rust blanket **`WalletKitZkArtifactSource`** impls as subclassing, so mobile code could build and preload these types but could not satisfy APIs that take the trait object until this explicit conversion exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a5f0973acff6708292d5b12c4bbb4b9d3a42ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->