### PR TITLE
feat(POP-4224): freeze the WIP-103 ownership circuit digest

### DIFF
--- a/crates/walletkit-core/src/authenticator/artifacts/mod.rs
+++ b/crates/walletkit-core/src/authenticator/artifacts/mod.rs
@@ -2,6 +2,14 @@
 
 use world_id_core::artifacts::ZkArtifactSource;
 
+/// Frozen R1CS hash of the WIP-103 ownership circuit, hex-encoded.
+///
+/// Changing this is a protocol change — proofs come from shipped binaries that
+/// cannot be recalled, so the verifier must accept the new hash before any
+/// client producing it ships.
+pub const OWNERSHIP_CIRCUIT_R1CS_HASH: &str =
+    "f2982dc89f49f4830ffa7fb535734afe7997db017cf8ef6f28cd3ef7ce6a0312";
+
 /// A blanket implementation interface that allows the ZK Artifact source implementations to be
 /// used by methods exposed to walletkit consumers.
 #[uniffi::export]
@@ -14,3 +22,55 @@ pub mod caching;
 /// Sources backed by ZK artifacts embedded in the binary.
 #[cfg(feature = "embed-zkeys")]
 pub mod embedded;
+
+#[cfg(all(test, feature = "embed-zkeys", not(target_arch = "wasm32")))]
+mod tests {
+    use super::{
+        embedded::EmbeddedZkArtifacts, ZkArtifactSource, OWNERSHIP_CIRCUIT_R1CS_HASH,
+    };
+
+    const PROTOCOL_CHANGE_HINT: &str = "\
+The WIP-103 ownership circuit changed. Every proof from every shipped client \
+will be rejected by a verifier still on the old circuit, and shipped clients \
+cannot be rolled back. Do not update the constant to make this pass: confirm \
+the Ownership Proof Verifier Service accepts the new hash first, then update \
+OWNERSHIP_CIRCUIT_R1CS_HASH in the same change.";
+
+    #[test]
+    fn ownership_verifier_matches_frozen_circuit_hash() {
+        let verifier = EmbeddedZkArtifacts::new()
+            .ownership_verifier()
+            .expect("embedded ownership verifier should load");
+        let scheme = verifier
+            .whir_for_witness
+            .as_ref()
+            .expect("verifier should carry a WHIR scheme");
+
+        assert_eq!(
+            hex::encode(scheme.r1cs_hash),
+            OWNERSHIP_CIRCUIT_R1CS_HASH,
+            "{PROTOCOL_CHANGE_HINT}"
+        );
+    }
+
+    #[test]
+    fn ownership_prover_and_verifier_share_a_circuit() {
+        let artifacts = EmbeddedZkArtifacts::new();
+        let prover = artifacts
+            .ownership_prover()
+            .expect("embedded ownership prover should load");
+        let verifier = artifacts
+            .ownership_verifier()
+            .expect("embedded ownership verifier should load");
+        let verifier_scheme = verifier
+            .whir_for_witness
+            .as_ref()
+            .expect("verifier should carry a WHIR scheme");
+
+        assert_eq!(
+            prover.whir_for_witness.r1cs_hash, verifier_scheme.r1cs_hash,
+            "embedded prover and verifier were built from different circuits; \
+             proofs generated locally would fail local verification"
+        );
+    }
+}


### PR DESCRIPTION
Closes POP-4224. First of a five-PR stack toward POP-4112 (World ID 4.0 ownership proofs).

## Why

WalletKit generates ownership proofs with `world-id-proof` 0.13.0; the Ownership Proof Verifier Service pins `=0.12.0`. A WHIR R1CS proof only verifies against a matching compiled circuit, so a silent circuit change rejects every proof from every shipped client — and shipped mobile binaries have no rollback path. Nothing guarded that.

## What

`OWNERSHIP_CIRCUIT_R1CS_HASH` in `walletkit-core`, asserted by two tests.

The frozen value is ProveKit's own canonical digest, `WhirR1CSScheme::r1cs_hash`, which seeds the proof transcript's domain separator — so it *is* the prover/verifier compatibility surface rather than a proxy for it. No new dependency; the field is reachable through `world_id_proof::OwnershipVerifier`.

Rejected alternative: hashing a re-serialization of the artifacts. `OwnershipProver` transitively contains `HashMap`s, so that digest would not reproduce across processes.

The constant is a hex `&str`, matching the existing upstream convention for `QUERY_ZKEY_FINGERPRINT` / `NULLIFIER_GRAPH_FINGERPRINT`, which walletkit already consumes in `caching.rs`.

## The 0.12.0 / 0.13.0 gap is verified safe

- Compiled circuit artifacts are **byte-identical** across the two releases — same `hash`, `abi`, `bytecode`, `noir_version`; only `file_map` (debug source paths) differs.
- `FieldElement`'s `Serialize` is character-identical, so the JSON wire encoding matches too.

## Scope

This is necessary, not sufficient: an unchanged hash does not rule out a library-level break in public-input packing or proof serialization. Verification coverage lands in POP-4228 (PR 5 of this stack).

## Verification

- `cargo test -p walletkit-core --all-features --lib` — 152 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Digest confirmed stable across separate test processes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a documented constant and CI guards only; no runtime behavior or auth/data paths change until the hash is intentionally updated with verifier coordination.
> 
> **Overview**
> **Freezes the WIP-103 ownership circuit digest** as `OWNERSHIP_CIRCUIT_R1CS_HASH` in `walletkit-core` artifacts, with docs that changing it is a protocol change (shipped clients cannot roll back).
> 
> Adds **two `embed-zkeys` tests** (non-wasm): one asserts the embedded ownership verifier’s WHIR `r1cs_hash` matches the constant (failure message tells engineers to coordinate with the Ownership Proof Verifier Service before updating the constant), and one asserts embedded prover and verifier share the same `r1cs_hash`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462329f4e3dae55d9a47dfb2092525133fd8c1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->