### PR TITLE
test(POP-4228): verify ownership proofs instead of only comparing roots

### DIFF
--- a/crates/walletkit-core/tests/proof_generation_integration.rs
+++ b/crates/walletkit-core/tests/proof_generation_integration.rs
@@ -18,12 +18,14 @@ use rand::rngs::OsRng;
 use tempfile::TempDir;
 use walletkit_testkit::issuer::issue_local_credential;
 use walletkit_testkit::proof::build_test_request;
+use walletkit_testkit::storage::create_artifact_source;
 use walletkit_testkit::utils::now_secs;
 use walletkit_testkit::{
     generate_and_verify_test_proof, init_and_register_account, CredentialType,
     ProofType, TestEnv,
 };
-use world_id_core::primitives::FieldElement;
+use world_id_core::primitives::{FieldElement, OwnershipProof as CoreOwnershipProof};
+use world_id_proof::ownership_proof::verify_ownership_proof;
 
 use eyre::{Result, WrapErr as _};
 
@@ -206,6 +208,54 @@ async fn e2e_session_proof() -> Result<()> {
         session_item.proof.as_ethereum_representation()[4],
         "ownership proof Merkle root should match the session proof"
     );
+
+    // Phase 6: the proof must actually verify. Matching Merkle roots says the
+    // proof covers the right account; it says nothing about validity, so a
+    // prover emitting structurally-valid garbage would satisfy Phase 5 alone.
+    let artifacts = create_artifact_source(root.path());
+    let encoded = ownership_proof.encode().wrap_err("encoding failed")?;
+    let core_proof: CoreOwnershipProof = ciborium::from_reader(&encoded[..])
+        .wrap_err("failed to decode the ownership proof")?;
+
+    verify_ownership_proof(&core_proof, nonce.0, sub.0, artifacts.as_ref())
+        .wrap_err("ownership proof should verify against the embedded verifier")?;
+
+    // Phase 7: and it must fail when tampered with. Without these, a verifier
+    // that returned Ok unconditionally would look healthy.
+    let mut wrong_root = core_proof.clone();
+    wrong_root.merkle_root = FieldElement::from(1u64);
+    assert!(
+        verify_ownership_proof(&wrong_root, nonce.0, sub.0, artifacts.as_ref())
+            .is_err(),
+        "verification must reject a mutated merkle_root"
+    );
+
+    let mut flipped_byte = core_proof.clone();
+    flipped_byte.proof.narg_string[0] ^= 0x01;
+    assert!(
+        verify_ownership_proof(&flipped_byte, nonce.0, sub.0, artifacts.as_ref())
+            .is_err(),
+        "verification must reject a flipped narg_string byte"
+    );
+
+    let wrong_sub = FieldElement::from(2u64);
+    assert!(
+        verify_ownership_proof(&core_proof, nonce.0, wrong_sub, artifacts.as_ref())
+            .is_err(),
+        "verification must reject a proof presented for a different sub"
+    );
+
+    // Phase 8: the payload the host forwards must be the shape the verifier
+    // parses, built from a real proof rather than a fixture.
+    let body = ownership_proof
+        .to_verification_request_json("6f1a8b2c-0e4d-4a7b-9c3e-5d2f8a1b7c40", &sub)
+        .wrap_err("verification request serialization failed")?;
+    let body: serde_json::Value = serde_json::from_str(&body)
+        .wrap_err("verification request is not valid JSON")?;
+    assert_eq!(body["challenge_type"], "enrollment");
+    assert_eq!(body["credential_sub"], sub.to_hex_string().as_str());
+    assert!(body["proof"]["proof"]["narg_string"].is_string());
+    assert!(body["proof"]["proof"]["hints"].is_string());
 
     Ok(())
 }

--- a/kotlin/walletkit-tests/src/test/kotlin/org/world/walletkit/SimpleTest.kt
+++ b/kotlin/walletkit-tests/src/test/kotlin/org/world/walletkit/SimpleTest.kt
@@ -1,10 +1,13 @@
 package org.world.walletkit
 
+import uniffi.walletkit_core.FieldElement
 import uniffi.walletkit_core.LogLevel
 import uniffi.walletkit_core.Logger
+import uniffi.walletkit_core.OwnershipProof
 import uniffi.walletkit_core.emitLog
 import uniffi.walletkit_core.initLogging
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 private class CapturingLogger : Logger {
@@ -45,5 +48,20 @@ class SimpleTest {
                 level == LogLevel.INFO && message.contains("bridge test")
             }
         assertTrue(hasBridgedMessage, "expected info-level bridged log")
+    }
+
+    /// Binds the WIP-103 verification-request builder as a value, so a rename,
+    /// a dropped `#[uniffi::export]`, or a changed parameter type fails to
+    /// compile here. Generating a proof to call it needs a registered account
+    /// and staging network, which belongs in the Rust integration suite.
+    @Test
+    fun ownershipProofExposesVerificationRequestBuilder() {
+        fun callBuilder(
+            proof: OwnershipProof,
+            challengeId: String,
+            credentialSub: FieldElement,
+        ): String = proof.toVerificationRequestJson(challengeId, credentialSub)
+
+        assertNotNull(::callBuilder)
     }
 }

--- a/kotlin/walletkit-tests/src/test/kotlin/org/world/walletkit/SimpleTest.kt
+++ b/kotlin/walletkit-tests/src/test/kotlin/org/world/walletkit/SimpleTest.kt
@@ -50,10 +50,8 @@ class SimpleTest {
         assertTrue(hasBridgedMessage, "expected info-level bridged log")
     }
 
