### PR TITLE
disclosed claims - small cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2644,6 +2644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,7 +2709,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2878,7 +2884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3796,7 +3802,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4191,6 +4197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,7 +4367,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4914,6 +4926,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -5713,7 +5735,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6241,7 +6263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6321,7 +6343,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7584,7 +7606,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8494,7 +8516,9 @@ dependencies = [
  "hex",
  "hkdf",
  "log",
+ "maplit",
  "mockito",
+ "pretty_assertions",
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
@@ -8749,7 +8773,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9269,6 +9293,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ hex = "0.4"
 hkdf = "0.12"
 log = "0.4"
 mockito = "1.6"
+maplit = "1"
+pretty_assertions = "1"
 rand = "0.8.6"
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false }

--- a/crates/walletkit-core/Cargo.toml
+++ b/crates/walletkit-core/Cargo.toml
@@ -78,6 +78,8 @@ chrono = { workspace = true }
 dotenvy = { workspace = true }
 eyre = { workspace = true }
 mockito = { workspace = true }
+maplit = { workspace = true }
+pretty_assertions = { workspace = true }
 regex = { workspace = true }
 taceo-oprf = { workspace = true, features = [
   "types",

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -8,10 +8,11 @@ use crate::{
 use alloy_core::primitives::Address;
 use ruint::aliases::U256;
 use ruint_uniffi::Uint256;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use world_id_core::{
     api_types::{GatewayErrorCode, GatewayRequestId, GatewayRequestState},
     primitives::{AuthenticatorPublicKeySet, Config, MAX_AUTHENTICATOR_KEYS},
+    requests::ProofResponse as CoreProofResponse,
     Authenticator as CoreAuthenticator, AuthenticatorError,
     Credential as CoreCredential, CredentialInput, EdDSAPublicKey,
     InitializingAuthenticator as CoreInitializingAuthenticator,
@@ -598,7 +599,7 @@ impl Authenticator {
         let claims_by_schema = if disclose_claims {
             claims_by_issuer_schema(&credentials, &result.proof_response)
         } else {
-            std::collections::HashMap::new()
+            HashMap::new()
         };
 
         Ok(ProofResponse::with_disclosed_claims(
@@ -646,28 +647,24 @@ fn resolve_now(now: Option<u64>) -> Result<u64, WalletKitError> {
 /// schema id yields exactly the credential its proof was generated against.
 fn claims_by_issuer_schema(
     credentials: &[CredentialInput],
-    proof_response: &world_id_core::requests::ProofResponse,
-) -> std::collections::HashMap<u64, Vec<String>> {
+    proof_response: &CoreProofResponse,
+) -> HashMap<u64, Vec<String>> {
     proof_response
         .responses
         .iter()
         .filter_map(|item| {
-            credentials
+            let input = credentials.iter().find(|input| {
+                input.credential.issuer_schema_id == item.issuer_schema_id
+            })?;
+
+            let claims = input
+                .credential
+                .claims
                 .iter()
-                .find(|input| {
-                    input.credential.issuer_schema_id == item.issuer_schema_id
-                })
-                .map(|input| {
-                    (
-                        item.issuer_schema_id,
-                        input
-                            .credential
-                            .claims
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect(),
-                    )
-                })
+                .map(ToString::to_string)
+                .collect();
+
+            Some((item.issuer_schema_id, claims))
         })
         .collect()
 }
@@ -1149,6 +1146,87 @@ mod tests {
     use super::*;
 
     const TEST_SEED: [u8; 32] = [1u8; 32];
+
+    fn credential_input(
+        issuer_schema_id: u64,
+        claim_hashes: &[u64],
+    ) -> CredentialInput {
+        let credential = claim_hashes.iter().enumerate().fold(
+            CoreCredential::new().issuer_schema_id(issuer_schema_id),
+            |credential, (index, claim_hash)| {
+                credential
+                    .claim_hash(index, U256::from(*claim_hash))
+                    .expect("claim index should be valid")
+            },
+        );
+
+        CredentialInput {
+            credential,
+            blinding_factor: 1u64.into(),
+        }
+    }
+
+    fn proof_response_with_schemas(issuer_schema_ids: &[u64]) -> CoreProofResponse {
+        let responses = issuer_schema_ids
+            .iter()
+            .enumerate()
+            .map(|(index, issuer_schema_id)| {
+                serde_json::json!({
+                    "identifier": format!("credential-{index}"),
+                    "issuer_schema_id": issuer_schema_id,
+                    "proof": "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
+                    "nullifier": format!("nil_{:064x}", index + 1),
+                    "expires_at_min": 1_700_000_000,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        serde_json::from_value(serde_json::json!({
+            "id": "test_response",
+            "version": 1,
+            "responses": responses,
+        }))
+        .expect("response fixture should parse")
+    }
+
+    #[test]
+    fn claims_by_issuer_schema_returns_claims_for_each_proven_credential() {
+        let credentials = vec![
+            credential_input(100, &[1, 2]),
+            credential_input(200, &[3, 4]),
+        ];
+        let response = proof_response_with_schemas(&[200, 100]);
+
+        let claims = claims_by_issuer_schema(&credentials, &response);
+
+        assert_eq!(claims.len(), 2);
+        assert_eq!(
+            &claims[&100][..2],
+            [
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000000000000000000000000000002",
+            ]
+        );
+        assert_eq!(
+            &claims[&200][..2],
+            [
+                "0x0000000000000000000000000000000000000000000000000000000000000003",
+                "0x0000000000000000000000000000000000000000000000000000000000000004",
+            ]
+        );
+    }
+
+    #[test]
+    fn claims_by_issuer_schema_omits_response_items_without_a_credential() {
+        let credentials = vec![credential_input(100, &[1])];
+        let response = proof_response_with_schemas(&[100, 999]);
+
+        let claims = claims_by_issuer_schema(&credentials, &response);
+
+        assert_eq!(claims.len(), 1);
+        assert!(claims.contains_key(&100));
+        assert!(!claims.contains_key(&999));
+    }
 
     async fn test_authenticator(
         server: &mut mockito::Server,

--- a/crates/walletkit-core/src/requests.rs
+++ b/crates/walletkit-core/src/requests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use world_id_core::requests::{
     ProofRequest as CoreProofRequest, ProofResponse as CoreProofResponse,
 };
@@ -58,7 +60,7 @@ pub struct ProofResponse {
     /// Claims of the credential used for each response item, keyed by issuer
     /// schema id and hex-encoded. Populated only by
     /// `Authenticator::generate_proof_disclosing_claims`; empty otherwise.
-    disclosed_claims: std::collections::HashMap<u64, Vec<String>>,
+    disclosed_claims: HashMap<u64, Vec<String>>,
 }
 
 #[uniffi::export]
@@ -74,16 +76,11 @@ impl ProofResponse {
     /// # Errors
     /// Returns an error if serialization fails.
     pub fn to_json(&self) -> Result<String, WalletKitError> {
-        let serialization_error = |e: serde_json::Error| WalletKitError::Generic {
-            error: format!("critical unexpected error serializing to json: {e}"),
-        };
-        if self.disclosed_claims.is_empty() {
-            return serde_json::to_string(&self.inner).map_err(serialization_error);
-        }
-        let mut value =
-            serde_json::to_value(&self.inner).map_err(serialization_error)?;
-        inject_claims(&mut value, &self.disclosed_claims);
-        serde_json::to_string(&value).map_err(serialization_error)
+        self.to_json_value()
+            .and_then(|v| serde_json::to_string(&v))
+            .map_err(|e| WalletKitError::Generic {
+                error: format!("critical unexpected error serializing to json: {e}"),
+            })
     }
 
     /// Returns the unique identifier for this response.
@@ -111,7 +108,7 @@ impl ProofResponse {
     #[must_use]
     pub(crate) const fn with_disclosed_claims(
         inner: CoreProofResponse,
-        disclosed_claims: std::collections::HashMap<u64, Vec<String>>,
+        disclosed_claims: HashMap<u64, Vec<String>>,
     ) -> Self {
         Self {
             inner,
@@ -130,13 +127,25 @@ impl ProofResponse {
     pub fn into_inner(self) -> CoreProofResponse {
         self.inner
     }
+
+    fn to_json_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        if self.disclosed_claims.is_empty() {
+            serde_json::to_value(&self.inner)
+        } else {
+            // TODO: Temporary workaround while we're figuring out the exact mechanism for claim
+            //       disclosure/use
+            let mut value = serde_json::to_value(&self.inner)?;
+            inject_claims(&mut value, &self.disclosed_claims);
+            Ok(value)
+        }
+    }
 }
 
 /// Inserts a `claims` array into every serialized response item whose
 /// `issuer_schema_id` has disclosed claims.
 fn inject_claims(
     value: &mut serde_json::Value,
-    disclosed_claims: &std::collections::HashMap<u64, Vec<String>>,
+    disclosed_claims: &HashMap<u64, Vec<String>>,
 ) {
     let Some(items) = value
         .get_mut("responses")
@@ -152,6 +161,7 @@ fn inject_claims(
         else {
             continue;
         };
+
         if let Some(item) = item.as_object_mut() {
             item.insert(
                 "claims".to_string(),
@@ -174,7 +184,7 @@ impl From<CoreProofRequest> for ProofRequest {
 
 impl From<CoreProofResponse> for ProofResponse {
     fn from(core_response: CoreProofResponse) -> Self {
-        Self::with_disclosed_claims(core_response, std::collections::HashMap::new())
+        Self::with_disclosed_claims(core_response, HashMap::new())
     }
 }
 
@@ -182,10 +192,14 @@ impl From<CoreProofResponse> for ProofResponse {
 mod tests {
     use alloy::signers::{local::PrivateKeySigner, SignerSync};
     use alloy_core::primitives::U160;
+    use pretty_assertions::assert_eq;
     use serde_json::Value;
     use world_id_core::{
-        primitives::{rp::RpId, FieldElement, OprfKeyId, SessionRef},
-        requests::{ProofType, RequestItem, RequestVersion},
+        primitives::{
+            rp::RpId, FieldElement, Nullifier, OprfKeyId, SessionRef,
+            ZeroKnowledgeProof,
+        },
+        requests::{ProofType, RequestItem, RequestVersion, ResponseItem},
     };
 
     use super::*;
@@ -223,75 +237,105 @@ mod tests {
     }
 
     fn base_core_response() -> CoreProofResponse {
-        let json = r#"{
-  "id": "test_response",
-  "version": 1,
-  "responses": [
-    {
-      "identifier": "orb",
-      "issuer_schema_id": 100,
-      "proof": "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
-      "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003e9",
-      "expires_at_min": 1700000000
-    },
-    {
-      "identifier": "face",
-      "issuer_schema_id": 200,
-      "proof": "00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
-      "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003ea",
-      "expires_at_min": 1700000000
-    }
-  ]
-}"#;
-        serde_json::from_str(json).expect("response fixture should parse")
+        CoreProofResponse {
+            id: "test_response".to_string(),
+            version: RequestVersion::V1,
+            session_id: None,
+            error: None,
+            responses: vec![
+                ResponseItem::new_uniqueness(
+                    "orb".to_string(),
+                    100,
+                    ZeroKnowledgeProof::default(),
+                    Nullifier::new(FieldElement::from(1_001u64)),
+                    1_700_000_000,
+                ),
+                ResponseItem::new_uniqueness(
+                    "face".to_string(),
+                    200,
+                    ZeroKnowledgeProof::default(),
+                    Nullifier::new(FieldElement::from(1_002u64)),
+                    1_700_000_000,
+                ),
+            ],
+        }
     }
 
     #[test]
     fn to_json_without_disclosure_matches_core_serialization() {
         let core = base_core_response();
-        let expected =
-            serde_json::to_string(&core).expect("core response should serialize");
+        let expected = serde_json::json!({
+            "id": "test_response",
+            "version": 1,
+            "responses": [
+                {
+                    "identifier": "orb",
+                    "issuer_schema_id": 100,
+                    "proof": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003e9",
+                    "expires_at_min": 1_700_000_000,
+                },
+                {
+                    "identifier": "face",
+                    "issuer_schema_id": 200,
+                    "proof": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003ea",
+                    "expires_at_min": 1_700_000_000,
+                },
+            ],
+        });
 
         let wrapped: ProofResponse = core.into();
         let json = wrapped.to_json().expect("wrapper should serialize");
+        let actual: Value =
+            serde_json::from_str(&json).expect("wrapper output should be valid json");
 
-        assert_eq!(json, expected);
+        assert_eq!(actual, expected);
         assert!(!json.contains("claims"));
     }
 
     #[test]
     fn to_json_injects_disclosed_claims_on_matching_items_only() {
-        let claims = std::collections::HashMap::from([(
-            200u64,
-            vec![
+        let claims = maplit::hashmap! {
+            200 => vec![
                 "0x0000000000000000000000000000000000000000000000000000000000000001"
                     .to_string(),
                 "0x0000000000000000000000000000000000000000000000000000000000000002"
                     .to_string(),
             ],
-        )]);
+        };
         let wrapped =
             ProofResponse::with_disclosed_claims(base_core_response(), claims);
 
-        let value: Value =
+        let expected = serde_json::json!({
+            "id": "test_response",
+            "version": 1,
+            "responses": [
+                {
+                    "identifier": "orb",
+                    "issuer_schema_id": 100,
+                    "proof": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003e9",
+                    "expires_at_min": 1_700_000_000,
+                },
+                {
+                    "identifier": "face",
+                    "issuer_schema_id": 200,
+                    "proof": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "nullifier": "nil_00000000000000000000000000000000000000000000000000000000000003ea",
+                    "expires_at_min": 1_700_000_000,
+                    "claims": [
+                        "0x0000000000000000000000000000000000000000000000000000000000000001",
+                        "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    ],
+                },
+            ],
+        });
+        let actual: Value =
             serde_json::from_str(&wrapped.to_json().expect("wrapper should serialize"))
                 .expect("output should be valid json");
 
-        let items = value["responses"].as_array().expect("responses array");
-        assert!(
-            items[0].get("claims").is_none(),
-            "item without disclosed claims must stay untouched"
-        );
-        let disclosed = items[1]["claims"].as_array().expect("claims array");
-        assert_eq!(disclosed.len(), 2);
-        assert_eq!(
-            disclosed[0],
-            "0x0000000000000000000000000000000000000000000000000000000000000001"
-        );
-        assert_eq!(
-            disclosed[1],
-            "0x0000000000000000000000000000000000000000000000000000000000000002"
-        );
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
- **feat: generate_proof_disclosing_claims attaches credential claims to the response JSON**
- **cleanup**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in disclosure exposes raw credential claim values that are explicitly not bound by the ZK proof; misuse could leak PII if callers skip the documented transport/integrity constraints.
> 
> **Overview**
> Adds **`Authenticator::generate_proof_disclosing_claims`**, an opt-in path alongside existing **`generate_proof`** that still runs the same proof flow but, when serializing **`ProofResponse`**, injects a per-item **`claims`** array (hex field elements in schema order) matched by **`issuer_schema_id`** from the stored credentials used for proving.
> 
> **`ProofResponse`** is no longer a public tuple wrapper: it keeps the core protocol payload in **`inner`**, optional disclosed claims in a side map, and **`to_json`** only adds **`claims`** when disclosure was requested—standard proofs stay byte-identical to core JSON. **`resolve_now`** and shared **`generate_proof_impl`** consolidate timestamp handling and proof assembly.
> 
> The CLI e2e proof test now passes **`proof_response.inner()`** into on-chain verification so injected JSON fields do not affect verifier input. Unit tests cover claim mapping and serialization; dev-only **`maplit`** / **`pretty_assertions`** were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659d70b03686263df423958ef056ff172514c904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->