### PR TITLE
feat(POP-4226): instrument ownership proof generation and add prove-ownership

### DIFF
--- a/crates/walletkit-cli/src/commands/proof.rs
+++ b/crates/walletkit-cli/src/commands/proof.rs
@@ -6,6 +6,7 @@ use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine as _};
 use clap::Subcommand;
 use eyre::WrapErr as _;
 use walletkit_core::requests::ProofRequest;
+use walletkit_core::FieldElement as WalletKitFieldElement;
 use walletkit_testkit::env::TestEnv;
 use walletkit_testkit::issuer::issue_faux_credential;
 use walletkit_testkit::proof::{
@@ -96,6 +97,19 @@ pub enum ProofCommand {
         #[arg(long)]
         verifier_address: Option<String>,
     },
+    /// Generate a WIP-103 ownership proof for a credential `sub`.
+    ProveOwnership {
+        /// Nonce from the verifier's challenge endpoint, as a 32-byte hex field element.
+        #[arg(long)]
+        nonce: String,
+        /// Credential blinding factor, as a 32-byte hex field element.
+        #[arg(long)]
+        blinding_factor: String,
+        /// Path to write the base64url-encoded proof to; stdout when omitted.
+        #[arg(long)]
+        output: Option<String>,
+    },
+
     /// Verify a WIP-103 ownership proof from a base64-encoded file.
     VerifyOwnership {
         /// Path to a file containing the base64url-encoded ownership proof, or `-` for stdin.
@@ -356,6 +370,60 @@ fn parse_field_element(value: &str, label: &str) -> eyre::Result<FieldElement> {
     })
 }
 
