### PR TITLE
feat: WIP-104 Expose authenticator account operations over the UniFFI surface

### DIFF
--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -1148,32 +1148,8 @@ mod tests {
         assert!(RecoveryData::from_seed(&[]).is_err());
     }
 
-    #[tokio::test]
-    async fn test_authenticator_account_ops_reject_invalid_ffi_inputs() {
-        use crate::storage::tests_utils::cleanup_test_storage;
-
-        let mut server = mockito::Server::new_async().await;
-        let (authenticator, root) = test_authenticator(&mut server).await;
-
-        let invalid_pubkey = authenticator
-            .insert_authenticator(
-                "not-a-public-key".to_string(),
-                Address::ZERO.to_string(),
-            )
-            .await;
-        assert!(matches!(
-            invalid_pubkey,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "new_authenticator_pubkey"
-        ));
-        let invalid_decoded_pubkey =
-            validate_authenticator_pubkey(&format!("0x{}", "ff".repeat(32)));
-        assert!(matches!(
-            invalid_decoded_pubkey,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "authenticator_pubkey"
-        ));
-
+    #[test]
+    fn test_authenticator_pubkey_validation() {
         let canonical = encoded_pubkey(&[2u8; 32]);
         assert_eq!(
             validate_authenticator_pubkey(&canonical).expect("valid key"),
@@ -1185,6 +1161,17 @@ mod tests {
                 .expect("uppercase hex should canonicalize"),
             canonical
         );
+
+        for invalid_pubkey in [
+            "not-a-public-key".to_string(),
+            format!("0x{}", "ff".repeat(32)),
+        ] {
+            assert!(matches!(
+                validate_authenticator_pubkey(&invalid_pubkey),
+                Err(WalletKitError::InvalidInput { attribute, .. })
+                    if attribute == "authenticator_pubkey"
+            ));
+        }
 
         let identity = format!("0x{}01", "0".repeat(62));
         assert!(matches!(
@@ -1198,115 +1185,21 @@ mod tests {
             Err(WalletKitError::InvalidInput { attribute, reason })
                 if attribute == "authenticator_pubkey" && reason.contains("canonical")
         ));
-
-        let invalid_insert_address = authenticator
-            .insert_authenticator(
-                encoded_pubkey(&[2u8; 32]),
-                "not-an-address".to_string(),
-            )
-            .await;
-        assert!(matches!(
-            invalid_insert_address,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "new_authenticator_address"
-        ));
-
-        let invalid_remove_address = authenticator
-            .remove_authenticator(
-                "not-an-address".to_string(),
-                0,
-                encoded_pubkey(&[2u8; 32]),
-            )
-            .await;
-        assert!(matches!(
-            invalid_remove_address,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "authenticator_address"
-        ));
-
-        let invalid_expected_pubkey = authenticator
-            .remove_authenticator(
-                Address::ZERO.to_string(),
-                0,
-                "not-a-public-key".to_string(),
-            )
-            .await;
-        assert!(matches!(
-            invalid_expected_pubkey,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "expected_authenticator_pubkey"
-        ));
-
-        drop(server);
-        cleanup_test_storage(&root);
     }
 
     #[tokio::test]
-    async fn test_insert_authenticator_constructs_request_and_polls_status() {
+    async fn test_poll_status_normalizes_request_id() {
         use crate::storage::tests_utils::cleanup_test_storage;
 
         let mut server = mockito::Server::new_async().await;
         let (authenticator, root) = test_authenticator(&mut server).await;
-        let existing_pubkey = encoded_pubkey(&TEST_SEED);
-        let new_pubkey = encoded_pubkey(&[2u8; 32]);
-
-        let nonce_mock = server
-            .mock("POST", "/signature-nonce")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(serde_json::json!({ "signature_nonce": "0x0" }).to_string())
-            .create_async()
-            .await;
-        let pubkeys_mock = mock_authenticator_pubkeys(
-            &mut server,
-            &[Some(existing_pubkey.as_str())],
-            1,
-        )
-        .await;
-        let insert_mock = server
-            .mock("POST", "/insert-authenticator")
-            .match_body(mockito::Matcher::JsonString(serde_json::json!({
-                "leaf_index": "0x2a",
-                "new_authenticator_address": "0x0000000000000000000000000000000000000000",
-                "old_offchain_signer_commitment": "0x25621ac3b8119fa030714e263a607e3ce2c1a9c28e1fcd2109b976b64c4c5758",
-                "new_offchain_signer_commitment": "0x14e70bb77e346fedbd4ab09b2dba10265794ed0e8b4cf1f378a3a8668489acf1",
-                "signature": "0x414f2149d1729181056d61f518e5d3eee9a56b57daf8f909f95b639b852cd6ae50a5298a21d1d48920c903bbd8b21cdbd7be17a4d07a33c4c35946ecba8c19d01b",
-                "nonce": "0x0",
-                "pubkey_id": "0x1",
-                "new_authenticator_pubkey": "0x9ffe38af11bfff8fb9fa44121b6f2ed5572917df56634c785911dd8ac991f65e"
-            }).to_string()))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "request_id": "gw_insert_test",
-                    "kind": "insert_authenticator",
-                    "status": { "state": "queued" }
-                })
-                .to_string(),
-            )
-            .create_async()
-            .await;
-
-        let request_id = authenticator
-            .insert_authenticator(new_pubkey, Address::ZERO.to_string())
-            .await
-            .expect("insert should succeed");
-        assert_eq!(request_id, "gw_insert_test");
-        nonce_mock.assert_async().await;
-        pubkeys_mock.assert_async().await;
-        insert_mock.assert_async().await;
-
         let status_mock = server
-            .mock("GET", "/status/gw_insert_test")
+            .mock("GET", "/status/gw_poll_test")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
                 serde_json::json!({
-                    "request_id": "gw_insert_test",
+                    "request_id": "gw_poll_test",
                     "kind": "insert_authenticator",
                     "status": {
                         "state": "finalized",
@@ -1315,18 +1208,21 @@ mod tests {
                 })
                 .to_string(),
             )
+            .expect(2)
             .create_async()
             .await;
-        let status = authenticator
-            .poll_status(request_id)
-            .await
-            .expect("status poll should succeed");
-        assert_eq!(
-            status,
-            GatewayRequestStatus::Finalized {
-                tx_hash: "0x1234".to_string()
-            }
-        );
+
+        for request_id in ["poll_test", "gw_poll_test"] {
+            assert_eq!(
+                authenticator
+                    .poll_status(request_id.to_string())
+                    .await
+                    .expect("status poll should succeed"),
+                GatewayRequestStatus::Finalized {
+                    tx_hash: "0x1234".to_string()
+                }
+            );
+        }
         status_mock.assert_async().await;
 
         drop(server);
@@ -1431,70 +1327,21 @@ mod tests {
         )
         .await;
 
-        let pubkeys = authenticator
-            .get_authenticator_pubkeys()
-            .await
-            .expect("key set read should succeed");
-        assert_eq!(
-            pubkeys,
-            vec![Some(existing_pubkey), None, Some(other_pubkey)]
-        );
-
         assert!(authenticator
-            .has_authenticator_pubkey(encoded_pubkey(&TEST_SEED))
+            .has_authenticator_pubkey(existing_pubkey.clone())
             .await
             .expect("membership read should succeed"));
         assert!(!authenticator
             .has_authenticator_pubkey(encoded_pubkey(&[3u8; 32]))
             .await
             .expect("absent key check should succeed"));
-        pubkeys_mock.assert_async().await;
-
-        drop(server);
-        cleanup_test_storage(&root);
-    }
-
-    #[tokio::test]
-    async fn test_account_ops_surface_5xx_as_network_errors() {
-        use crate::storage::tests_utils::cleanup_test_storage;
-
-        let mut server = mockito::Server::new_async().await;
-        let (authenticator, root) = test_authenticator(&mut server).await;
-
-        let status_mock = server
-            .mock("GET", "/status/gw_unavailable")
-            .with_status(503)
-            .with_body("batcher unavailable")
-            .create_async()
-            .await;
-        let gateway_error = authenticator
-            .poll_status("gw_unavailable".to_string())
-            .await;
-        assert!(matches!(
-            gateway_error,
-            Err(WalletKitError::NetworkError {
-                url,
-                status: Some(503),
-                ..
-            }) if url == "gateway"
-        ));
-        status_mock.assert_async().await;
-
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .with_status(500)
-            .with_body("indexer unavailable")
-            .create_async()
-            .await;
-        let indexer_error = authenticator.get_authenticator_pubkeys().await;
-        assert!(matches!(
-            indexer_error,
-            Err(WalletKitError::NetworkError {
-                url,
-                status: Some(500),
-                ..
-            }) if url == "indexer"
-        ));
+        assert_eq!(
+            authenticator
+                .get_authenticator_pubkeys()
+                .await
+                .expect("key set read should succeed"),
+            vec![Some(existing_pubkey), None, Some(other_pubkey)]
+        );
         pubkeys_mock.assert_async().await;
 
         drop(server);

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -1099,6 +1099,33 @@ mod tests {
         format!("{pubkey:#066x}")
     }
 
+    /// Mocks the indexer's `/authenticator-pubkeys` endpoint with a fixed
+    /// key-set response (`None` entries are empty slots), asserting the
+    /// request body and the expected number of hits.
+    async fn mock_authenticator_pubkeys(
+        server: &mut mockito::Server,
+        pubkeys: &[Option<&str>],
+        expected_hits: usize,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": pubkeys,
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .expect(expected_hits)
+            .create_async()
+            .await
+    }
+
     #[test]
     fn test_recovery_data_from_seed() {
         let seed = [1u8; 32];
@@ -1271,22 +1298,12 @@ mod tests {
             .with_body(serde_json::json!({ "signature_nonce": "0x0" }).to_string())
             .create_async()
             .await;
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey],
-                    "offchain_signer_commitment": "0x0"
-                })
-                .to_string(),
-            )
-            .create_async()
-            .await;
+        let pubkeys_mock = mock_authenticator_pubkeys(
+            &mut server,
+            &[Some(existing_pubkey.as_str())],
+            1,
+        )
+        .await;
         let insert_mock = server
             .mock("POST", "/insert-authenticator")
             .match_body(mockito::Matcher::JsonString(serde_json::json!({
@@ -1362,23 +1379,12 @@ mod tests {
         let (authenticator, root) = test_authenticator(&mut server).await;
         let existing_pubkey = encoded_pubkey(&TEST_SEED);
 
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey.clone()],
-                    "offchain_signer_commitment": "0x0"
-                })
-                .to_string(),
-            )
-            .expect(2)
-            .create_async()
-            .await;
+        let pubkeys_mock = mock_authenticator_pubkeys(
+            &mut server,
+            &[Some(existing_pubkey.as_str())],
+            2,
+        )
+        .await;
 
         assert!(authenticator
             .has_authenticator_pubkey(existing_pubkey)
@@ -1413,23 +1419,15 @@ mod tests {
             .with_body(serde_json::json!({ "signature_nonce": "0x1" }).to_string())
             .create_async()
             .await;
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey, removed_pubkey.clone()],
-                    "offchain_signer_commitment": "0x0"
-                })
-                .to_string(),
-            )
-            .expect(2)
-            .create_async()
-            .await;
+        let pubkeys_mock = mock_authenticator_pubkeys(
+            &mut server,
+            &[
+                Some(existing_pubkey.as_str()),
+                Some(removed_pubkey.as_str()),
+            ],
+            2,
+        )
+        .await;
         let remove_mock = server
             .mock("POST", "/remove-authenticator")
             .match_body(mockito::Matcher::JsonString(serde_json::json!({
@@ -1477,23 +1475,16 @@ mod tests {
         let existing_pubkey = encoded_pubkey(&TEST_SEED);
         let slot_pubkey = encoded_pubkey(&[2u8; 32]);
 
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey, null, slot_pubkey],
-                    "offchain_signer_commitment": "0x0"
-                })
-                .to_string(),
-            )
-            .expect(2)
-            .create_async()
-            .await;
+        let pubkeys_mock = mock_authenticator_pubkeys(
+            &mut server,
+            &[
+                Some(existing_pubkey.as_str()),
+                None,
+                Some(slot_pubkey.as_str()),
+            ],
+            2,
+        )
+        .await;
         let nonce_mock = server
             .mock("POST", "/signature-nonce")
             .expect(0)
@@ -1562,26 +1553,16 @@ mod tests {
         let existing_pubkey = encoded_pubkey(&TEST_SEED);
         let other_pubkey = encoded_pubkey(&[2u8; 32]);
 
-        let pubkeys_mock = server
-            .mock("POST", "/authenticator-pubkeys")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "authenticator_pubkeys": [
-                        existing_pubkey.clone(),
-                        null,
-                        other_pubkey.clone()
-                    ],
-                    "offchain_signer_commitment": "0x0"
-                })
-                .to_string(),
-            )
-            .create_async()
-            .await;
+        let pubkeys_mock = mock_authenticator_pubkeys(
+            &mut server,
+            &[
+                Some(existing_pubkey.as_str()),
+                None,
+                Some(other_pubkey.as_str()),
+            ],
+            1,
+        )
+        .await;
 
         let pubkeys = authenticator
             .get_authenticator_pubkeys()

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -868,6 +868,8 @@ mod tests {
         use world_id_core::primitives::ServiceEndpoint;
         use world_id_proof::artifacts::dummy::DummyZkArtifactSource;
 
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let packed_account_mock = server
             .mock("POST", "/packed-account")
             .with_status(200)
@@ -1020,11 +1022,6 @@ mod tests {
         let (authenticator, root) = test_authenticator(&mut server).await;
         let existing_pubkey = encoded_pubkey(&TEST_SEED);
         let new_pubkey = encoded_pubkey(&[2u8; 32]);
-        let new_pubkey_u256 = U256::from_str_radix(
-            new_pubkey.strip_prefix("0x").expect("0x-prefixed"),
-            16,
-        )
-        .expect("valid U256");
 
         let nonce_mock = server
             .mock("POST", "/signature-nonce")
@@ -1054,12 +1051,16 @@ mod tests {
             .await;
         let insert_mock = server
             .mock("POST", "/insert-authenticator")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            .match_body(mockito::Matcher::JsonString(serde_json::json!({
                 "leaf_index": "0x2a",
-                "new_authenticator_address": Address::ZERO.to_string(),
+                "new_authenticator_address": "0x0000000000000000000000000000000000000000",
+                "old_offchain_signer_commitment": "0x25621ac3b8119fa030714e263a607e3ce2c1a9c28e1fcd2109b976b64c4c5758",
+                "new_offchain_signer_commitment": "0x14e70bb77e346fedbd4ab09b2dba10265794ed0e8b4cf1f378a3a8668489acf1",
+                "signature": "0x414f2149d1729181056d61f518e5d3eee9a56b57daf8f909f95b639b852cd6ae50a5298a21d1d48920c903bbd8b21cdbd7be17a4d07a33c4c35946ecba8c19d01b",
+                "nonce": "0x0",
                 "pubkey_id": "0x1",
-                "new_authenticator_pubkey": format!("{new_pubkey_u256:#x}")
-            })))
+                "new_authenticator_pubkey": "0x9ffe38af11bfff8fb9fa44121b6f2ed5572917df56634c785911dd8ac991f65e"
+            }).to_string()))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1123,14 +1124,12 @@ mod tests {
         let (authenticator, root) = test_authenticator(&mut server).await;
         let existing_pubkey = encoded_pubkey(&TEST_SEED);
         let removed_pubkey = encoded_pubkey(&[2u8; 32]);
-        let removed_pubkey_u256 = U256::from_str_radix(
-            removed_pubkey.strip_prefix("0x").expect("0x-prefixed"),
-            16,
-        )
-        .expect("valid U256");
 
         let nonce_mock = server
             .mock("POST", "/signature-nonce")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(serde_json::json!({ "signature_nonce": "0x1" }).to_string())
@@ -1138,6 +1137,9 @@ mod tests {
             .await;
         let pubkeys_mock = server
             .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1151,12 +1153,16 @@ mod tests {
             .await;
         let remove_mock = server
             .mock("POST", "/remove-authenticator")
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            .match_body(mockito::Matcher::JsonString(serde_json::json!({
                 "leaf_index": "0x2a",
-                "authenticator_address": Address::ZERO.to_string(),
+                "authenticator_address": "0x0000000000000000000000000000000000000000",
+                "old_offchain_signer_commitment": "0x14e70bb77e346fedbd4ab09b2dba10265794ed0e8b4cf1f378a3a8668489acf1",
+                "new_offchain_signer_commitment": "0x25621ac3b8119fa030714e263a607e3ce2c1a9c28e1fcd2109b976b64c4c5758",
+                "signature": "0x1abd59abf790df476662f6bbde31e7bd75c90d53ff69e6f2d69eb76acec98d1f0abe1df0e170528f015be0422bdda8db98cc6466e1f67f53c12d373edc0515e31c",
+                "nonce": "0x1",
                 "pubkey_id": "0x1",
-                "authenticator_pubkey": format!("{removed_pubkey_u256:#x}")
-            })))
+                "authenticator_pubkey": "0x9ffe38af11bfff8fb9fa44121b6f2ed5572917df56634c785911dd8ac991f65e"
+            }).to_string()))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -10,10 +10,10 @@ use ruint::aliases::U256;
 use ruint_uniffi::Uint256;
 use std::sync::Arc;
 use world_id_core::{
-    api_types::{GatewayErrorCode, GatewayRequestState},
+    api_types::{GatewayErrorCode, GatewayRequestId, GatewayRequestState},
     primitives::{AuthenticatorPublicKeySet, Config},
     Authenticator as CoreAuthenticator, Credential as CoreCredential, CredentialInput,
-    InitializingAuthenticator as CoreInitializingAuthenticator,
+    EdDSAPublicKey, InitializingAuthenticator as CoreInitializingAuthenticator,
     OnchainKeyRepresentable, Signer,
 };
 
