### PR TITLE
feat(POP-4227): export a verifier-shaped ownership verification request

### DIFF
--- a/crates/walletkit-cli/src/commands/proof.rs
+++ b/crates/walletkit-cli/src/commands/proof.rs
@@ -105,7 +105,11 @@ pub enum ProofCommand {
         /// Credential blinding factor, as a 32-byte hex field element.
         #[arg(long)]
         blinding_factor: String,
-        /// Path to write the base64url-encoded proof to; stdout when omitted.
+        /// Challenge UUID from the verifier. When set, emits the full
+        /// `POST /api/v4/verify` body instead of the bare proof.
+        #[arg(long)]
+        challenge_id: Option<String>,
+        /// Path to write the output to; stdout when omitted.
         #[arg(long)]
         output: Option<String>,
     },
@@ -377,6 +381,7 @@ async fn run_prove_ownership(
     cli: &Cli,
     nonce: &str,
     blinding_factor: &str,
+    challenge_id: Option<&str>,
     output_path: Option<&str>,
 ) -> eyre::Result<()> {
     let nonce = WalletKitFieldElement::try_from_hex_string(nonce)
@@ -393,12 +398,17 @@ async fn run_prove_ownership(
         .await
         .wrap_err("ownership proof generation failed")?;
 
-    let encoded = proof.encode_b64().wrap_err("failed to encode proof")?;
+    let payload = match challenge_id {
+        Some(challenge_id) => proof
+            .to_verification_request_json(challenge_id, &sub)
+            .wrap_err("failed to build the verification request")?,
+        None => proof.encode_b64().wrap_err("failed to encode proof")?,
+    };
     let merkle_root = proof.merkle_root().to_hex_string();
     let sub = sub.to_hex_string();
 
     if let Some(path) = output_path {
-        std::fs::write(path, &encoded)
+        std::fs::write(path, &payload)
             .wrap_err_with(|| format!("failed to write proof to {path}"))?;
     }
 
@@ -407,7 +417,9 @@ async fn run_prove_ownership(
             &serde_json::json!({
                 "sub": sub,
                 "merkle_root": merkle_root,
-                "proof": output_path.is_none().then_some(encoded),
+                "bytes": payload.len(),
+                "verification_request": challenge_id.is_some(),
+                "payload": output_path.is_none().then_some(payload),
                 "output": output_path,
             }),
             true,
@@ -416,9 +428,10 @@ async fn run_prove_ownership(
         println!("{} ownership proof generated", output::pass_label());
         println!("  sub:         {sub}");
         println!("  merkle_root: {merkle_root}");
+        println!("  bytes:       {}", payload.len());
         match output_path {
             Some(path) => println!("  written to:  {path}"),
-            None => println!("\n{encoded}"),
+            None => println!("\n{payload}"),
         }
     }
     Ok(())
@@ -503,8 +516,18 @@ pub async fn run(cli: &Cli, action: &ProofCommand) -> eyre::Result<()> {
         ProofCommand::ProveOwnership {
             nonce,
             blinding_factor,
+            challenge_id,
             output,
-        } => run_prove_ownership(cli, nonce, blinding_factor, output.as_deref()).await,
+        } => {
+            run_prove_ownership(
+                cli,
+                nonce,
+                blinding_factor,
+                challenge_id.as_deref(),
+                output.as_deref(),
+            )
+            .await
+        }
         ProofCommand::VerifyOwnership { proof, nonce, sub } => {
             run_verify_ownership(cli, proof, nonce, sub)
         }

--- a/crates/walletkit-core/src/proof.rs
+++ b/crates/walletkit-core/src/proof.rs
@@ -1,7 +1,26 @@
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
-use world_id_core::primitives::OwnershipProof as CoreOwnershipProof;
+use serde::Serialize;
+use uuid::Uuid;
+use world_id_core::primitives::{
+    FieldElement as CoreFieldElement, OwnershipProof as CoreOwnershipProof,
+};
 
 use crate::{error::WalletKitError, FieldElement};
+
+/// The only challenge type the verifier issues. A second type would need this to
+/// become a parameter, which is a breaking change for foreign bindings either way.
+const CHALLENGE_TYPE_ENROLLMENT: &str = "enrollment";
+
+/// Mirrors the verifier's `OwnershipVerificationRequest`. The nonce is absent by
+/// design: the service looks it up from its nonce store by `challenge_id` and
+/// never accepts a client-supplied one.
+#[derive(Serialize)]
+struct OwnershipVerificationRequest<'a> {
+    challenge_id: Uuid,
+    challenge_type: &'static str,
+    credential_sub: &'a CoreFieldElement,
+    proof: &'a CoreOwnershipProof,
+}
 
 /// A WIP-103 Ownership Proof available to foreign bindings
 #[derive(Debug, Clone, uniffi::Object)]
@@ -35,5 +54,153 @@ impl OwnershipProof {
     #[must_use]
     pub fn merkle_root(&self) -> FieldElement {
         self.0.merkle_root.into()
+    }
+
+    /// Builds the complete JSON body for the verifier's `POST /api/v4/verify`.
+    ///
+    /// The whole body is assembled here rather than leaving the host to wrap the
+    /// proof, so the request shape lives in the crate that owns the proof type
+    /// and cannot drift per consumer.
+    ///
+    /// `challenge_id` is the value the host received from
+    /// `POST /api/v4/zkp/challenge/enrollment`; walletkit does not fetch it.
+    ///
+    /// # Errors
+    /// - [`WalletKitError::InvalidInput`] if `challenge_id` is not a UUID.
+    /// - [`WalletKitError::SerializationError`] if serialization fails, which
+    ///   should not happen in practice.
+    pub fn to_verification_request_json(
+        &self,
+        challenge_id: &str,
+        credential_sub: &FieldElement,
+    ) -> Result<String, WalletKitError> {
+        let challenge_id = Uuid::try_parse(challenge_id.trim()).map_err(|_| {
+            WalletKitError::InvalidInput {
+                attribute: "challenge_id".to_string(),
+                reason: "expected the UUID issued by the challenge endpoint"
+                    .to_string(),
+            }
+        })?;
+
+        serde_json::to_string(&OwnershipVerificationRequest {
+            challenge_id,
+            challenge_type: CHALLENGE_TYPE_ENROLLMENT,
+            credential_sub: &credential_sub.0,
+            proof: &self.0,
+        })
+        .map_err(|_| WalletKitError::SerializationError {
+            error: "unexpected error serializing the verification request".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use world_id_proof::WhirR1CSProof;
+
+    const CHALLENGE_ID: &str = "6f1a8b2c-0e4d-4a7b-9c3e-5d2f8a1b7c40";
+
+    fn proof_fixture() -> OwnershipProof {
+        OwnershipProof(CoreOwnershipProof {
+            proof: WhirR1CSProof {
+                narg_string: vec![0xde, 0xad, 0xbe, 0xef],
+                hints: vec![0x01, 0x02],
+            },
+            merkle_root: CoreFieldElement::from(7u64),
+        })
+    }
+
+    fn request_json() -> serde_json::Value {
+        let json = proof_fixture()
+            .to_verification_request_json(CHALLENGE_ID, &FieldElement::from_u64(42))
+            .expect("request should serialize");
+        serde_json::from_str(&json).expect("output should be valid JSON")
+    }
+
+    /// Asserted against the verifier's own `OwnershipVerificationRequest` shape
+    /// rather than round-tripped through our own deserializer, which would pass
+    /// even if every key name were wrong.
+    #[test]
+    fn request_matches_the_verifier_shape() {
+        let value = request_json();
+        let object = value.as_object().expect("top level is an object");
+
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            ["challenge_id", "challenge_type", "credential_sub", "proof"]
+        );
+
+        let mut proof_keys: Vec<&str> = value["proof"]
+            .as_object()
+            .expect("proof is an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        proof_keys.sort_unstable();
+        assert_eq!(proof_keys, ["merkle_root", "proof"]);
+
+        let mut whir_keys: Vec<&str> = value["proof"]["proof"]
+            .as_object()
+            .expect("whir proof is an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        whir_keys.sort_unstable();
+        assert_eq!(whir_keys, ["hints", "narg_string"]);
+    }
+
+    #[test]
+    fn challenge_type_is_the_snake_case_name_the_verifier_expects() {
+        assert_eq!(request_json()["challenge_type"], "enrollment");
+    }
+
+    #[test]
+    fn challenge_id_is_the_hyphenated_uuid() {
+        assert_eq!(request_json()["challenge_id"], CHALLENGE_ID);
+    }
+
+    /// `ProveKit`'s `serde_hex` module is misnamed: in human-readable formats it
+    /// emits standard base64, and only auto-detects hex when deserializing.
+    /// Both sides are on provekit-common 0.1.4, so this is the agreed encoding.
+    #[test]
+    fn proof_components_are_base64_not_hex() {
+        let value = request_json();
+        assert_eq!(value["proof"]["proof"]["narg_string"], "3q2+7w==");
+        assert_eq!(value["proof"]["proof"]["hints"], "AQI=");
+    }
+
+    #[test]
+    fn field_elements_serialize_as_their_hex_string() {
+        let value = request_json();
+        assert_eq!(
+            value["credential_sub"],
+            FieldElement::from_u64(42).to_hex_string().as_str()
+        );
+        assert_eq!(
+            value["proof"]["merkle_root"],
+            FieldElement::from_u64(7).to_hex_string().as_str()
+        );
+    }
+
+    #[test]
+    fn rejects_a_challenge_id_that_is_not_a_uuid() {
+        let error = proof_fixture()
+            .to_verification_request_json("not-a-uuid", &FieldElement::from_u64(1))
+            .expect_err("a malformed challenge id must not reach the verifier");
+        assert!(matches!(error, WalletKitError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn accepts_a_challenge_id_with_surrounding_whitespace() {
+        let json = proof_fixture()
+            .to_verification_request_json(
+                &format!("  {CHALLENGE_ID}\n"),
+                &FieldElement::from_u64(1),
+            )
+            .expect("surrounding whitespace should be tolerated");
+        assert!(json.contains(CHALLENGE_ID));
     }
 }


### PR DESCRIPTION
Closes POP-4227. PR 4 of 5 toward POP-4112. **Base: #466.**

## Why

`OwnershipProof` exposed only CBOR (`encode`, `encode_b64`) to foreign bindings. A Swift or Kotlin caller had to hand-assemble the verifier's JSON from it — precisely the host-side re-encoding that silently drifts out of contract.

## What

`to_verification_request_json(challenge_id, credential_sub)` builds the complete `POST /api/v4/verify` body. The **whole body** is assembled here, not just the proof object, so the request shape lives in the crate that owns the proof type and cannot drift per consumer.

`challenge_id` is validated as a UUID rather than passed through, so a malformed handle fails locally instead of as an opaque rejection. The nonce is deliberately absent — the service looks it up by `challenge_id` from its nonce store and never accepts a client-supplied one.

`encode`/`encode_b64` are untouched. The CLI's `prove-ownership` gains `--challenge-id`, which emits the ready-to-POST body.

## Contract taken from the service, not from the ticket

Read off `world-id-proof-verification-service` @ `d9a3f0f` (`src/models/ownership_model.rs`, `src/api/challenge_api.rs`, `src/app.rs`) rather than from POP-4112's prose. Two places the prose was wrong:

1. **The proof components are base64, not hex.** ProveKit's module is *named* `serde_hex` but emits standard base64 in human-readable formats, auto-detecting hex only on the way in. My first test asserted hex and failed — which is the test doing its job. Both sides are on provekit-common 0.1.4, so base64 is the agreed encoding.
2. **`/api/v4/verify` is authenticated** — via an `AuthenticatedService` extractor, not a router layer, so it is easy to miss when skimming `app.rs`.

Verified end-to-end: the body generated from a real staging proof matches the service's struct exactly — `{challenge_id, challenge_type: "enrollment", credential_sub, proof: {merkle_root, proof: {narg_string, hints}}}`.

## ⚠️ Blocker for POP-4112: a real proof exceeds the verifier's size limits

Measured on a genuine staging-generated proof, not extrapolated:

| | Measured | Verifier limit | Result |
|---|---|---|---|
| `narg_string` (decoded) | 32,256 B | 65,536 B | OK |
| `hints` (decoded) | **538,832 B** | 65,536 B (`MAX_PROOF_COMPONENT_BYTES`) | **8.2× over** |
| request body | **761,754 B** (744 KiB) | 524,288 B (`max_body_bytes`, default 512 KiB) | **over by 232 KiB** |

Nothing in walletkit can fix this — the sizes are what ProveKit produces. It needs a verifier-side decision:

- raise both limits (the config comment already says *"tune via env once production proof sizes are measured"* — this is that measurement), and/or
- accept a compressed body, and/or
- reduce `hints` via ProveKit configuration.

Filed on POP-4112 for the verifier owners. This PR ships the correct payload regardless; it will start being accepted the moment the limits allow it.

## Verification

- `cargo test -p walletkit-core --all-features --lib` — 159 passed (7 new)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and CLI flag; existing encodings unchanged. Risk is mainly contract drift with the verifier, mitigated by explicit serialization and tests.
> 
> **Overview**
> Adds **`OwnershipProof::to_verification_request_json`** so hosts no longer hand-wrap proofs into the verifier’s **`POST /api/v4/verify`** JSON. The body includes `challenge_id`, fixed `challenge_type: "enrollment"`, `credential_sub`, and the proof; **no client nonce** (the service resolves it from `challenge_id`). Invalid `challenge_id` values fail locally as **`InvalidInput`**.
> 
> **`walletkit proof prove-ownership`** gains optional **`--challenge-id`**: when set, stdout/file output is the full verification request instead of base64url CBOR; JSON CLI output reports byte size and whether a verification request was emitted. **`encode` / `encode_b64`** are unchanged.
> 
> New unit tests lock the serialized shape, base64 proof components, hex field elements, and UUID validation against the verifier contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f16ee4c8eff03d0abe73fb5516eb877c41e2183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->