### PR TITLE
Pin the byte-stability of plaintext vault exports

### DIFF
--- a/crates/walletkit-core/src/storage/credential_vault/tests.rs
+++ b/crates/walletkit-core/src/storage/credential_vault/tests.rs
@@ -30,6 +30,12 @@ fn cleanup_lock_file(path: &Path) {
     let _ = fs::remove_file(path);
 }
 
+fn temp_export_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("walletkit-vault-export-{}.bin", Uuid::new_v4()));
+    path
+}
+
 fn sample_blinding_factor() -> Vec<u8> {
     [0x11u8; 32].to_vec()
 }
@@ -514,6 +520,123 @@ fn test_list_credentials_round_trips_genesis_issued_at() {
     let records = db.list_credentials(None, 1000).expect("list credentials");
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].genesis_issued_at, genesis_issued_at);
+    cleanup_vault_files(&path);
+    cleanup_lock_file(&lock_path);
+}
+
+/// Hosts record a checksum of an export, delete the plaintext copy so it does not sit on disk, and
+/// re-derive it later to prove the backup they hold still matches. That only holds if exporting an
+/// unchanged vault is byte-identical.
+#[test]
+fn test_plaintext_export_is_byte_identical_for_an_unchanged_vault() {
+    let path = temp_vault_path();
+    let lock_path = temp_lock_path();
+    let key = SecretBox::init_with(|| [0x0Du8; 32]);
+    let db = CredentialVault::new(&path, &key).expect("create vault");
+    db.store_credential(
+        10,
+        sample_blinding_factor(),
+        123,
+        2000,
+        b"credential".to_vec(),
+        None,
+        1000,
+    )
+    .expect("store credential");
+
+    let first = temp_export_path();
+    let second = temp_export_path();
+    db.export_plaintext(&first).expect("first export");
+    db.export_plaintext(&second).expect("second export");
+
+    assert_eq!(
+        fs::read(&first).expect("read first export"),
+        fs::read(&second).expect("read second export"),
+        "re-exporting an unchanged vault produced different bytes",
+    );
+
+    let _ = fs::remove_file(&first);
+    let _ = fs::remove_file(&second);
+    cleanup_vault_files(&path);
+    cleanup_lock_file(&lock_path);
+}
+
+/// The re-derived export runs against a vault that was reopened and had its leaf index initialized
+/// again with the current time, unlike the export that produced the recorded checksum. Neither the
+/// reopen nor the re-init may change the exported bytes.
+#[test]
+fn test_plaintext_export_is_unaffected_by_reopening_and_reinitializing_the_leaf_index()
+{
+    let path = temp_vault_path();
+    let lock_path = temp_lock_path();
+    let key = SecretBox::init_with(|| [0x0Eu8; 32]);
+    let registered = temp_export_path();
+    let regenerated = temp_export_path();
+
+    let db = CredentialVault::new(&path, &key).expect("create vault");
+    db.init_leaf_index(7, 1000).expect("init leaf index");
+    db.store_credential(
+        10,
+        sample_blinding_factor(),
+        123,
+        2000,
+        b"credential".to_vec(),
+        None,
+        1000,
+    )
+    .expect("store credential");
+    db.export_plaintext(&registered).expect("registered export");
+    drop(db);
+
+    let db = CredentialVault::new(&path, &key).expect("reopen vault");
+    db.init_leaf_index(7, 9999).expect("re-init leaf index");
+    db.export_plaintext(&regenerated)
+        .expect("regenerated export");
+
+    assert_eq!(
+        fs::read(&registered).expect("read registered export"),
+        fs::read(&regenerated).expect("read regenerated export"),
+        "re-exporting after a reopen and a re-init produced different bytes",
+    );
+
+    let _ = fs::remove_file(&registered);
+    let _ = fs::remove_file(&regenerated);
+    cleanup_vault_files(&path);
+    cleanup_lock_file(&lock_path);
+}
+
+/// Control for the two tests above: the export has to track the vault's contents, otherwise
+/// byte-identical exports would prove nothing.
+#[test]
+fn test_plaintext_export_changes_when_a_credential_is_stored() {
+    let path = temp_vault_path();
+    let lock_path = temp_lock_path();
+    let key = SecretBox::init_with(|| [0x0Fu8; 32]);
+    let db = CredentialVault::new(&path, &key).expect("create vault");
+    let before = temp_export_path();
+    let after = temp_export_path();
+
+    db.export_plaintext(&before).expect("export before");
+    db.store_credential(
+        10,
+        sample_blinding_factor(),
+        123,
+        2000,
+        b"credential".to_vec(),
+        None,
+        1000,
+    )
+    .expect("store credential");
+    db.export_plaintext(&after).expect("export after");
+
+    assert_ne!(
+        fs::read(&before).expect("read export before"),
+        fs::read(&after).expect("read export after"),
+        "storing a credential did not change the exported bytes",
+    );
+
+    let _ = fs::remove_file(&before);
+    let _ = fs::remove_file(&after);
     cleanup_vault_files(&path);
     cleanup_lock_file(&lock_path);
 }


### PR DESCRIPTION
Motivation: hosts record a checksum of a plaintext vault export, delete the export so plaintext credentials do not sit on disk, then re-derive it later to prove the backup they hold still matches. Nothing in this repo guaranteed that a re-export of an unchanged vault produces the same bytes, and a mismatch fails the whole backup rather than just the export.

Three tests in `credential_vault`: exporting an unchanged vault twice is byte-identical, reopening the vault and initializing the leaf index again does not change the exported bytes, and storing a credential does (the control, so byte-identical exports prove something). All three pass today, so the property holds and is now protected against a change to `BACKUP_TABLES`, the export SQL, or the schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications; low risk to runtime behavior.
> 
> **Overview**
> Adds regression tests so **plaintext vault export** behavior stays stable for backup checksum workflows (export, delete on-disk copy, re-export later to verify the backup).
> 
> A **`temp_export_path`** helper supports writing exports to unique temp files. Three tests assert: repeated **`export_plaintext`** on an unchanged vault is byte-identical; reopening the vault and calling **`init_leaf_index`** again with a different timestamp does not change export bytes; and storing a credential **does** change export bytes (control so stability tests are meaningful).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c83aa12efd808d8cc9dc7478e846db068d1d4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->