@@ -50,6 +50,29 @@ impl Authenticator {
             store,
         })
     }
+}
+
+fn parse_authenticator_pubkey(
+    encoded_pubkey: &str,
+) -> Result<EdDSAPublicKey, WalletKitError> {
+    let invalid_input = |reason: String| WalletKitError::InvalidInput {
+        attribute: "new_authenticator_pubkey".to_string(),
+        reason,
+    };
+    let hex = encoded_pubkey.strip_prefix("0x").ok_or_else(|| {
+        invalid_input("Public key must be a 0x-prefixed 32-byte hex string".to_string())
+    })?;
+
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_input(
+            "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
+        ));
+    }
+
+    let encoded = U256::from_str_radix(hex, 16)
+        .map_err(|error| invalid_input(error.to_string()))?;
+    EdDSAPublicKey::from_compressed_bytes(encoded.to_le_bytes())
+        .map_err(|error| invalid_input(error.to_string()))
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -232,6 +255,80 @@ impl Authenticator {
         let request_id = self.inner.revert_recovery_agent_update().await?;
 
         Ok(request_id.to_string())
+    }
+
+    /// Inserts an authenticator into the holder's World ID account.
+    ///
+    /// # Arguments
+    /// * `new_authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
+    ///   as a `0x`-prefixed, zero-padded 32-byte hex string.
+    /// * `new_authenticator_address` — the Ethereum address associated with the
+    ///   new authenticator. Callers may pass the zero address for a proving-only
+    ///   authenticator.
+    ///
+    /// # Errors
+    /// - Returns [`WalletKitError::InvalidInput`] if the public key or address is
+    ///   invalid.
+    /// - Returns a network error if an indexer or gateway request fails.
+    pub async fn insert_authenticator(
+        &self,
+        new_authenticator_pubkey: String,
+        new_authenticator_address: String,
+    ) -> Result<String, WalletKitError> {
+        let new_authenticator_pubkey =
+            parse_authenticator_pubkey(&new_authenticator_pubkey)?;
+        let new_authenticator_address = Address::parse_from_ffi(
+            &new_authenticator_address,
+            "new_authenticator_address",
+        )?;
+
+        let request_id = self
+            .inner
+            .insert_authenticator(new_authenticator_pubkey, new_authenticator_address)
+            .await?;
+
+        Ok(request_id.to_string())
+    }
+
+    /// Removes an authenticator from the holder's World ID account.
+    ///
+    /// # Arguments
+    /// * `authenticator_address` — the Ethereum address associated with the
+    ///   authenticator being removed.
+    /// * `pubkey_id` — the stable key-set slot of the authenticator being removed.
+    ///
+    /// # Errors
+    /// - Returns [`WalletKitError::InvalidInput`] if the address is invalid.
+    /// - Returns a network error if an indexer or gateway request fails.
+    pub async fn remove_authenticator(
+        &self,
+        authenticator_address: String,
+        pubkey_id: u32,
+    ) -> Result<String, WalletKitError> {
+        let authenticator_address =
+            Address::parse_from_ffi(&authenticator_address, "authenticator_address")?;
+
+        let request_id = self
+            .inner
+            .remove_authenticator(authenticator_address, pubkey_id)
+            .await?;
+
+        Ok(request_id.to_string())
+    }
+
+    /// Polls the gateway once for the status of an account operation.
+    ///
+    /// # Errors
+    /// Returns a network error if the gateway request fails.
+    pub async fn poll_status(
+        &self,
+        request_id: String,
+    ) -> Result<GatewayRequestStatus, WalletKitError> {
+        let request_id = GatewayRequestId::new(
+            request_id.strip_prefix("gw_").unwrap_or(&request_id),
+        );
+        let status = self.inner.poll_status(&request_id).await?;
+        Ok(status.into())
     }
 }
 
