### PR TITLE
feat: expose credential claims accessors and a stored-credential fetch

### DIFF
--- a/crates/walletkit-core/src/credential.rs
+++ b/crates/walletkit-core/src/credential.rs
@@ -59,6 +59,32 @@ impl Credential {
     pub fn associated_data_commitment(&self) -> FieldElement {
         self.0.associated_data_commitment.into()
     }
+
+    /// Returns the credential's raw claims, in schema order.
+    ///
+    /// Each claim is a field element; interpretation is defined by the issuer
+    /// schema ([`Self::issuer_schema_id`]). Unset slots hold the zero field
+    /// element. This exposes nothing [`Self::to_bytes`] doesn't already
+    /// serialize — it is an accessor, not a disclosure mechanism; whether and
+    /// which claims leave the device is entirely the host app's policy.
+    #[must_use]
+    pub fn claims(&self) -> Vec<std::sync::Arc<FieldElement>> {
+        self.0
+            .claims
+            .iter()
+            .map(|claim| std::sync::Arc::new((*claim).into()))
+            .collect()
+    }
+
+    /// Returns the credential's raw claims as hex-encoded, padded strings, in
+    /// schema order.
+    ///
+    /// Convenience over [`Self::claims`] using the same encoding claims carry
+    /// in credential JSON.
+    #[must_use]
+    pub fn claims_hex(&self) -> Vec<String> {
+        self.0.claims.iter().map(ToString::to_string).collect()
+    }
 }
 
 impl Credential {
@@ -97,5 +123,55 @@ impl Deref for Credential {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruint::aliases::U256;
+    use world_id_core::Credential as CoreCredential;
+
+    use super::Credential;
+
+    fn credential_with_claims() -> Credential {
+        let core = CoreCredential::new()
+            .claim_hash(0, U256::from(1u64))
+            .expect("claim 0 in bounds")
+            .claim_hash(1, U256::from(2u64))
+            .expect("claim 1 in bounds");
+        Credential(core)
+    }
+
+    #[test]
+    fn claims_expose_field_elements_in_schema_order() {
+        let credential = credential_with_claims();
+
+        let claims = credential.claims();
+        assert_eq!(claims.len(), credential.claims_hex().len());
+        assert_eq!(
+            claims[0].to_hex_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
+        assert_eq!(
+            claims[1].to_hex_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+        );
+    }
+
+    #[test]
+    fn claims_hex_matches_field_element_encoding() {
+        let credential = credential_with_claims();
+
+        let hex = credential.claims_hex();
+        let from_elements: Vec<String> = credential
+            .claims()
+            .iter()
+            .map(|claim| claim.to_hex_string())
+            .collect();
+        assert_eq!(hex, from_elements);
+
+        // Unset slots are the zero field element.
+        assert!(hex[2..].iter().all(|claim| claim
+            == "0x0000000000000000000000000000000000000000000000000000000000000000"));
     }
 }

--- a/crates/walletkit-core/src/storage/credential_storage.rs
+++ b/crates/walletkit-core/src/storage/credential_storage.rs
@@ -215,6 +215,27 @@ impl CredentialStore {
         self.lock_inner()?.list_credentials(issuer_schema_id, now)
     }
 
+    /// Retrieves the most recent non-expired credential matching the issuer
+    /// schema ID, or `None` when the store holds no usable match.
+    ///
+    /// This is the same selection `generate_proof` uses when building its
+    /// credential inputs, so fields read from the returned credential (e.g.
+    /// [`Credential::claims_hex`]) describe the credential a proof for that
+    /// schema is generated against.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the credential query fails.
+    pub fn fetch_credential(
+        &self,
+        issuer_schema_id: u64,
+        now: u64,
+    ) -> StorageResult<Option<std::sync::Arc<Credential>>> {
+        Ok(self
+            .get_credential(issuer_schema_id, now)?
+            .map(|(credential, _blinding_factor)| std::sync::Arc::new(credential)))
+    }
+
     /// Deletes a credential by ID.
     ///
     /// # Errors
@@ -1050,6 +1071,46 @@ mod tests {
         );
 
         cleanup_test_storage(&root);
+    }
+
+    #[test]
+    fn fetch_credential_returns_stored_credential_with_claims() {
+        use ruint::aliases::U256;
+        use world_id_core::Credential as CoreCredential;
+
+        let root = temp_root_path();
+        let provider = InMemoryStorageProvider::new(&root);
+        let store = CredentialStore::from_provider(&provider).expect("create store");
+        store.init(42, 1000).expect("init storage");
+
+        let blinding_factor = FieldElement::from(7u64);
+        let cred: Credential = CoreCredential::new()
+            .issuer_schema_id(100u64)
+            .genesis_issued_at(1000)
+            .claim_hash(0, U256::from(11u64))
+            .expect("claim 0 in bounds")
+            .into();
+        store
+            .store_credential(&cred, &blinding_factor, 9999, None, 1000)
+            .expect("store credential");
+
+        let fetched = store
+            .fetch_credential(100, 1000)
+            .expect("fetch should succeed")
+            .expect("credential should exist");
+        assert_eq!(fetched.issuer_schema_id(), 100);
+        assert_eq!(
+            fetched.claims_hex()[0],
+            "0x000000000000000000000000000000000000000000000000000000000000000b"
+        );
+
+        assert!(
+            store
+                .fetch_credential(200, 1000)
+                .expect("fetch should succeed")
+                .is_none(),
+            "unknown schema id should fetch no credential"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

Follow-up to the review on #487: WalletKit should not attach claims to proof responses — per @paolodamico, *the requested claim can be attached by World App in the response*, with a mechanism for requesting specific claims and user consent for sharing them. This PR provides the minimal read surface that approach needs, and nothing more:

* `Credential::claims()` / `Credential::claims_hex()` — the credential's raw claims in schema order (zero field element for unset slots).
* `CredentialStore::fetch_credential(issuer_schema_id, now)` — returns the same most-recent-non-expired credential that `generate_proof` selects its inputs from, so values read here describe the credential a proof for that schema is generated against. (The internal `get_credential` already existed; this exports it without the blinding factor, which has no reason to cross the FFI boundary.)

### Why this is not a disclosure mechanism

* The accessors expose nothing `to_bytes()` doesn't already serialize — the full credential JSON, claims included, is already available to any holder of a `Credential`. This is read-only parity with the existing `sub()` / `issuer_schema_id()` / `associated_data_commitment()` accessors.
* WalletKit's proof generation and response serialization are untouched. Whether claims leave the device, **which specific claims** are shared, and the **user consent** surfacing are entirely host-app policy — exactly the separation requested on #487, which this replaces.

### Testing

* `cargo test -p walletkit-core --lib` — 138 passed, including new tests: accessor values/encoding in schema order, zero-padding of unset slots, and `fetch_credential` returning the stored credential (claims intact) and `None` for unknown schema ids.
* clippy (pedantic) clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands FFI access to full claim vectors from vault storage; behavior is read-only and policy stays with the host app, but mishandling or over-sharing claims in the app layer is the main concern.
> 
> **Overview**
> Adds a **read-only FFI surface** so host apps (e.g. World App) can read claim values from the same stored credential used for proof generation, without WalletKit attaching claims to proof responses.
> 
> **`Credential`** gains **`claims()`** (field elements in schema order, zero for unset slots) and **`claims_hex()`** (padded hex strings matching credential JSON). Docs stress these mirror data already in **`to_bytes()`** / JSON — accessors only, not a new disclosure path.
> 
> **`CredentialStore`** exposes **`fetch_credential(issuer_schema_id, now)`**, returning the most recent non-expired credential for that schema (or `None`), aligned with internal **`get_credential`** / proof input selection but **without** the blinding factor over FFI.
> 
> New unit tests cover claim ordering/encoding and **`fetch_credential`** round-trip vs unknown schema IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592765d518d2530ac0d529227dd1483f36731996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->