-    /// Binds the WIP-103 verification-request builder as a value, so a rename,
-    /// a dropped `#[uniffi::export]`, or a changed parameter type fails to
-    /// compile here. Generating a proof to call it needs a registered account
-    /// and staging network, which belongs in the Rust integration suite.
+    // Compile-time only: a rename, a dropped export, or a changed parameter
+    // type fails here. Calling it needs a proof, so that stays in Rust.
     @Test
     fun ownershipProofExposesVerificationRequestBuilder() {
         fun callBuilder(

--- a/swift/tests/WalletKitTests/SimpleTest.swift
+++ b/swift/tests/WalletKitTests/SimpleTest.swift
@@ -46,10 +46,8 @@ final class SimpleTest: XCTestCase {
         XCTAssertTrue(hasBridgedMessage, "expected info-level bridged log")
     }
 
-    /// Binds the WIP-103 verification-request builder as a value, so a rename,
-    /// a dropped `#[uniffi::export]`, or a changed parameter type fails to
-    /// compile here. Generating a proof to call it needs a registered account
-    /// and staging network, which belongs in the Rust integration suite.
+    // Compile-time only: a rename, a dropped export, or a changed parameter
+    // type fails here. Calling it needs a proof, so that stays in Rust.
     func testOwnershipProofExposesVerificationRequestBuilder() {
         func callBuilder(
             _ proof: WalletKit.OwnershipProof,

--- a/swift/tests/WalletKitTests/SimpleTest.swift
+++ b/swift/tests/WalletKitTests/SimpleTest.swift
@@ -45,4 +45,22 @@ final class SimpleTest: XCTestCase {
         }
         XCTAssertTrue(hasBridgedMessage, "expected info-level bridged log")
     }
+
+    /// Binds the WIP-103 verification-request builder as a value, so a rename,
+    /// a dropped `#[uniffi::export]`, or a changed parameter type fails to
+    /// compile here. Generating a proof to call it needs a registered account
+    /// and staging network, which belongs in the Rust integration suite.
+    func testOwnershipProofExposesVerificationRequestBuilder() {
+        func callBuilder(
+            _ proof: WalletKit.OwnershipProof,
+            _ challengeId: String,
+            _ credentialSub: WalletKit.FieldElement
+        ) throws -> String {
+            try proof.toVerificationRequestJson(
+                challengeId: challengeId,
+                credentialSub: credentialSub
+            )
+        }
+        XCTAssertNotNil(callBuilder)
+    }
 }


### PR DESCRIPTION
Closes POP-4228. PR 5 of 5 toward POP-4112. **Base: #467.**

## Why

The only test that generated an ownership proof asserted just that its Merkle root matched the session proof's. That establishes the proof covers the right account and says nothing about validity — a prover emitting structurally-valid garbage with a correct root would have passed. Meanwhile `verify_ownership_proof` was already sitting in the CLI, unused by the test suite.

## What

Extends the staging integration test:

- **Verifies** the generated proof against the embedded verifier.
- **Tamper rejection** — mutated `merkle_root`, flipped `narg_string` byte, and a proof presented for a different `sub`. Without the negative cases, a verifier that returned `Ok` unconditionally would look healthy.
- **Payload shape** asserted from a real proof rather than a fixture.

Plus the new uniffi method is bound in the Swift and Kotlin smoke suites, so a rename, a dropped `#[uniffi::export]`, or a changed parameter type fails to compile.

## Scope change: the live round-trip is not here

POP-4228 originally required a live `POST /api/v4/verify` round-trip. Dropped by agreement with the ticket owner: walletkit is a **library**. It generates the proof; the importing CLI or app forwards it to the verification service. That acceptance criterion belongs to the integrator, not to this repo, and POP-4112/POP-4228 have been updated to say so.

What walletkit can and does prove is everything up to the wire: the proof verifies, tampering is rejected, and the request body matches the service's `OwnershipVerificationRequest` exactly.

## Verification

Ran against staging (101s):

```
test e2e_session_proof ... ok
test result: ok. 1 passed; 0 failed
```

- `cargo test -p walletkit-core --all-features --lib` — 159 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean

**Not verified locally:** the Swift and Kotlin additions. `cargo xtask kotlin test` fails on this machine with a JVM-target mismatch (local JDK 22 vs Kotlin target 21) — confirmed pre-existing by running it on the unmodified test file, and CI pins Java 17. Swift needs an iOS build. Both were written as plain method calls inside an unused local function rather than unapplied method references, to keep the syntax boring. CI is the first real check on them.

## Still open for POP-4112

The size blocker from #467: a real proof's `hints` is 8.2× the verifier's per-component cap and the body is 744 KiB against a 512 KiB limit. Nothing in walletkit can fix that — it needs a verifier-side limit change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration and mobile smoke tests; no production wallet or verifier logic is modified.
> 
> **Overview**
> The staging **session proof** integration test no longer stops at matching Merkle roots. It now **cryptographically verifies** the generated ownership proof with `verify_ownership_proof`, adds **negative cases** (bad root, flipped `narg_string`, wrong `sub`), and checks **`to_verification_request_json`** output shape from a real proof.
> 
> **Swift** and **Kotlin** smoke tests gain compile-time coverage that `OwnershipProof.toVerificationRequestJson` stays exported with the expected types—no runtime proof needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a54b918ec9bd23675fbde3a38b6c933a7b79f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->