@@ -510,6 +607,47 @@ pub enum RegistrationStatus {
     },
 }
 
+/// Status of an account operation submitted through the gateway.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum GatewayRequestStatus {
+    /// Request queued but not yet batched.
+    Queued,
+    /// Request currently being batched.
+    Batching,
+    /// Request submitted on-chain.
+    Submitted {
+        /// Transaction hash emitted when the request was submitted.
+        tx_hash: String,
+    },
+    /// Request finalized on-chain.
+    Finalized {
+        /// Transaction hash emitted when the request was finalized.
+        tx_hash: String,
+    },
+    /// Request failed during processing.
+    Failed {
+        /// Error message returned by the gateway.
+        error: String,
+        /// Specific error code, if available.
+        error_code: Option<String>,
+    },
+}
+
+impl From<GatewayRequestState> for GatewayRequestStatus {
+    fn from(state: GatewayRequestState) -> Self {
+        match state {
+            GatewayRequestState::Queued => Self::Queued,
+            GatewayRequestState::Batching => Self::Batching,
+            GatewayRequestState::Submitted { tx_hash } => Self::Submitted { tx_hash },
+            GatewayRequestState::Finalized { tx_hash } => Self::Finalized { tx_hash },
+            GatewayRequestState::Failed { error, error_code } => Self::Failed {
+                error,
+                error_code: error_code.map(|code| code.to_string()),
+            },
+        }
+    }
+}
+
 impl From<GatewayRequestState> for RegistrationStatus {
     fn from(state: GatewayRequestState) -> Self {
         match state {
@@ -720,6 +858,59 @@ pub fn recovery_data_from_seed(seed: &[u8]) -> Result<RecoveryData, WalletKitErr
 mod tests {
     use super::*;
 
+    const TEST_SEED: [u8; 32] = [1u8; 32];
+
+    async fn test_authenticator(
+        server: &mut mockito::Server,
+    ) -> (Authenticator, std::path::PathBuf) {
+        use crate::storage::tests_utils::{temp_root_path, InMemoryStorageProvider};
+        use alloy::primitives::address;
+        use world_id_core::primitives::ServiceEndpoint;
+        use world_id_proof::artifacts::dummy::DummyZkArtifactSource;
+
+        let packed_account_mock = server
+            .mock("POST", "/packed-account")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "packed_account_data": "0x2a" }).to_string())
+            .create_async()
+            .await;
+        let config = Config::new(
+            None,
+            480,
+            address!("0x969947cFED008bFb5e3F32a25A1A2CDdf64d46fe"),
+            ServiceEndpoint::direct(server.url()),
+            ServiceEndpoint::direct(server.url()),
+            vec![],
+            2,
+        )
+        .expect("valid config");
+        let root = temp_root_path();
+        let provider = InMemoryStorageProvider::new(&root);
+        let store =
+            CredentialStore::from_provider(&provider).expect("credential store");
+        let authenticator = Authenticator::init_with_config(
+            &TEST_SEED,
+            config,
+            Arc::new(DummyZkArtifactSource),
+            Arc::new(store),
+        )
+        .await
+        .expect("authenticator should initialize");
+        packed_account_mock.assert_async().await;
+
+        (authenticator, root)
+    }
+
+    fn encoded_pubkey(seed: &[u8; 32]) -> String {
+        let pubkey = Signer::from_seed_bytes(seed)
+            .expect("valid seed")
+            .offchain_signer_pubkey()
+            .to_ethereum_representation()
+            .expect("public key should encode");
+        format!("{pubkey:#066x}")
+    }
+
     #[test]
     fn test_recovery_data_from_seed() {
         let seed = [1u8; 32];
@@ -740,6 +931,256 @@ mod tests {
     fn test_recovery_data_rejects_invalid_seed() {
         assert!(RecoveryData::from_seed(&[0u8; 16]).is_err());
         assert!(RecoveryData::from_seed(&[]).is_err());
+    }
+
+    #[test]
+    fn test_gateway_request_status_preserves_payloads() {
+        assert_eq!(
+            GatewayRequestStatus::from(GatewayRequestState::Submitted {
+                tx_hash: "0xsubmitted".to_string(),
+            }),
+            GatewayRequestStatus::Submitted {
+                tx_hash: "0xsubmitted".to_string(),
+            }
+        );
+        assert_eq!(
+            GatewayRequestStatus::from(GatewayRequestState::Finalized {
+                tx_hash: "0xfinalized".to_string(),
+            }),
+            GatewayRequestStatus::Finalized {
+                tx_hash: "0xfinalized".to_string(),
+            }
+        );
+        assert_eq!(
+            GatewayRequestStatus::from(GatewayRequestState::Failed {
+                error: "request failed".to_string(),
+                error_code: Some(GatewayErrorCode::BadRequest),
+            }),
+            GatewayRequestStatus::Failed {
+                error: "request failed".to_string(),
+                error_code: Some("bad_request".to_string()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authenticator_account_ops_reject_invalid_ffi_inputs() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+
+        let invalid_pubkey = authenticator
+            .insert_authenticator(
+                "not-a-public-key".to_string(),
+                Address::ZERO.to_string(),
+            )
+            .await;
+        assert!(matches!(
+            invalid_pubkey,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "new_authenticator_pubkey"
+        ));
+        assert!(matches!(
+            parse_authenticator_pubkey(&format!("0x{}", "ff".repeat(32))),
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "new_authenticator_pubkey"
+        ));
+
+        let invalid_insert_address = authenticator
+            .insert_authenticator(
+                encoded_pubkey(&[2u8; 32]),
+                "not-an-address".to_string(),
+            )
+            .await;
+        assert!(matches!(
+            invalid_insert_address,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "new_authenticator_address"
+        ));
+
+        let invalid_remove_address = authenticator
+            .remove_authenticator("not-an-address".to_string(), 0)
+            .await;
+        assert!(matches!(
+            invalid_remove_address,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "authenticator_address"
+        ));
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_insert_authenticator_constructs_request_and_polls_status() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+        let new_pubkey = encoded_pubkey(&[2u8; 32]);
+        let new_pubkey_u256 = U256::from_str_radix(
+            new_pubkey.strip_prefix("0x").expect("0x-prefixed"),
+            16,
+        )
+        .expect("valid U256");
+
+        let nonce_mock = server
+            .mock("POST", "/signature-nonce")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "signature_nonce": "0x0" }).to_string())
+            .create_async()
+            .await;
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": [existing_pubkey],
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let insert_mock = server
+            .mock("POST", "/insert-authenticator")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "leaf_index": "0x2a",
+                "new_authenticator_address": Address::ZERO.to_string(),
+                "pubkey_id": "0x1",
+                "new_authenticator_pubkey": format!("{new_pubkey_u256:#x}")
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "request_id": "gw_insert_test",
+                    "kind": "insert_authenticator",
+                    "status": { "state": "queued" }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let request_id = authenticator
+            .insert_authenticator(new_pubkey, Address::ZERO.to_string())
+            .await
+            .expect("insert should succeed");
+        assert_eq!(request_id, "gw_insert_test");
+        nonce_mock.assert_async().await;
+        pubkeys_mock.assert_async().await;
+        insert_mock.assert_async().await;
+
+        let status_mock = server
+            .mock("GET", "/status/gw_insert_test")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "request_id": "gw_insert_test",
+                    "kind": "insert_authenticator",
+                    "status": {
+                        "state": "finalized",
+                        "tx_hash": "0x1234"
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let status = authenticator
+            .poll_status(request_id)
+            .await
+            .expect("status poll should succeed");
+        assert_eq!(
+            status,
+            GatewayRequestStatus::Finalized {
+                tx_hash: "0x1234".to_string()
+            }
+        );
+        status_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_remove_authenticator_constructs_request() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+        let removed_pubkey = encoded_pubkey(&[2u8; 32]);
+        let removed_pubkey_u256 = U256::from_str_radix(
+            removed_pubkey.strip_prefix("0x").expect("0x-prefixed"),
+            16,
+        )
+        .expect("valid U256");
+
+        let nonce_mock = server
+            .mock("POST", "/signature-nonce")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "signature_nonce": "0x1" }).to_string())
+            .create_async()
+            .await;
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": [existing_pubkey, removed_pubkey],
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let remove_mock = server
+            .mock("POST", "/remove-authenticator")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "leaf_index": "0x2a",
+                "authenticator_address": Address::ZERO.to_string(),
+                "pubkey_id": "0x1",
+                "authenticator_pubkey": format!("{removed_pubkey_u256:#x}")
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "request_id": "gw_remove_test",
+                    "kind": "remove_authenticator",
+                    "status": { "state": "queued" }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let request_id = authenticator
+            .remove_authenticator(Address::ZERO.to_string(), 1)
+            .await
+            .expect("remove should succeed");
+        assert_eq!(request_id, "gw_remove_test");
+        nonce_mock.assert_async().await;
+        pubkeys_mock.assert_async().await;
+        remove_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
     }
 
     #[cfg(feature = "embed-zkeys")]

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -308,6 +308,31 @@ impl Authenticator {
         Ok(())
     }
 
+    /// Returns whether the holder's account already contains an authenticator
+    /// public key.
+    ///
+    /// This performs a read-only indexer fetch and does not submit an account
+    /// operation.
+    ///
+    /// # Arguments
+    /// * `authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
+    ///   as a `0x`-prefixed, zero-padded 32-byte hex string.
+    ///
+    /// # Errors
+    /// - Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
+    /// - Returns a network error if the indexer request fails.
+    pub async fn has_authenticator_pubkey(
+        &self,
+        authenticator_pubkey: String,
+    ) -> Result<bool, WalletKitError> {
+        let authenticator_pubkey = parse_authenticator_pubkey(authenticator_pubkey)?;
+        let pubkeys = self.inner.fetch_authenticator_pubkeys().await?;
+        Ok(pubkeys
+            .iter()
+            .flatten()
+            .any(|existing_pubkey| existing_pubkey == &authenticator_pubkey))
+    }
+
     /// Removes an authenticator from the holder's World ID account.
     ///
     /// # Arguments
@@ -1140,6 +1165,46 @@ mod tests {
             }
         );
         status_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_has_authenticator_pubkey_reads_indexer_without_writing() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": [existing_pubkey.clone()],
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .expect(2)
+            .create_async()
+            .await;
+
+        assert!(authenticator
+            .has_authenticator_pubkey(existing_pubkey)
+            .await
+            .expect("keyset read should succeed"));
+        assert!(!authenticator
+            .has_authenticator_pubkey(encoded_pubkey(&[2u8; 32]))
+            .await
+            .expect("absent key check should succeed"));
+        pubkeys_mock.assert_async().await;
 
         drop(server);
         cleanup_test_storage(&root);

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -11,7 +11,7 @@ use ruint_uniffi::Uint256;
 use std::sync::Arc;
 use world_id_core::{
     api_types::{GatewayErrorCode, GatewayRequestId, GatewayRequestState},
-    primitives::{AuthenticatorPublicKeySet, Config},
+    primitives::{AuthenticatorPublicKeySet, Config, MAX_AUTHENTICATOR_KEYS},
     Authenticator as CoreAuthenticator, AuthenticatorError,
     Credential as CoreCredential, CredentialInput, EdDSAPublicKey,
     InitializingAuthenticator as CoreInitializingAuthenticator,
@@ -74,8 +74,29 @@ fn parse_authenticator_pubkey(
 
     let encoded = U256::from_str_radix(hex, 16)
         .map_err(|error| invalid_input(error.to_string()))?;
-    EdDSAPublicKey::from_compressed_bytes(encoded.to_le_bytes())
-        .map_err(|error| invalid_input(error.to_string()))
+    let pubkey = EdDSAPublicKey::from_compressed_bytes(encoded.to_le_bytes())
+        .map_err(|error| invalid_input(error.to_string()))?;
+
+    // `from_compressed_bytes` accepts the curve's neutral element and a
+    // sign-bit alias of it. Empty key-set slots hash as the neutral element
+    // on-chain (a slot holding it is commitment-indistinguishable from an
+    // empty slot, and it is unusable for verification), so reject it and any
+    // encoding that does not round-trip to the canonical form.
+    let canonical = pubkey
+        .to_ethereum_representation()
+        .map_err(|error| invalid_input(error.to_string()))?;
+    if canonical != encoded {
+        return Err(invalid_input(
+            "Public key is not the canonical compressed point encoding".to_string(),
+        ));
+    }
+    if canonical == U256::from(1u64) {
+        return Err(invalid_input(
+            "Public key must not be the BabyJubJub identity point".to_string(),
+        ));
+    }
+
+    Ok(pubkey)
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -273,6 +294,11 @@ impl Authenticator {
     /// - Returns [`WalletKitError::InvalidInput`] if the public key or address is
     ///   invalid.
     /// - Returns a network error if an indexer or gateway request fails.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "gateway_insert_authenticator",
+        skip_all
+    )]
     pub async fn insert_authenticator(
         &self,
         new_authenticator_pubkey: String,
@@ -308,6 +334,11 @@ impl Authenticator {
     /// # Errors
     /// - Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
     /// - Returns a network error if the indexer request fails.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "indexer_authenticator_pubkeys",
+        skip_all
+    )]
     pub async fn has_authenticator_pubkey(
         &self,
         authenticator_pubkey: String,
@@ -334,6 +365,11 @@ impl Authenticator {
     /// # Errors
     /// - Returns a network error if the indexer request fails.
     /// - Returns an error if a stored public key cannot be encoded.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "indexer_authenticator_pubkeys",
+        skip_all
+    )]
     pub async fn get_authenticator_pubkeys(
         &self,
     ) -> Result<Vec<Option<String>>, WalletKitError> {
@@ -361,15 +397,24 @@ impl Authenticator {
     /// * `expected_authenticator_pubkey` — the compressed `BabyJubJub` public key
     ///   the caller intends to remove, encoded as a `0x`-prefixed, zero-padded
     ///   32-byte hex string. The removal is refused if `pubkey_id` currently
-    ///   holds a different key, so a caller acting on a stale key-set view (see
-    ///   [`Self::get_authenticator_pubkeys`]) cannot remove the wrong
-    ///   authenticator. The registry's signature-nonce and leaf checks reject
-    ///   the operation if the key set changes after this check.
+    ///   holds a different key, catching callers acting on a stale key-set view
+    ///   (see [`Self::get_authenticator_pubkeys`]). This check is best-effort:
+    ///   the signing flow re-reads the key set afterwards, so a concurrent
+    ///   change to the slot between the check and that read can still remove
+    ///   whichever key the slot holds at signing time. Callers that need an
+    ///   exact-target guarantee must serialize account operations across the
+    ///   account's authenticators.
     ///
     /// # Errors
     /// - Returns [`WalletKitError::InvalidInput`] if the address or public key
-    ///   is invalid, if the slot is empty, or if the slot holds a different key.
+    ///   is invalid, if `pubkey_id` is out of range, if the slot is empty, or
+    ///   if the slot holds a different key.
     /// - Returns a network error if an indexer or gateway request fails.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "gateway_remove_authenticator",
+        skip_all
+    )]
     pub async fn remove_authenticator(
         &self,
         authenticator_address: String,
@@ -382,6 +427,16 @@ impl Authenticator {
         )?;
         let authenticator_address =
             Address::parse_from_ffi(&authenticator_address, "authenticator_address")?;
+
+        if pubkey_id as usize >= MAX_AUTHENTICATOR_KEYS {
+            return Err(WalletKitError::InvalidInput {
+                attribute: "pubkey_id".to_string(),
+                reason: format!(
+                    "pubkey_id {pubkey_id} is out of range; the key set has at \
+                     most {MAX_AUTHENTICATOR_KEYS} slots"
+                ),
+            });
+        }
 
         let empty_slot = || WalletKitError::InvalidInput {
             attribute: "pubkey_id".to_string(),
@@ -417,6 +472,11 @@ impl Authenticator {
     ///
     /// # Errors
     /// Returns a network error if the gateway request fails.
+    #[tracing::instrument(
+        target = "walletkit_latency",
+        name = "gateway_poll",
+        skip_all
+    )]
     pub async fn poll_status(
         &self,
         request_id: String,
@@ -941,24 +1001,32 @@ impl RecoveryData {
 }
 
 /// Validates an authenticator public key without submitting an account
-/// operation.
+/// operation, returning its canonical encoding.
 ///
 /// This is a free function (not a method on [`Authenticator`]) so consumers
 /// can validate a key — e.g. one scanned during pairing — before an
 /// `Authenticator` exists.
+///
+/// The returned string is the canonical form of the key (lowercase,
+/// `0x`-prefixed, zero-padded 32-byte hex), byte-identical to the entries
+/// returned by [`Authenticator::get_authenticator_pubkeys`]. Use it — not the
+/// raw input — for string comparisons against key-set entries.
 ///
 /// # Arguments
 /// * `authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
 ///   as a `0x`-prefixed, zero-padded 32-byte hex string.
 ///
 /// # Errors
-/// Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
+/// Returns [`WalletKitError::InvalidInput`] if the public key is invalid,
+/// is not in canonical form, or is the `BabyJubJub` identity point.
 #[uniffi::export]
 pub fn validate_authenticator_pubkey(
     authenticator_pubkey: &str,
-) -> Result<(), WalletKitError> {
-    parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
-    Ok(())
+) -> Result<String, WalletKitError> {
+    let pubkey =
+        parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
+    let encoded = pubkey.to_ethereum_representation()?;
+    Ok(format!("{encoded:#066x}"))
 }
 
 /// Derives recovery data from a 32-byte seed.
@@ -1117,7 +1185,30 @@ mod tests {
                 if attribute == "authenticator_pubkey"
         ));
 
-        assert!(validate_authenticator_pubkey(&encoded_pubkey(&[2u8; 32])).is_ok());
+        let canonical = encoded_pubkey(&[2u8; 32]);
+        assert_eq!(
+            validate_authenticator_pubkey(&canonical).expect("valid key"),
+            canonical
+        );
+        let uppercase = format!("0x{}", canonical[2..].to_uppercase());
+        assert_eq!(
+            validate_authenticator_pubkey(&uppercase)
+                .expect("uppercase hex should canonicalize"),
+            canonical
+        );
+
+        let identity = format!("0x{}01", "0".repeat(62));
+        assert!(matches!(
+            validate_authenticator_pubkey(&identity),
+            Err(WalletKitError::InvalidInput { attribute, reason })
+                if attribute == "authenticator_pubkey" && reason.contains("identity")
+        ));
+        let sign_bit_alias = format!("0x80{}01", "0".repeat(60));
+        assert!(matches!(
+            validate_authenticator_pubkey(&sign_bit_alias),
+            Err(WalletKitError::InvalidInput { attribute, reason })
+                if attribute == "authenticator_pubkey" && reason.contains("canonical")
+        ));
 
         let invalid_insert_address = authenticator
             .insert_authenticator(
@@ -1395,7 +1486,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(
                 serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey, slot_pubkey],
+                    "authenticator_pubkeys": [existing_pubkey, null, slot_pubkey],
                     "offchain_signer_commitment": "0x0"
                 })
                 .to_string(),
@@ -1417,7 +1508,7 @@ mod tests {
         let mismatched = authenticator
             .remove_authenticator(
                 Address::ZERO.to_string(),
-                1,
+                2,
                 encoded_pubkey(&[3u8; 32]),
             )
             .await;
@@ -1430,14 +1521,28 @@ mod tests {
         let empty_slot = authenticator
             .remove_authenticator(
                 Address::ZERO.to_string(),
-                7,
+                1,
                 encoded_pubkey(&[3u8; 32]),
             )
             .await;
         assert!(matches!(
             empty_slot,
-            Err(WalletKitError::InvalidInput { attribute, .. })
+            Err(WalletKitError::InvalidInput { attribute, reason })
                 if attribute == "pubkey_id"
+                    && reason.contains("no authenticator at key set slot 1")
+        ));
+
+        let out_of_range = authenticator
+            .remove_authenticator(
+                Address::ZERO.to_string(),
+                7,
+                encoded_pubkey(&[3u8; 32]),
+            )
+            .await;
+        assert!(matches!(
+            out_of_range,
+            Err(WalletKitError::InvalidInput { attribute, reason })
+                if attribute == "pubkey_id" && reason.contains("out of range")
         ));
 
         pubkeys_mock.assert_async().await;
@@ -1487,6 +1592,137 @@ mod tests {
             vec![Some(existing_pubkey), None, Some(other_pubkey)]
         );
         pubkeys_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_poll_status_surfaces_gateway_5xx_as_network_error() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+
+        let status_mock = server
+            .mock("GET", "/status/gw_unavailable")
+            .with_status(503)
+            .with_body("batcher unavailable")
+            .create_async()
+            .await;
+
+        let result = authenticator
+            .poll_status("gw_unavailable".to_string())
+            .await;
+        assert!(matches!(
+            result,
+            Err(WalletKitError::NetworkError {
+                url,
+                status: Some(503),
+                ..
+            }) if url == "gateway"
+        ));
+        status_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_get_authenticator_pubkeys_surfaces_indexer_5xx_as_network_error() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .with_status(500)
+            .with_body("indexer unavailable")
+            .create_async()
+            .await;
+
+        let result = authenticator.get_authenticator_pubkeys().await;
+        assert!(matches!(
+            result,
+            Err(WalletKitError::NetworkError {
+                url,
+                status: Some(500),
+                ..
+            }) if url == "indexer"
+        ));
+        pubkeys_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_remove_authenticator_reports_slot_emptied_during_signing() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+        let removed_pubkey = encoded_pubkey(&[2u8; 32]);
+
+        // The first read (the wrapper's guard) sees the key at slot 1; the
+        // second read (the crate's own signing fetch) sees the slot already
+        // emptied, as if a concurrent operation landed in between. The
+        // `PublicKeyNotFound` this produces must surface as the `pubkey_id`
+        // input error, not as an authorization failure.
+        let full_body = serde_json::json!({
+            "authenticator_pubkeys": [existing_pubkey.clone(), removed_pubkey.clone()],
+            "offchain_signer_commitment": "0x0"
+        })
+        .to_string();
+        let emptied_body = serde_json::json!({
+            "authenticator_pubkeys": [existing_pubkey],
+            "offchain_signer_commitment": "0x0"
+        })
+        .to_string();
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let fetches_in_mock = Arc::clone(&fetches);
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body_from_request(move |_request| {
+                if fetches_in_mock.fetch_add(1, Ordering::SeqCst) == 0 {
+                    full_body.clone().into_bytes()
+                } else {
+                    emptied_body.clone().into_bytes()
+                }
+            })
+            .expect(2)
+            .create_async()
+            .await;
+        let nonce_mock = server
+            .mock("POST", "/signature-nonce")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "signature_nonce": "0x1" }).to_string())
+            .create_async()
+            .await;
+        let remove_mock = server
+            .mock("POST", "/remove-authenticator")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let raced = authenticator
+            .remove_authenticator(Address::ZERO.to_string(), 1, removed_pubkey)
+            .await;
+        assert!(matches!(
+            raced,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "pubkey_id"
+        ));
+
+        pubkeys_mock.assert_async().await;
+        nonce_mock.assert_async().await;
+        remove_mock.assert_async().await;
 
         drop(server);
         cleanup_test_storage(&root);

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -53,31 +53,6 @@ impl Authenticator {
     }
 }
 
