### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @Dzejkop @kilianglas @paolodamico @Takaros999 @Guardiola31337 @danielle-tfh @philsippl @murph
+CODEOWNERS @philsippl @murph @paolodamico @Dzejkop @kilianglas


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Repository metadata only; no runtime or application behavior changes.
> 
> **Overview**
> Adds a new **`.github/CODEOWNERS`** file so GitHub can automatically request reviews on pull requests.
> 
> The default rule (`*`) assigns **@Dzejkop**, **@kilianglas**, **@paolodamico**, **@Takaros999**, **@Guardiola31337**, **@danielle-tfh**, **@philsippl**, and **@murph** as owners for all paths. Changes to **`CODEOWNERS`** itself are owned by **@philsippl**, **@murph**, **@paolodamico**, **@Dzejkop**, and **@kilianglas**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9893734c7e7d96afd9649d5b4110a9d5a12957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->