### PR TITLE
feat(POP-4225): guard nargo pin drift against Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           uniffi_version: ${{ vars.UNIFFI_VERSION }}
           rust_toolchain_channel: ${{ vars.RUST_TOOLCHAIN_CHANNEL }}
 
+      # Runs on the runner's preinstalled cargo, which honours rust-toolchain.toml.
+      # No nargo install: the check reads pinned versions, it does not compile Noir.
+      - name: Check nargo pins against Cargo.lock
+        run: cargo xtask nargo check-pins
+
   lint:
     name: Format, Clippy & Build
     runs-on: ubuntu-latest

--- a/xtask/src/kotlin/build.rs
+++ b/xtask/src/kotlin/build.rs
@@ -36,6 +36,7 @@ const ANDROID_TARGETS: [AndroidTarget; 4] = [
 pub(super) fn run(sh: &Shell, artifacts_dir: Option<&Path>) -> Result<()> {
     if artifacts_dir.is_none() {
         ensure_android_toolchain(sh)?;
+        crate::nargo::ensure_installed(sh)?;
         build_native_libraries(sh)?;
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 //! Repository automation for `WalletKit`.
 
 mod kotlin;
+mod nargo;
 mod swift;
 
 use std::path::Path;
@@ -24,6 +25,12 @@ enum Command {
         command: kotlin::Command,
     },
 
+    /// Noir toolchain pinning.
+    Nargo {
+        #[command(subcommand)]
+        command: nargo::Command,
+    },
+
     /// Swift/iOS automation.
     Swift {
         #[command(subcommand)]
@@ -38,6 +45,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Command::Kotlin { command } => kotlin::run(&sh, &command),
+        Command::Nargo { command } => nargo::run(&sh, &command),
         Command::Swift { command } => swift::run(&sh, &command),
     }
 }

--- a/xtask/src/nargo.rs
+++ b/xtask/src/nargo.rs
@@ -1,0 +1,471 @@
+//! Noir toolchain pinning.
+//!
+//! `Cargo.lock` is the authority: `world-id-proof`'s `build.rs` refuses to build
+//! unless the installed `nargo` matches the Noir release encoded in the
+//! `provekit_*` crate versions. Everything else that names a version — the
+//! `noirup` steps, `nix/nargo.nix`, the docs — is a mirror, and mirrors drift.
+
+use std::{ffi::OsStr, path::PathBuf};
+
+use clap::Subcommand;
+use eyre::{bail, Context as _, Result};
+use xshell::{cmd, Shell};
+
+/// `Cargo.lock` packages whose versions encode the Noir release as
+/// `<noir-version>-alpha.<n>`.
+const PROVEKIT_PREFIX: &str = "provekit_";
+
+const WORKFLOWS_DIR: &str = ".github/workflows";
+const NOIRUP_ACTION: &str = "noir-lang/noirup";
+const NIX_DERIVATION: &str = "nix/nargo.nix";
+const SWIFT_README: &str = "swift/README.md";
+
+/// How far past a `noirup` step to look for its `toolchain:` input.
+const TOOLCHAIN_LOOKAHEAD: usize = 6;
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Print the `nargo` version required by `Cargo.lock`.
+    Version,
+
+    /// Fail if any pinned `nargo` version disagrees with `Cargo.lock`.
+    CheckPins,
+}
+
+pub fn run(sh: &Shell, command: &Command) -> Result<()> {
+    match command {
+        Command::Version => {
+            println!("{}", required_version(sh)?);
+            Ok(())
+        }
+        Command::CheckPins => check_pins(sh),
+    }
+}
+
+/// A pinned version that disagrees with `Cargo.lock`.
+struct Drift {
+    location: String,
+    found: Option<String>,
+}
+
+/// Returns the `nargo` version `Cargo.lock` requires.
+pub fn required_version(sh: &Shell) -> Result<String> {
+    let lock = sh.read_file("Cargo.lock").context("reading Cargo.lock")?;
+    required_version_from_lock(&lock)
+}
+
+/// Fails unless a `nargo` matching `Cargo.lock` is on `PATH`.
+pub fn ensure_installed(sh: &Shell) -> Result<()> {
+    let required = required_version(sh)?;
+
+    let Ok(reported) = cmd!(sh, "nargo --version").quiet().ignore_stderr().read()
+    else {
+        bail!(
+            "nargo {required} is required to build the Noir ownership-proof circuit, but nargo \
+             was not found on PATH. Install it with `noirup --version v{required}`, or use the Nix \
+             default devshell."
+        );
+    };
+
+    if reported_version(&reported) != Some(required.as_str()) {
+        bail!(
+            "nargo {required} is required to produce circuit artifacts byte-identical to every \
+             other builder's. `nargo --version` reported:\n{reported}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Reads the version off the `nargo version = X` line, ignoring the `noirc`
+/// line. Exact rather than substring, so `1.0.0-beta.110` cannot satisfy a
+/// requirement of `1.0.0-beta.11`.
+fn reported_version(output: &str) -> Option<&str> {
+    output.lines().find_map(|line| {
+        Some(
+            line.trim()
+                .strip_prefix("nargo version")?
+                .trim_start()
+                .strip_prefix('=')?
+                .trim(),
+        )
+    })
+}
+
+fn check_pins(sh: &Shell) -> Result<()> {
+    let required = required_version(sh)?;
+    let mut drifts = Vec::new();
+
+    let nix = sh
+        .read_file(NIX_DERIVATION)
+        .with_context(|| format!("reading {NIX_DERIVATION}"))?;
+    drifts.extend(check_nix_derivation(&nix, &required));
+
+    let readme = sh
+        .read_file(SWIFT_README)
+        .with_context(|| format!("reading {SWIFT_README}"))?;
+    drifts.extend(check_prose(&readme, SWIFT_README, &required));
+
+    let mut noirup_steps = 0;
+    for path in workflow_paths(sh)? {
+        let display = path.display().to_string();
+        let workflow = sh
+            .read_file(&path)
+            .with_context(|| format!("reading {display}"))?;
+        noirup_steps += workflow.matches(NOIRUP_ACTION).count();
+        drifts.extend(check_workflow(&workflow, &display, &required));
+    }
+
+    // Without this, moving noirup into a composite action or a `run:` line would
+    // leave the parser finding nothing and the check passing on air.
+    if noirup_steps == 0 {
+        bail!(
+            "no `{NOIRUP_ACTION}` step found in {WORKFLOWS_DIR}, so no CI pin was checked. If the \
+             toolchain is now installed another way, teach this check how to find it."
+        );
+    }
+
+    if drifts.is_empty() {
+        println!("nargo pins agree with Cargo.lock: {required}");
+        return Ok(());
+    }
+
+    let report = drifts
+        .iter()
+        .map(|drift| {
+            format!(
+                "  {} — {}",
+                drift.location,
+                describe(drift.found.as_deref())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    bail!(
+        "Cargo.lock requires nargo {required}, but these pins disagree:\n{report}\n\n\
+         Update each to {required}. {NIX_DERIVATION} also carries a per-platform `hash` for the \
+         release tarball — those must be refreshed for the new version, not just the version \
+         string."
+    );
+}
+
+fn describe(found: Option<&str>) -> String {
+    found.map_or_else(|| "no version pinned".to_owned(), |v| format!("found {v}"))
+}
+
+/// Uses the shell's working directory, not the process's, so `cargo xtask` works
+/// from any subdirectory.
+fn workflow_paths(sh: &Shell) -> Result<Vec<PathBuf>> {
+    let mut paths = sh
+        .read_dir(WORKFLOWS_DIR)
+        .with_context(|| format!("reading {WORKFLOWS_DIR}"))?
+        .into_iter()
+        .filter(|path| {
+            path.extension().is_some_and(|ext| {
+                ext == OsStr::new("yml") || ext == OsStr::new("yaml")
+            })
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    Ok(paths)
+}
+
+fn required_version_from_lock(lock: &str) -> Result<String> {
+    let packages = provekit_packages(lock);
+
+    if packages.is_empty() {
+        bail!(
+            "no `{PROVEKIT_PREFIX}*` package found in Cargo.lock, so the required nargo version \
+             cannot be derived. If the Noir prover was removed, remove this check too."
+        );
+    }
+
+    let mut bases: Vec<&str> = packages.iter().map(|(_, base)| *base).collect();
+    bases.sort_unstable();
+    bases.dedup();
+
+    if let [base] = bases[..] {
+        return Ok(base.to_owned());
+    }
+
+    let listing = packages
+        .iter()
+        .map(|(name, base)| format!("  {name} → {base}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    bail!(
+        "`{PROVEKIT_PREFIX}*` packages in Cargo.lock disagree on the Noir version, so the required \
+         nargo version is ambiguous:\n{listing}"
+    );
+}
+
+/// Returns each `provekit_*` package paired with its Noir base version.
+fn provekit_packages(lock: &str) -> Vec<(&str, &str)> {
+    let mut packages = Vec::new();
+    let mut current: Option<&str> = None;
+
+    for line in lock.lines().map(str::trim) {
+        if let Some(name) = quoted_value(line, "name") {
+            current = name.starts_with(PROVEKIT_PREFIX).then_some(name);
+        } else if let Some(version) = quoted_value(line, "version") {
+            if let Some(name) = current.take() {
+                packages.push((name, base_version(version)));
+            }
+        }
+    }
+
+    packages
+}
+
+/// Strips the provekit fork's `-alpha.<n>` suffix, leaving the Noir version.
+fn base_version(version: &str) -> &str {
+    version
+        .split_once("-alpha.")
+        .map_or(version, |(base, _)| base)
+}
+
+fn quoted_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    line.strip_prefix(key)?
+        .trim_start()
+        .strip_prefix('=')?
+        .trim_start()
+        .strip_prefix('"')?
+        .split('"')
+        .next()
+}
+
+fn check_nix_derivation(content: &str, required: &str) -> Vec<Drift> {
+    let found = content
+        .lines()
+        .map(str::trim)
+        .find_map(|line| quoted_value(line, "version"));
+
+    match found {
+        Some(version) if version == required => Vec::new(),
+        found => vec![Drift {
+            location: format!("{NIX_DERIVATION} (version)"),
+            found: found.map(str::to_owned),
+        }],
+    }
+}
+
+/// Flags any `v<version>` in prose that looks like a `nargo` pin but is stale.
+fn check_prose(content: &str, path: &str, required: &str) -> Vec<Drift> {
+    content
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.contains("nargo"))
+        .filter_map(|(index, line)| {
+            let found = tagged_version(line)?;
+            (found != required).then(|| Drift {
+                location: format!("{path}:{}", index + 1),
+                found: Some(found.to_owned()),
+            })
+        })
+        .collect()
+}
+
+fn check_workflow(content: &str, path: &str, required: &str) -> Vec<Drift> {
+    let lines: Vec<&str> = content.lines().collect();
+
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.contains(NOIRUP_ACTION))
+        .filter_map(|(index, _)| {
+            let found = lines
+                .iter()
+                .skip(index + 1)
+                .take(TOOLCHAIN_LOOKAHEAD)
+                .find_map(|line| line.trim().strip_prefix("toolchain:"))
+                .map(str::trim)
+                .and_then(|value| value.strip_prefix('v'));
+
+            match found {
+                Some(version) if version == required => None,
+                found => Some(Drift {
+                    location: format!("{path}:{} (noirup)", index + 1),
+                    found: found.map(str::to_owned),
+                }),
+            }
+        })
+        .collect()
+}
+
+/// Extracts a `v1.2.3`-style version, ignoring the `v`.
+fn tagged_version(line: &str) -> Option<&str> {
+    line.split_whitespace().find_map(|word| {
+        let candidate =
+            word.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '.');
+        candidate
+            .strip_prefix('v')
+            .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOCK: &str = r#"
+[[package]]
+name = "provekit-common"
+version = "0.1.4"
+
+[[package]]
+name = "provekit_nargo"
+version = "1.0.0-beta.11-alpha.4"
+
+[[package]]
+name = "provekit_acir"
+version = "1.0.0-beta.11-alpha.2"
+
+[[package]]
+name = "serde"
+version = "1.0.230"
+"#;
+
+    #[test]
+    fn derives_version_from_provekit_packages() {
+        assert_eq!(required_version_from_lock(LOCK).unwrap(), "1.0.0-beta.11");
+    }
+
+    #[test]
+    fn ignores_hyphenated_provekit_crates() {
+        let packages = provekit_packages(LOCK);
+        assert!(packages
+            .iter()
+            .all(|(name, _)| name.starts_with("provekit_")));
+        assert_eq!(packages.len(), 2);
+    }
+
+    #[test]
+    fn rejects_disagreeing_provekit_versions() {
+        let skewed = LOCK.replace("1.0.0-beta.11-alpha.2", "1.0.0-beta.12-alpha.2");
+        let error = required_version_from_lock(&skewed).unwrap_err().to_string();
+        assert!(error.contains("disagree"), "{error}");
+        assert!(error.contains("provekit_acir"), "{error}");
+    }
+
+    #[test]
+    fn rejects_lock_without_provekit() {
+        let error = required_version_from_lock(
+            "[[package]]\nname = \"serde\"\nversion = \"1\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("cannot be derived"), "{error}");
+    }
+
+    #[test]
+    fn reads_version_off_the_nargo_line_not_the_noirc_line() {
+        let output =
+            "nargo version = 1.0.0-beta.11\nnoirc version = 1.0.0-beta.11+fd3925a\n";
+        assert_eq!(reported_version(output), Some("1.0.0-beta.11"));
+    }
+
+    #[test]
+    fn does_not_accept_a_longer_version_as_a_prefix_match() {
+        let output = "nargo version = 1.0.0-beta.110\n";
+        assert_ne!(reported_version(output), Some("1.0.0-beta.11"));
+    }
+
+    #[test]
+    fn reports_no_version_for_unrecognised_output() {
+        assert_eq!(reported_version("something else entirely\n"), None);
+    }
+
+    #[test]
+    fn accepts_matching_nix_derivation() {
+        let nix = "  pname = \"nargo\";\n  version = \"1.0.0-beta.11\";\n";
+        assert!(check_nix_derivation(nix, "1.0.0-beta.11").is_empty());
+    }
+
+    #[test]
+    fn flags_skewed_nix_derivation() {
+        let nix = "  version = \"1.0.0-beta.10\";\n";
+        let drifts = check_nix_derivation(nix, "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].found.as_deref(), Some("1.0.0-beta.10"));
+    }
+
+    #[test]
+    fn flags_nix_derivation_without_version() {
+        let drifts = check_nix_derivation("  pname = \"nargo\";\n", "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 1);
+        assert!(drifts[0].found.is_none());
+    }
+
+    #[test]
+    fn accepts_matching_workflow_pin() {
+        let workflow = "\
+      - uses: noir-lang/noirup@7dbe69c # v0.1.4
+        with:
+          # a specific nargo toolchain version is required
+          toolchain: v1.0.0-beta.11
+";
+        assert!(check_workflow(workflow, "ci.yml", "1.0.0-beta.11").is_empty());
+    }
+
+    #[test]
+    fn flags_skewed_workflow_pin() {
+        let workflow = "\
+      - uses: noir-lang/noirup@7dbe69c # v0.1.4
+        with:
+          toolchain: v1.0.0-beta.10
+";
+        let drifts = check_workflow(workflow, "ci.yml", "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].found.as_deref(), Some("1.0.0-beta.10"));
+        assert!(
+            drifts[0].location.contains("ci.yml:1"),
+            "{}",
+            drifts[0].location
+        );
+    }
+
+    #[test]
+    fn flags_workflow_pin_left_unset() {
+        let workflow = "      - uses: noir-lang/noirup@7dbe69c # v0.1.4\n";
+        let drifts = check_workflow(workflow, "ci.yml", "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 1);
+        assert!(drifts[0].found.is_none());
+    }
+
+    #[test]
+    fn flags_every_stale_workflow_pin_not_only_the_first() {
+        let step = "\
+      - uses: noir-lang/noirup@7dbe69c
+        with:
+          toolchain: v1.0.0-beta.10
+";
+        let drifts = check_workflow(&step.repeat(3), "ci.yml", "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 3);
+    }
+
+    #[test]
+    fn does_not_confuse_the_noirup_action_tag_with_the_toolchain() {
+        let workflow = "\
+      - uses: noir-lang/noirup@7dbe69c # v0.1.4
+        with:
+          toolchain: v1.0.0-beta.11
+";
+        assert!(check_workflow(workflow, "ci.yml", "1.0.0-beta.11").is_empty());
+    }
+
+    #[test]
+    fn flags_stale_prose_version() {
+        let readme =
+            "Xcode, the iOS Rust targets, and `nargo` v1.0.0-beta.10 installed.";
+        let drifts = check_prose(readme, "swift/README.md", "1.0.0-beta.11");
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].found.as_deref(), Some("1.0.0-beta.10"));
+    }
+
+    #[test]
+    fn ignores_prose_without_nargo() {
+        let readme = "Requires Xcode v16.0 and a recent toolchain.";
+        assert!(check_prose(readme, "swift/README.md", "1.0.0-beta.11").is_empty());
+    }
+}

--- a/xtask/src/swift/build.rs
+++ b/xtask/src/swift/build.rs
@@ -27,7 +27,7 @@ struct FrameworkSlice<'a> {
 pub(super) fn run(sh: &Shell, output_dir: Option<&Path>) -> Result<()> {
     ensure_macos()?;
     ensure_ios_sdks(sh)?;
-    ensure_nargo(sh)?;
+    crate::nargo::ensure_installed(sh)?;
 
     let output_dir = resolve_output_dir(output_dir);
     let sources_dir = output_dir.join("Sources/WalletKit");
@@ -82,21 +82,6 @@ fn ensure_ios_sdks(sh: &Shell) -> Result<()> {
                  sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
             );
         }
-    }
-    Ok(())
-}
-
-fn ensure_nargo(sh: &Shell) -> Result<()> {
-    if cmd!(sh, "nargo --version")
-        .quiet()
-        .ignore_stdout()
-        .ignore_stderr()
-        .run()
-        .is_err()
-    {
-        bail!(
-            "nargo v1.0.0-beta.11 is required; install it with noirup or use the Nix default devshell"
-        );
     }
     Ok(())
 }


### PR DESCRIPTION
Closes POP-4225. PR 2 of 5 toward POP-4112. **Base: #464** — review that first.

## Why

`Cargo.lock` fixes the required `nargo` version: the `provekit_*` crates are versioned `<noir-version>-alpha.N`, and `world-id-proof`'s `build.rs` refuses to build unless the installed compiler matches. That requirement was mirrored by hand in nine other places — six `noirup` steps across three workflows, `nix/nargo.nix`, and `swift/README.md` — with nothing checking they agree.

Two gaps were worse than the ticket described:

1. **The Swift build's `nargo` gate never checked the version.** It only checked that `nargo` runs, and named `1.0.0-beta.11` in the error string. A wrong-version toolchain passed it and failed later inside a dependency's `build.rs`.
2. **The Android path had no `nargo` check at all.**

## What

`cargo xtask nargo check-pins` derives the version from `Cargo.lock` and validates every mirror, reporting all mismatches at once:

```
Cargo.lock requires nargo 1.0.0-beta.11, but these pins disagree:
  nix/nargo.nix (version) — found 1.0.0-beta.10
  swift/README.md:9 — found 1.0.0-beta.8
  .github/workflows/ci.yml:51 (noirup) — found 1.0.0-beta.9
  .github/workflows/ci.yml:128 (noirup) — no version pinned

Update each to 1.0.0-beta.11. nix/nargo.nix also carries a per-platform `hash` for the
release tarball — those must be refreshed for the new version, not just the version string.
```

Runs in the existing `version-alignment` job. No `nargo` install needed — the check reads pins, it does not compile Noir.

## One authority, guarded mirrors

The ticket asked for the version to live in exactly one place. That is not achievable: `noirup` needs the value before Rust exists in the job, and Nix needs a literal at `fetchurl` eval time plus four per-platform `sha256` hashes that no version string can produce. Even perfect templating would still need a human edit for the hashes. So duplication stays and becomes **loud** instead. `Cargo.lock` is the authority — derived, not declared, so there is no second declaration that can itself drift.

The guard fails when zero `noirup` steps are found, so moving the toolchain into a composite action cannot leave it silently checking nothing. Workflow discovery globs the directory rather than listing known files, so a fourth workflow is covered automatically.

## Noir compile cost

Measured on the real WIP-103 circuit: **1.94s cold, 0.14s warm**. No artifact caching needed, and the large runner needs no extra resourcing. (Excludes the one-time fetch of the two git-hosted Noir dependencies, which recurs per fresh runner.)

## Verification

- `cargo test -p xtask` — 25 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Skewed four real pins at once; all four reported with locations, then restored
- `check-pins` verified from a subdirectory, not just the workspace root

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local build-tooling guardrails only; no runtime wallet or proof logic changes, though mis-pinned Noir toolchains would fail builds earlier with clearer errors.
> 
> **Overview**
> Introduces **`cargo xtask nargo`** so **`Cargo.lock`** (via `provekit_*` versions) is the single source of truth for the required **`nargo`** version. **`check-pins`** fails CI when mirrors drift—**`noirup`** toolchain pins in workflows, **`nix/nargo.nix`**, and **`nargo`** mentions in **`swift/README.md`**—and errors if no **`noirup`** steps are found so the check cannot pass vacuously.
> 
> The **version-alignment** job runs **`cargo xtask nargo check-pins`** without installing Noir (it only reads pins).
> 
> **Swift** and **Kotlin/Android** builds now share **`ensure_installed`**, which requires an on-**PATH** **`nargo`** whose version exactly matches **`Cargo.lock`**. That replaces Swift’s prior “is **`nargo`** present?” gate (wrong versions could slip through) and adds the same gate on Android, which previously had none.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022fb1571f0a16491c862cbf7fbc977870b4d57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->