-fn parse_authenticator_pubkey(
-    attribute: &str,
-    encoded_pubkey: impl AsRef<str>,
-) -> Result<EdDSAPublicKey, WalletKitError> {
-    let encoded_pubkey = encoded_pubkey.as_ref();
-    let invalid_input = |reason: String| WalletKitError::InvalidInput {
-        attribute: attribute.to_string(),
-        reason,
-    };
-    let hex = encoded_pubkey.strip_prefix("0x").ok_or_else(|| {
-        invalid_input("Public key must be a 0x-prefixed 32-byte hex string".to_string())
-    })?;
-
-    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err(invalid_input(
-            "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
-        ));
-    }
-
-    let encoded = U256::from_str_radix(hex, 16)
-        .map_err(|error| invalid_input(error.to_string()))?;
-    EdDSAPublicKey::from_compressed_bytes(encoded.to_le_bytes())
-        .map_err(|error| invalid_input(error.to_string()))
-}
-
 #[uniffi::export(async_runtime = "tokio")]
 impl Authenticator {
     /// Returns the packed account data for the holder's World ID.
@@ -278,9 +253,9 @@ impl Authenticator {
         new_authenticator_pubkey: String,
         new_authenticator_address: String,
     ) -> Result<String, WalletKitError> {
-        let new_authenticator_pubkey = parse_authenticator_pubkey(
+        let new_authenticator_pubkey = EdDSAPublicKey::parse_from_ffi(
+            &new_authenticator_pubkey,
             "new_authenticator_pubkey",
-            new_authenticator_pubkey,
         )?;
         let new_authenticator_address = Address::parse_from_ffi(
             &new_authenticator_address,
@@ -306,9 +281,9 @@ impl Authenticator {
     /// Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
     pub fn validate_authenticator_pubkey(
         &self,
-        authenticator_pubkey: String,
+        authenticator_pubkey: &str,
     ) -> Result<(), WalletKitError> {
-        parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
+        EdDSAPublicKey::parse_from_ffi(authenticator_pubkey, "authenticator_pubkey")?;
         Ok(())
     }
 
@@ -329,8 +304,10 @@ impl Authenticator {
         &self,
         authenticator_pubkey: String,
     ) -> Result<bool, WalletKitError> {
-        let authenticator_pubkey =
-            parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
+        let authenticator_pubkey = EdDSAPublicKey::parse_from_ffi(
+            &authenticator_pubkey,
+            "authenticator_pubkey",
+        )?;
         let pubkeys = self.inner.fetch_authenticator_pubkeys().await?;
         Ok(pubkeys
             .iter()
@@ -393,9 +370,9 @@ impl Authenticator {
         pubkey_id: u32,
         expected_authenticator_pubkey: String,
     ) -> Result<String, WalletKitError> {
-        let expected_pubkey = parse_authenticator_pubkey(
+        let expected_pubkey = EdDSAPublicKey::parse_from_ffi(
+            &expected_authenticator_pubkey,
             "expected_authenticator_pubkey",
-            expected_authenticator_pubkey,
         )?;
         let authenticator_address =
             Address::parse_from_ffi(&authenticator_address, "authenticator_address")?;
@@ -1098,15 +1075,15 @@ mod tests {
                 if attribute == "new_authenticator_pubkey"
         ));
         assert!(matches!(
-            parse_authenticator_pubkey(
-                "new_authenticator_pubkey",
-                format!("0x{}", "ff".repeat(32))
+            EdDSAPublicKey::parse_from_ffi(
+                &format!("0x{}", "ff".repeat(32)),
+                "new_authenticator_pubkey"
             ),
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"
         ));
         let invalid_decoded_pubkey = authenticator
-            .validate_authenticator_pubkey(format!("0x{}", "ff".repeat(32)));
+            .validate_authenticator_pubkey(&format!("0x{}", "ff".repeat(32)));
         assert!(matches!(
             invalid_decoded_pubkey,
             Err(WalletKitError::InvalidInput { attribute, .. })
@@ -1114,7 +1091,7 @@ mod tests {
         ));
 
         assert!(authenticator
-            .validate_authenticator_pubkey(encoded_pubkey(&[2u8; 32]))
+            .validate_authenticator_pubkey(&encoded_pubkey(&[2u8; 32]))
             .is_ok());
 
         let invalid_insert_address = authenticator

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -12,8 +12,9 @@ use std::sync::Arc;
 use world_id_core::{
     api_types::{GatewayErrorCode, GatewayRequestId, GatewayRequestState},
     primitives::{AuthenticatorPublicKeySet, Config},
-    Authenticator as CoreAuthenticator, Credential as CoreCredential, CredentialInput,
-    EdDSAPublicKey, InitializingAuthenticator as CoreInitializingAuthenticator,
+    Authenticator as CoreAuthenticator, AuthenticatorError,
+    Credential as CoreCredential, CredentialInput, EdDSAPublicKey,
+    InitializingAuthenticator as CoreInitializingAuthenticator,
     OnchainKeyRepresentable, Signer,
 };
 
@@ -53,11 +54,12 @@ impl Authenticator {
 }
 
 fn parse_authenticator_pubkey(
+    attribute: &str,
     encoded_pubkey: impl AsRef<str>,
 ) -> Result<EdDSAPublicKey, WalletKitError> {
     let encoded_pubkey = encoded_pubkey.as_ref();
     let invalid_input = |reason: String| WalletKitError::InvalidInput {
-        attribute: "new_authenticator_pubkey".to_string(),
+        attribute: attribute.to_string(),
         reason,
     };
     let hex = encoded_pubkey.strip_prefix("0x").ok_or_else(|| {
@@ -276,8 +278,10 @@ impl Authenticator {
         new_authenticator_pubkey: String,
         new_authenticator_address: String,
     ) -> Result<String, WalletKitError> {
-        let new_authenticator_pubkey =
-            parse_authenticator_pubkey(new_authenticator_pubkey)?;
+        let new_authenticator_pubkey = parse_authenticator_pubkey(
+            "new_authenticator_pubkey",
+            new_authenticator_pubkey,
+        )?;
         let new_authenticator_address = Address::parse_from_ffi(
             &new_authenticator_address,
             "new_authenticator_address",
@@ -304,7 +308,7 @@ impl Authenticator {
         &self,
         authenticator_pubkey: String,
     ) -> Result<(), WalletKitError> {
-        parse_authenticator_pubkey(authenticator_pubkey)?;
+        parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
         Ok(())
     }
 
@@ -325,7 +329,8 @@ impl Authenticator {
         &self,
         authenticator_pubkey: String,
     ) -> Result<bool, WalletKitError> {
-        let authenticator_pubkey = parse_authenticator_pubkey(authenticator_pubkey)?;
+        let authenticator_pubkey =
+            parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
         let pubkeys = self.inner.fetch_authenticator_pubkeys().await?;
         Ok(pubkeys
             .iter()
@@ -333,28 +338,94 @@ impl Authenticator {
             .any(|existing_pubkey| existing_pubkey == &authenticator_pubkey))
     }
 
+    /// Returns the account's authenticator public keys, indexed by key-set slot.
+    ///
+    /// Each entry is the compressed `BabyJubJub` public key at that slot encoded
+    /// as a `0x`-prefixed, zero-padded 32-byte hex string, or `None` for an
+    /// empty slot. A key's position in this list is the `pubkey_id` expected by
+    /// [`Self::remove_authenticator`].
+    ///
+    /// This performs a read-only indexer fetch and does not submit an account
+    /// operation.
+    ///
+    /// # Errors
+    /// - Returns a network error if the indexer request fails.
+    /// - Returns an error if a stored public key cannot be encoded.
+    pub async fn get_authenticator_pubkeys(
+        &self,
+    ) -> Result<Vec<Option<String>>, WalletKitError> {
+        let key_set = self.inner.fetch_authenticator_pubkeys().await?;
+        key_set
+            .iter()
+            .map(|slot| {
+                slot.as_ref()
+                    .map(|pubkey| {
+                        let encoded = pubkey.to_ethereum_representation()?;
+                        Ok(format!("{encoded:#066x}"))
+                    })
+                    .transpose()
+            })
+            .collect()
+    }
+
     /// Removes an authenticator from the holder's World ID account.
     ///
     /// # Arguments
     /// * `authenticator_address` — the Ethereum address associated with the
-    ///   authenticator being removed.
+    ///   authenticator being removed. Callers must pass the zero address for a
+    ///   proving-only authenticator.
     /// * `pubkey_id` — the stable key-set slot of the authenticator being removed.
+    /// * `expected_authenticator_pubkey` — the compressed `BabyJubJub` public key
+    ///   the caller intends to remove, encoded as a `0x`-prefixed, zero-padded
+    ///   32-byte hex string. The removal is refused if `pubkey_id` currently
+    ///   holds a different key, so a caller acting on a stale key-set view (see
+    ///   [`Self::get_authenticator_pubkeys`]) cannot remove the wrong
+    ///   authenticator. The registry's signature-nonce and leaf checks reject
+    ///   the operation if the key set changes after this check.
     ///
     /// # Errors
-    /// - Returns [`WalletKitError::InvalidInput`] if the address is invalid.
+    /// - Returns [`WalletKitError::InvalidInput`] if the address or public key
+    ///   is invalid, if the slot is empty, or if the slot holds a different key.
     /// - Returns a network error if an indexer or gateway request fails.
     pub async fn remove_authenticator(
         &self,
         authenticator_address: String,
         pubkey_id: u32,
+        expected_authenticator_pubkey: String,
     ) -> Result<String, WalletKitError> {
+        let expected_pubkey = parse_authenticator_pubkey(
+            "expected_authenticator_pubkey",
+            expected_authenticator_pubkey,
+        )?;
         let authenticator_address =
             Address::parse_from_ffi(&authenticator_address, "authenticator_address")?;
+
+        let empty_slot = || WalletKitError::InvalidInput {
+            attribute: "pubkey_id".to_string(),
+            reason: format!("no authenticator at key set slot {pubkey_id}"),
+        };
+        let key_set = self.inner.fetch_authenticator_pubkeys().await?;
+        let actual_pubkey = key_set.get(pubkey_id as usize).ok_or_else(empty_slot)?;
+        if actual_pubkey != &expected_pubkey {
+            return Err(WalletKitError::InvalidInput {
+                attribute: "expected_authenticator_pubkey".to_string(),
+                reason: format!(
+                    "key set slot {pubkey_id} holds a different authenticator public key"
+                ),
+            });
+        }
 
         let request_id = self
             .inner
             .remove_authenticator(authenticator_address, pubkey_id)
-            .await?;
+            .await
+            .map_err(|error| match error {
+                // The slot emptied between the check above and the crate's own
+                // signing read; report it as the input problem it is rather
+                // than an authorization failure.
+                AuthenticatorError::PublicKeyNotFound => empty_slot(),
+                other => other.into(),
+            })?;
 
         Ok(request_id.to_string())
     }
@@ -1027,7 +1098,10 @@ mod tests {
                 if attribute == "new_authenticator_pubkey"
         ));
         assert!(matches!(
-            parse_authenticator_pubkey(format!("0x{}", "ff".repeat(32))),
+            parse_authenticator_pubkey(
+                "new_authenticator_pubkey",
+                format!("0x{}", "ff".repeat(32))
+            ),
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"
         ));
@@ -1036,7 +1110,7 @@ mod tests {
         assert!(matches!(
             invalid_decoded_pubkey,
             Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "new_authenticator_pubkey"
+                if attribute == "authenticator_pubkey"
         ));
 
         assert!(authenticator
@@ -1056,12 +1130,29 @@ mod tests {
         ));
 
         let invalid_remove_address = authenticator
-            .remove_authenticator("not-an-address".to_string(), 0)
+            .remove_authenticator(
+                "not-an-address".to_string(),
+                0,
+                encoded_pubkey(&[2u8; 32]),
+            )
             .await;
         assert!(matches!(
             invalid_remove_address,
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "authenticator_address"
+        ));
+
+        let invalid_expected_pubkey = authenticator
+            .remove_authenticator(
+                Address::ZERO.to_string(),
+                0,
+                "not-a-public-key".to_string(),
+            )
+            .await;
+        assert!(matches!(
+            invalid_expected_pubkey,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "expected_authenticator_pubkey"
         ));
 
         drop(server);
@@ -1238,11 +1329,12 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(
                 serde_json::json!({
-                    "authenticator_pubkeys": [existing_pubkey, removed_pubkey],
+                    "authenticator_pubkeys": [existing_pubkey, removed_pubkey.clone()],
                     "offchain_signer_commitment": "0x0"
                 })
                 .to_string(),
             )
+            .expect(2)
             .create_async()
             .await;
         let remove_mock = server
@@ -1271,13 +1363,128 @@ mod tests {
             .await;
 
         let request_id = authenticator
-            .remove_authenticator(Address::ZERO.to_string(), 1)
+            .remove_authenticator(Address::ZERO.to_string(), 1, removed_pubkey)
             .await
             .expect("remove should succeed");
         assert_eq!(request_id, "gw_remove_test");
         nonce_mock.assert_async().await;
         pubkeys_mock.assert_async().await;
         remove_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_remove_authenticator_refuses_unexpected_slot_contents() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+        let slot_pubkey = encoded_pubkey(&[2u8; 32]);
+
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": [existing_pubkey, slot_pubkey],
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .expect(2)
+            .create_async()
+            .await;
+        let nonce_mock = server
+            .mock("POST", "/signature-nonce")
+            .expect(0)
+            .create_async()
+            .await;
+        let remove_mock = server
+            .mock("POST", "/remove-authenticator")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mismatched = authenticator
+            .remove_authenticator(
+                Address::ZERO.to_string(),
+                1,
+                encoded_pubkey(&[3u8; 32]),
+            )
+            .await;
+        assert!(matches!(
+            mismatched,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "expected_authenticator_pubkey"
+        ));
+
+        let empty_slot = authenticator
+            .remove_authenticator(
+                Address::ZERO.to_string(),
+                7,
+                encoded_pubkey(&[3u8; 32]),
+            )
+            .await;
+        assert!(matches!(
+            empty_slot,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "pubkey_id"
+        ));
+
+        pubkeys_mock.assert_async().await;
+        nonce_mock.assert_async().await;
+        remove_mock.assert_async().await;
+
+        drop(server);
+        cleanup_test_storage(&root);
+    }
+
+    #[tokio::test]
+    async fn test_get_authenticator_pubkeys_returns_slot_indexed_keys() {
+        use crate::storage::tests_utils::cleanup_test_storage;
+
+        let mut server = mockito::Server::new_async().await;
+        let (authenticator, root) = test_authenticator(&mut server).await;
+        let existing_pubkey = encoded_pubkey(&TEST_SEED);
+        let other_pubkey = encoded_pubkey(&[2u8; 32]);
+
+        let pubkeys_mock = server
+            .mock("POST", "/authenticator-pubkeys")
+            .match_body(mockito::Matcher::JsonString(
+                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "authenticator_pubkeys": [
+                        existing_pubkey.clone(),
+                        null,
+                        other_pubkey.clone()
+                    ],
+                    "offchain_signer_commitment": "0x0"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let pubkeys = authenticator
+            .get_authenticator_pubkeys()
+            .await
+            .expect("key set read should succeed");
+        assert_eq!(
+            pubkeys,
+            vec![Some(existing_pubkey), None, Some(other_pubkey)]
+        );
+        pubkeys_mock.assert_async().await;
 
         drop(server);
         cleanup_test_storage(&root);

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -1148,36 +1148,6 @@ mod tests {
         assert!(RecoveryData::from_seed(&[]).is_err());
     }
 
-    #[test]
-    fn test_gateway_request_status_preserves_payloads() {
-        assert_eq!(
-            GatewayRequestStatus::from(GatewayRequestState::Submitted {
-                tx_hash: "0xsubmitted".to_string(),
-            }),
-            GatewayRequestStatus::Submitted {
-                tx_hash: "0xsubmitted".to_string(),
-            }
-        );
-        assert_eq!(
-            GatewayRequestStatus::from(GatewayRequestState::Finalized {
-                tx_hash: "0xfinalized".to_string(),
-            }),
-            GatewayRequestStatus::Finalized {
-                tx_hash: "0xfinalized".to_string(),
-            }
-        );
-        assert_eq!(
-            GatewayRequestStatus::from(GatewayRequestState::Failed {
-                error: "request failed".to_string(),
-                error_code: Some(GatewayErrorCode::BadRequest),
-            }),
-            GatewayRequestStatus::Failed {
-                error: "request failed".to_string(),
-                error_code: Some("bad_request".to_string()),
-            }
-        );
-    }
-
     #[tokio::test]
     async fn test_authenticator_account_ops_reject_invalid_ffi_inputs() {
         use crate::storage::tests_utils::cleanup_test_storage;
@@ -1193,14 +1163,6 @@ mod tests {
             .await;
         assert!(matches!(
             invalid_pubkey,
-            Err(WalletKitError::InvalidInput { attribute, .. })
-                if attribute == "new_authenticator_pubkey"
-        ));
-        assert!(matches!(
-            parse_authenticator_pubkey(
-                "new_authenticator_pubkey",
-                format!("0x{}", "ff".repeat(32))
-            ),
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"
         ));
@@ -1372,101 +1334,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_has_authenticator_pubkey_reads_indexer_without_writing() {
-        use crate::storage::tests_utils::cleanup_test_storage;
-
-        let mut server = mockito::Server::new_async().await;
-        let (authenticator, root) = test_authenticator(&mut server).await;
-        let existing_pubkey = encoded_pubkey(&TEST_SEED);
-
-        let pubkeys_mock = mock_authenticator_pubkeys(
-            &mut server,
-            &[Some(existing_pubkey.as_str())],
-            2,
-        )
-        .await;
-
-        assert!(authenticator
-            .has_authenticator_pubkey(existing_pubkey)
-            .await
-            .expect("keyset read should succeed"));
-        assert!(!authenticator
-            .has_authenticator_pubkey(encoded_pubkey(&[2u8; 32]))
-            .await
-            .expect("absent key check should succeed"));
-        pubkeys_mock.assert_async().await;
-
-        drop(server);
-        cleanup_test_storage(&root);
-    }
-
-    #[tokio::test]
-    async fn test_remove_authenticator_constructs_request() {
-        use crate::storage::tests_utils::cleanup_test_storage;
-
-        let mut server = mockito::Server::new_async().await;
-        let (authenticator, root) = test_authenticator(&mut server).await;
-        let existing_pubkey = encoded_pubkey(&TEST_SEED);
-        let removed_pubkey = encoded_pubkey(&[2u8; 32]);
-
-        let nonce_mock = server
-            .mock("POST", "/signature-nonce")
-            .match_body(mockito::Matcher::JsonString(
-                serde_json::json!({ "leaf_index": "0x2a" }).to_string(),
-            ))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(serde_json::json!({ "signature_nonce": "0x1" }).to_string())
-            .create_async()
-            .await;
-        let pubkeys_mock = mock_authenticator_pubkeys(
-            &mut server,
-            &[
-                Some(existing_pubkey.as_str()),
-                Some(removed_pubkey.as_str()),
-            ],
-            2,
-        )
-        .await;
-        let remove_mock = server
-            .mock("POST", "/remove-authenticator")
-            .match_body(mockito::Matcher::JsonString(serde_json::json!({
-                "leaf_index": "0x2a",
-                "authenticator_address": "0x0000000000000000000000000000000000000000",
-                "old_offchain_signer_commitment": "0x14e70bb77e346fedbd4ab09b2dba10265794ed0e8b4cf1f378a3a8668489acf1",
-                "new_offchain_signer_commitment": "0x25621ac3b8119fa030714e263a607e3ce2c1a9c28e1fcd2109b976b64c4c5758",
-                "signature": "0x1abd59abf790df476662f6bbde31e7bd75c90d53ff69e6f2d69eb76acec98d1f0abe1df0e170528f015be0422bdda8db98cc6466e1f67f53c12d373edc0515e31c",
-                "nonce": "0x1",
-                "pubkey_id": "0x1",
-                "authenticator_pubkey": "0x9ffe38af11bfff8fb9fa44121b6f2ed5572917df56634c785911dd8ac991f65e"
-            }).to_string()))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                serde_json::json!({
-                    "request_id": "gw_remove_test",
-                    "kind": "remove_authenticator",
-                    "status": { "state": "queued" }
-                })
-                .to_string(),
-            )
-            .create_async()
-            .await;
-
-        let request_id = authenticator
-            .remove_authenticator(Address::ZERO.to_string(), 1, removed_pubkey)
-            .await
-            .expect("remove should succeed");
-        assert_eq!(request_id, "gw_remove_test");
-        nonce_mock.assert_async().await;
-        pubkeys_mock.assert_async().await;
-        remove_mock.assert_async().await;
-
-        drop(server);
-        cleanup_test_storage(&root);
-    }
-
-    #[tokio::test]
     async fn test_remove_authenticator_refuses_unexpected_slot_contents() {
         use crate::storage::tests_utils::cleanup_test_storage;
 
@@ -1545,7 +1412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_authenticator_pubkeys_returns_slot_indexed_keys() {
+    async fn test_key_set_reads_return_slots_and_membership() {
         use crate::storage::tests_utils::cleanup_test_storage;
 
         let mut server = mockito::Server::new_async().await;
@@ -1560,7 +1427,7 @@ mod tests {
                 None,
                 Some(other_pubkey.as_str()),
             ],
-            1,
+            3,
         )
         .await;
 
@@ -1572,6 +1439,15 @@ mod tests {
             pubkeys,
             vec![Some(existing_pubkey), None, Some(other_pubkey)]
         );
+
+        assert!(authenticator
+            .has_authenticator_pubkey(encoded_pubkey(&TEST_SEED))
+            .await
+            .expect("membership read should succeed"));
+        assert!(!authenticator
+            .has_authenticator_pubkey(encoded_pubkey(&[3u8; 32]))
+            .await
+            .expect("absent key check should succeed"));
         pubkeys_mock.assert_async().await;
 
         drop(server);
@@ -1579,7 +1455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_poll_status_surfaces_gateway_5xx_as_network_error() {
+    async fn test_account_ops_surface_5xx_as_network_errors() {
         use crate::storage::tests_utils::cleanup_test_storage;
 
         let mut server = mockito::Server::new_async().await;
@@ -1591,12 +1467,11 @@ mod tests {
             .with_body("batcher unavailable")
             .create_async()
             .await;
-
-        let result = authenticator
+        let gateway_error = authenticator
             .poll_status("gw_unavailable".to_string())
             .await;
         assert!(matches!(
-            result,
+            gateway_error,
             Err(WalletKitError::NetworkError {
                 url,
                 status: Some(503),
@@ -1605,27 +1480,15 @@ mod tests {
         ));
         status_mock.assert_async().await;
 
-        drop(server);
-        cleanup_test_storage(&root);
-    }
-
-    #[tokio::test]
-    async fn test_get_authenticator_pubkeys_surfaces_indexer_5xx_as_network_error() {
-        use crate::storage::tests_utils::cleanup_test_storage;
-
-        let mut server = mockito::Server::new_async().await;
-        let (authenticator, root) = test_authenticator(&mut server).await;
-
         let pubkeys_mock = server
             .mock("POST", "/authenticator-pubkeys")
             .with_status(500)
             .with_body("indexer unavailable")
             .create_async()
             .await;
-
-        let result = authenticator.get_authenticator_pubkeys().await;
+        let indexer_error = authenticator.get_authenticator_pubkeys().await;
         assert!(matches!(
-            result,
+            indexer_error,
             Err(WalletKitError::NetworkError {
                 url,
                 status: Some(500),

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -53,6 +53,31 @@ impl Authenticator {
     }
 }
 
+fn parse_authenticator_pubkey(
+    attribute: &str,
+    encoded_pubkey: impl AsRef<str>,
+) -> Result<EdDSAPublicKey, WalletKitError> {
+    let encoded_pubkey = encoded_pubkey.as_ref();
+    let invalid_input = |reason: String| WalletKitError::InvalidInput {
+        attribute: attribute.to_string(),
+        reason,
+    };
+    let hex = encoded_pubkey.strip_prefix("0x").ok_or_else(|| {
+        invalid_input("Public key must be a 0x-prefixed 32-byte hex string".to_string())
+    })?;
+
+    if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_input(
+            "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
+        ));
+    }
+
+    let encoded = U256::from_str_radix(hex, 16)
+        .map_err(|error| invalid_input(error.to_string()))?;
+    EdDSAPublicKey::from_compressed_bytes(encoded.to_le_bytes())
+        .map_err(|error| invalid_input(error.to_string()))
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl Authenticator {
     /// Returns the packed account data for the holder's World ID.
@@ -253,9 +278,9 @@ impl Authenticator {
         new_authenticator_pubkey: String,
         new_authenticator_address: String,
     ) -> Result<String, WalletKitError> {
-        let new_authenticator_pubkey = EdDSAPublicKey::parse_from_ffi(
-            &new_authenticator_pubkey,
+        let new_authenticator_pubkey = parse_authenticator_pubkey(
             "new_authenticator_pubkey",
+            new_authenticator_pubkey,
         )?;
         let new_authenticator_address = Address::parse_from_ffi(
             &new_authenticator_address,
@@ -287,10 +312,8 @@ impl Authenticator {
         &self,
         authenticator_pubkey: String,
     ) -> Result<bool, WalletKitError> {
-        let authenticator_pubkey = EdDSAPublicKey::parse_from_ffi(
-            &authenticator_pubkey,
-            "authenticator_pubkey",
-        )?;
+        let authenticator_pubkey =
+            parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
         let pubkeys = self.inner.fetch_authenticator_pubkeys().await?;
         Ok(pubkeys
             .iter()
@@ -353,9 +376,9 @@ impl Authenticator {
         pubkey_id: u32,
         expected_authenticator_pubkey: String,
     ) -> Result<String, WalletKitError> {
-        let expected_pubkey = EdDSAPublicKey::parse_from_ffi(
-            &expected_authenticator_pubkey,
+        let expected_pubkey = parse_authenticator_pubkey(
             "expected_authenticator_pubkey",
+            expected_authenticator_pubkey,
         )?;
         let authenticator_address =
             Address::parse_from_ffi(&authenticator_address, "authenticator_address")?;
@@ -934,7 +957,7 @@ impl RecoveryData {
 pub fn validate_authenticator_pubkey(
     authenticator_pubkey: &str,
 ) -> Result<(), WalletKitError> {
-    EdDSAPublicKey::parse_from_ffi(authenticator_pubkey, "authenticator_pubkey")?;
+    parse_authenticator_pubkey("authenticator_pubkey", authenticator_pubkey)?;
     Ok(())
 }
 
@@ -1079,9 +1102,9 @@ mod tests {
                 if attribute == "new_authenticator_pubkey"
         ));
         assert!(matches!(
-            EdDSAPublicKey::parse_from_ffi(
-                &format!("0x{}", "ff".repeat(32)),
-                "new_authenticator_pubkey"
+            parse_authenticator_pubkey(
+                "new_authenticator_pubkey",
+                format!("0x{}", "ff".repeat(32))
             ),
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -270,23 +270,6 @@ impl Authenticator {
         Ok(request_id.to_string())
     }
 
-    /// Validates an authenticator public key without submitting an account
-    /// operation.
-    ///
-    /// # Arguments
-    /// * `authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
-    ///   as a `0x`-prefixed, zero-padded 32-byte hex string.
-    ///
-    /// # Errors
-    /// Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
-    pub fn validate_authenticator_pubkey(
-        &self,
-        authenticator_pubkey: &str,
-    ) -> Result<(), WalletKitError> {
-        EdDSAPublicKey::parse_from_ffi(authenticator_pubkey, "authenticator_pubkey")?;
-        Ok(())
-    }
-
     /// Returns whether the holder's account already contains an authenticator
     /// public key.
     ///
@@ -934,6 +917,27 @@ impl RecoveryData {
     }
 }
 
+/// Validates an authenticator public key without submitting an account
+/// operation.
+///
+/// This is a free function (not a method on [`Authenticator`]) so consumers
+/// can validate a key — e.g. one scanned during pairing — before an
+/// `Authenticator` exists.
+///
+/// # Arguments
+/// * `authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
+///   as a `0x`-prefixed, zero-padded 32-byte hex string.
+///
+/// # Errors
+/// Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
+#[uniffi::export]
+pub fn validate_authenticator_pubkey(
+    authenticator_pubkey: &str,
+) -> Result<(), WalletKitError> {
+    EdDSAPublicKey::parse_from_ffi(authenticator_pubkey, "authenticator_pubkey")?;
+    Ok(())
+}
+
 /// Derives recovery data from a 32-byte seed.
 ///
 /// This is the foreign-bindings entrypoint for recovery data generation.
@@ -1082,17 +1086,15 @@ mod tests {
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"
         ));
-        let invalid_decoded_pubkey = authenticator
-            .validate_authenticator_pubkey(&format!("0x{}", "ff".repeat(32)));
+        let invalid_decoded_pubkey =
+            validate_authenticator_pubkey(&format!("0x{}", "ff".repeat(32)));
         assert!(matches!(
             invalid_decoded_pubkey,
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "authenticator_pubkey"
         ));
 
-        assert!(authenticator
-            .validate_authenticator_pubkey(&encoded_pubkey(&[2u8; 32]))
-            .is_ok());
+        assert!(validate_authenticator_pubkey(&encoded_pubkey(&[2u8; 32])).is_ok());
 
         let invalid_insert_address = authenticator
             .insert_authenticator(

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -53,8 +53,9 @@ impl Authenticator {
 }
 
 fn parse_authenticator_pubkey(
-    encoded_pubkey: &str,
+    encoded_pubkey: impl AsRef<str>,
 ) -> Result<EdDSAPublicKey, WalletKitError> {
+    let encoded_pubkey = encoded_pubkey.as_ref();
     let invalid_input = |reason: String| WalletKitError::InvalidInput {
         attribute: "new_authenticator_pubkey".to_string(),
         reason,
@@ -276,7 +277,7 @@ impl Authenticator {
         new_authenticator_address: String,
     ) -> Result<String, WalletKitError> {
         let new_authenticator_pubkey =
-            parse_authenticator_pubkey(&new_authenticator_pubkey)?;
+            parse_authenticator_pubkey(new_authenticator_pubkey)?;
         let new_authenticator_address = Address::parse_from_ffi(
             &new_authenticator_address,
             "new_authenticator_address",
@@ -288,6 +289,23 @@ impl Authenticator {
             .await?;
 
         Ok(request_id.to_string())
+    }
+
+    /// Validates an authenticator public key without submitting an account
+    /// operation.
+    ///
+    /// # Arguments
+    /// * `authenticator_pubkey` — a compressed `BabyJubJub` public key encoded
+    ///   as a `0x`-prefixed, zero-padded 32-byte hex string.
+    ///
+    /// # Errors
+    /// Returns [`WalletKitError::InvalidInput`] if the public key is invalid.
+    pub fn validate_authenticator_pubkey(
+        &self,
+        authenticator_pubkey: String,
+    ) -> Result<(), WalletKitError> {
+        parse_authenticator_pubkey(authenticator_pubkey)?;
+        Ok(())
     }
 
     /// Removes an authenticator from the holder's World ID account.
@@ -984,10 +1002,21 @@ mod tests {
                 if attribute == "new_authenticator_pubkey"
         ));
         assert!(matches!(
-            parse_authenticator_pubkey(&format!("0x{}", "ff".repeat(32))),
+            parse_authenticator_pubkey(format!("0x{}", "ff".repeat(32))),
             Err(WalletKitError::InvalidInput { attribute, .. })
                 if attribute == "new_authenticator_pubkey"
         ));
+        let invalid_decoded_pubkey = authenticator
+            .validate_authenticator_pubkey(format!("0x{}", "ff".repeat(32)));
+        assert!(matches!(
+            invalid_decoded_pubkey,
+            Err(WalletKitError::InvalidInput { attribute, .. })
+                if attribute == "new_authenticator_pubkey"
+        ));
+
+        assert!(authenticator
+            .validate_authenticator_pubkey(encoded_pubkey(&[2u8; 32]))
+            .is_ok());
 
         let invalid_insert_address = authenticator
             .insert_authenticator(

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -63,12 +63,13 @@ fn parse_authenticator_pubkey(
         reason,
     };
     let hex = encoded_pubkey.strip_prefix("0x").ok_or_else(|| {
-        invalid_input("Public key must be a 0x-prefixed 32-byte hex string".to_string())
+        invalid_input("Public key must start with a 0x prefix".to_string())
     })?;
 
     if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(invalid_input(
-            "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
+            "Public key must be exactly 32 bytes (64 hex characters) after the 0x prefix"
+                .to_string(),
         ));
     }
 

--- a/crates/walletkit-core/src/lib.rs
+++ b/crates/walletkit-core/src/lib.rs
@@ -119,8 +119,8 @@ pub mod storage;
 
 pub mod authenticator;
 pub use authenticator::{
-    Authenticator, InitializingAuthenticator, RecoveryData, RecoveryUpdateSignature,
-    RegistrationStatus,
+    Authenticator, GatewayRequestStatus, InitializingAuthenticator, RecoveryData,
+    RecoveryUpdateSignature, RegistrationStatus,
 };
 
 /// Default configuration values for each [`Environment`].

--- a/crates/walletkit-core/src/primitives.rs
+++ b/crates/walletkit-core/src/primitives.rs
@@ -1,5 +1,7 @@
 use alloy_core::primitives::Address;
+use ruint::aliases::U256;
 use std::str::FromStr;
+use world_id_core::EdDSAPublicKey;
 
 use crate::error::WalletKitError;
 
@@ -25,7 +27,13 @@ pub trait ParseFromForeignBinding {
         attr: &'static str,
     ) -> Result<Option<Self>, WalletKitError>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        if let Some(s) = s {
+            return Self::parse_from_ffi(s.as_str(), attr).map(Some);
+        }
+        Ok(None)
+    }
 }
 
 impl ParseFromForeignBinding for Address {
@@ -35,13 +43,31 @@ impl ParseFromForeignBinding for Address {
             reason: e.to_string(),
         })
     }
-    fn parse_from_ffi_optional(
-        s: Option<String>,
-        attr: &'static str,
-    ) -> Result<Option<Self>, WalletKitError> {
-        if let Some(s) = s {
-            return Self::parse_from_ffi(s.as_str(), attr).map(Some);
+}
+
+impl ParseFromForeignBinding for EdDSAPublicKey {
+    /// Parses a compressed `BabyJubJub` public key from a `0x`-prefixed,
+    /// zero-padded 32-byte hex string.
+    fn parse_from_ffi(s: &str, attr: &'static str) -> Result<Self, WalletKitError> {
+        let invalid_input = |reason: String| WalletKitError::InvalidInput {
+            attribute: attr.to_string(),
+            reason,
+        };
+        let hex = s.strip_prefix("0x").ok_or_else(|| {
+            invalid_input(
+                "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
+            )
+        })?;
+
+        if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(invalid_input(
+                "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
+            ));
         }
-        Ok(None)
+
+        let encoded = U256::from_str_radix(hex, 16)
+            .map_err(|error| invalid_input(error.to_string()))?;
+        Self::from_compressed_bytes(encoded.to_le_bytes())
+            .map_err(|error| invalid_input(error.to_string()))
     }
 }

--- a/crates/walletkit-core/src/primitives.rs
+++ b/crates/walletkit-core/src/primitives.rs
@@ -1,7 +1,5 @@
 use alloy_core::primitives::Address;
-use ruint::aliases::U256;
 use std::str::FromStr;
-use world_id_core::EdDSAPublicKey;
 
 use crate::error::WalletKitError;
 
@@ -27,13 +25,7 @@ pub trait ParseFromForeignBinding {
         attr: &'static str,
     ) -> Result<Option<Self>, WalletKitError>
     where
-        Self: Sized,
-    {
-        if let Some(s) = s {
-            return Self::parse_from_ffi(s.as_str(), attr).map(Some);
-        }
-        Ok(None)
-    }
+        Self: Sized;
 }
 
 impl ParseFromForeignBinding for Address {
@@ -43,31 +35,13 @@ impl ParseFromForeignBinding for Address {
             reason: e.to_string(),
         })
     }
-}
-
-impl ParseFromForeignBinding for EdDSAPublicKey {
-    /// Parses a compressed `BabyJubJub` public key from a `0x`-prefixed,
-    /// zero-padded 32-byte hex string.
-    fn parse_from_ffi(s: &str, attr: &'static str) -> Result<Self, WalletKitError> {
-        let invalid_input = |reason: String| WalletKitError::InvalidInput {
-            attribute: attr.to_string(),
-            reason,
-        };
-        let hex = s.strip_prefix("0x").ok_or_else(|| {
-            invalid_input(
-                "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
-            )
-        })?;
-
-        if hex.len() != 64 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            return Err(invalid_input(
-                "Public key must be a 0x-prefixed 32-byte hex string".to_string(),
-            ));
+    fn parse_from_ffi_optional(
+        s: Option<String>,
+        attr: &'static str,
+    ) -> Result<Option<Self>, WalletKitError> {
+        if let Some(s) = s {
+            return Self::parse_from_ffi(s.as_str(), attr).map(Some);
         }
-
-        let encoded = U256::from_str_radix(hex, 16)
-            .map_err(|error| invalid_input(error.to_string()))?;
-        Self::from_compressed_bytes(encoded.to_le_bytes())
-            .map_err(|error| invalid_input(error.to_string()))
+        Ok(None)
     }
 }


### PR DESCRIPTION
## Summary

`world-id-core` already supports the WIP-104 authenticator account operations, but WalletKit did not expose them through UniFFI. This PR adds the account-management surface needed by Swift and Kotlin consumers to pair, inspect, revoke, and track authenticators without reaching into Rust internals.

## What changed

- Add `insert_authenticator`, which validates an authenticator public key and address, submits the account operation, and returns the gateway request ID.
- Add slot-preserving `get_authenticator_pubkeys` and `has_authenticator_pubkey` reads. Empty slots remain `None`, so each list position is the `pubkey_id` accepted by removal.
- Add `remove_authenticator`, which accepts the authenticator address, slot ID, and expected public key. It rejects malformed input, out-of-range or empty slots, and an already-mismatched slot before submitting the operation.
- Add single-shot `poll_status` plus the UniFFI-visible `GatewayRequestStatus` enum. Queued, batching, submitted, finalized, and failed states are exposed to mobile callers, including transaction hashes and gateway error details where available. Request IDs are accepted with or without the `gw_` prefix.
- Add the standalone `validate_authenticator_pubkey` function so pairing flows can validate scanned keys before constructing an `Authenticator`. It returns the canonical `0x`-prefixed, zero-padded encoding and rejects malformed points, non-canonical encodings, and the BabyJubJub identity point.
- Add `walletkit_latency` spans to all new indexer and gateway calls.

## Testing

- `cargo fmt --all --check`
- `cargo test -p walletkit-core --lib` — 135 passed
- Focused coverage for public-key normalization and rejection, prefixed and unprefixed status polling, slot-preserving reads and membership, removal refusal paths, and the slot-emptied-during-signing error mapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect on-chain account key-set mutations and cryptographic input validation; removal is best-effort against stale views with documented concurrency limits.
> 
> **Overview**
> Exposes **WIP-104 authenticator account management** to Swift/Kotlin by wiring existing `world-id-core` flows through the WalletKit UniFFI `Authenticator` surface.
> 
> Mobile callers can **add** (`insert_authenticator`), **list** slot-indexed keys (`get_authenticator_pubkeys`), **check membership** (`has_authenticator_pubkey`), and **remove** (`remove_authenticator`) authenticators, each returning or using gateway request IDs. Removal validates `pubkey_id`, empty slots, and an **expected pubkey** against a fresh indexer read, with `PublicKeyNotFound` during signing mapped to slot-empty input errors.
> 
> Shared **`parse_authenticator_pubkey`** enforces `0x`-prefixed 32-byte BabyJubJub keys (canonical encoding, rejects identity / alias points). **`validate_authenticator_pubkey`** exposes the same rules pre-`Authenticator` for pairing. **`poll_status`** plus exported **`GatewayRequestStatus`** (including tx hashes) track gateway operations; request IDs accept optional `gw_` prefix. New **`walletkit_latency`** spans cover indexer/gateway calls, with Mockito tests for validation, polling, reads, and removal guard paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d378f26a8064384f110db7253cff19cbe623fcc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->