+/// The nonce is supplied by the caller rather than fetched: walletkit has no
+/// verifier client, so the host redeems `POST /api/v4/zkp/challenge/enrollment`
+/// and passes the `nonce` in.
+async fn run_prove_ownership(
+    cli: &Cli,
+    nonce: &str,
+    blinding_factor: &str,
+    output_path: Option<&str>,
+) -> eyre::Result<()> {
+    let nonce = WalletKitFieldElement::try_from_hex_string(nonce)
+        .wrap_err("invalid --nonce: expected 32-byte hex field element")?;
+    let blinding_factor = WalletKitFieldElement::try_from_hex_string(blinding_factor)
+        .wrap_err(
+        "invalid --blinding-factor: expected 32-byte hex field element",
+    )?;
+
+    let (authenticator, _store) = init_authenticator(cli).await?;
+    let sub = authenticator.compute_credential_sub(&blinding_factor);
+    let proof = authenticator
+        .prove_credential_sub(&nonce, &blinding_factor, &sub)
+        .await
+        .wrap_err("ownership proof generation failed")?;
+
+    let encoded = proof.encode_b64().wrap_err("failed to encode proof")?;
+    let merkle_root = proof.merkle_root().to_hex_string();
+    let sub = sub.to_hex_string();
+
+    if let Some(path) = output_path {
+        std::fs::write(path, &encoded)
+            .wrap_err_with(|| format!("failed to write proof to {path}"))?;
+    }
+
+    if cli.json {
+        output::print_json_data(
+            &serde_json::json!({
+                "sub": sub,
+                "merkle_root": merkle_root,
+                "proof": output_path.is_none().then_some(encoded),
+                "output": output_path,
+            }),
+            true,
+        );
+    } else {
+        println!("{} ownership proof generated", output::pass_label());
+        println!("  sub:         {sub}");
+        println!("  merkle_root: {merkle_root}");
+        match output_path {
+            Some(path) => println!("  written to:  {path}"),
+            None => println!("\n{encoded}"),
+        }
+    }
+    Ok(())
+}
+
 fn run_verify_ownership(
     cli: &Cli,
     proof_path: &str,
@@ -432,6 +500,11 @@ pub async fn run(cli: &Cli, action: &ProofCommand) -> eyre::Result<()> {
             signal,
             verifier_address,
         } => run_test(cli, signal, verifier_address.as_deref()).await,
+        ProofCommand::ProveOwnership {
+            nonce,
+            blinding_factor,
+            output,
+        } => run_prove_ownership(cli, nonce, blinding_factor, output.as_deref()).await,
         ProofCommand::VerifyOwnership { proof, nonce, sub } => {
             run_verify_ownership(cli, proof, nonce, sub)
         }

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -450,6 +450,11 @@ impl Authenticator {
     /// - Returns a network error if the Merkle inclusion proof cannot be
     ///   fetched from the indexer.
     /// - Returns [`WalletKitError::ProofGeneration`] if the ZK proof fails.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "ownership_proof",
+        skip_all
+    )]
     pub async fn prove_credential_sub(
         &self,
         nonce: &FieldElement,
@@ -475,15 +480,20 @@ impl Authenticator {
                 .as_secs();
 
             let inclusion_proof = self.fetch_inclusion_proof_with_cache(now).await?;
-            let proof = self
-                .inner
-                .prove_credential_sub(
+
+            // Nested under `ownership_proof` and a sibling of the fetch's
+            // `indexer_inclusion_proof`, so WHIR proving cost is attributable on
+            // its own rather than inferred by subtraction.
+            let proof = tracing::Instrument::instrument(
+                self.inner.prove_credential_sub(
                     nonce.0,
                     blinding_factor.0,
                     sub.0,
                     Some(inclusion_proof),
-                )
-                .await?;
+                ),
+                tracing::info_span!(target: "walletkit_latency", "whir_proving"),
+            )
+            .await?;
 
             Ok(OwnershipProof(proof))
         }


### PR DESCRIPTION
Closes POP-4226. PR 3 of 5 toward POP-4112. **Base: #465.**

Scoped to code only — device benchmarking is explicitly out, per the ticket owner.

## Why

`prove_credential_sub` was the only `Authenticator` method with no `walletkit_latency` span. WHIR proving is the most expensive operation in the library and it was the one thing the latency harness could not see. And there was no way to drive proof *generation* from the CLI at all — only `verify-ownership` existed.

## What

- `ownership_proof` span over the whole call, plus a nested `whir_proving` span around the prover so proving cost is attributable on its own rather than inferred by subtracting `indexer_inclusion_proof`.
- `walletkit proof prove-ownership --nonce --blinding-factor [--output]`, symmetric with `verify-ownership`. The `sub` is derived via `compute_credential_sub` rather than passed in.

The nonce is caller-supplied. walletkit has no verifier client and gains none here: the host redeems `POST /api/v4/zkp/challenge/enrollment` and passes the nonce in, so walletkit stays offline and testable without the verifier.

## Verified end-to-end against staging

Registered an account, issued a faux credential, generated a proof and verified it:

```
$ walletkit --latency proof prove-ownership --nonce 0x008ca6… --blinding-factor 0x03175b…
[PASS] ownership proof generated
  sub:         0x0b7f5530e748b83e29fa63fda1440fba4fdc46b1f985802946c3794deb7bf677
  merkle_root: 0x19daef2595e1c272ea4cca2a715008833eb483908bcb1403bb9cea00e84771a7

Latency:
  indexer_inclusion_proof       2ms
  whir_proving               4043ms
  ownership_proof            4046ms

$ walletkit proof verify-ownership --proof … --nonce … --sub …
[PASS] ownership proof verified
```

That is the span doing its job: 4,043 ms of the 4,046 ms is WHIR proving, and the cached inclusion-proof fetch is 2 ms.

**Incidental datapoint, not a deliverable:** ~4.0s proving on an M-series Mac. Device numbers remain unmeasured by agreement.

## Heads-up for PR 5

Measuring the resulting proof surfaced a cross-repo blocker for POP-4112 — the verifier's size caps reject a real proof. Numbers and detail are in the POP-4227/POP-4228 PRs and on POP-4112.

## Verification

- `cargo test -p walletkit-core --all-features --lib` — 152 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and CLI tooling around existing proof APIs; no new network clients or auth changes, though ownership proofs remain security-sensitive at call sites.
> 
> **Overview**
> Adds **`walletkit_latency`** instrumentation around **`prove_credential_sub`**: an **`ownership_proof`** span for the full call and a nested **`whir_proving`** span around the inner prover so WHIR cost shows up separately from **`indexer_inclusion_proof`**.
> 
> Introduces **`walletkit proof prove-ownership`** with **`--nonce`**, **`--blinding-factor`**, and optional **`--output`**, mirroring **`verify-ownership`**. The CLI derives **`sub`** via **`compute_credential_sub`** and expects the host to supply the verifier challenge nonce (no verifier client in walletkit). Human and JSON output include **`sub`**, **`merkle_root`**, and the base64url proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdf25a9404d1d68ef26c32c22d3c0d4088f20a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->