### PR TITLE
refactor: make key sealing and blob storage async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8732,6 +8732,7 @@ version = "0.21.4"
 dependencies = [
  "alloy",
  "alloy-core",
+ "async-trait",
  "backon",
  "base64 0.22.1",
  "chacha20poly1305",
@@ -8781,6 +8782,7 @@ dependencies = [
 name = "walletkit-db"
 version = "0.21.4"
 dependencies = [
+ "async-trait",
  "ciborium",
  "getrandom 0.3.4",
  "hex",
@@ -8789,6 +8791,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "walletkit-sqlite",
  "zeroize",
 ]
@@ -8815,6 +8818,7 @@ version = "0.21.4"
 dependencies = [
  "alloy",
  "alloy-core",
+ "async-trait",
  "eyre",
  "rand 0.8.6",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ alloy = { version = "2", default-features = false }
 alloy-core = { version = "1", default-features = false, features = [
   "sol-types",
 ] }
+async-trait = "0.1"
 backon = "1.6"
 base64 = "0.22"
 cc = "1"

--- a/crates/walletkit-cli/src/commands/mod.rs
+++ b/crates/walletkit-cli/src/commands/mod.rs
@@ -331,6 +331,7 @@ pub async fn init_authenticator(
     let now = now_secs();
     authenticator
         .init_storage(now)
+        .await
         .wrap_err("storage init failed")?;
 
     Ok((Arc::new(authenticator), store))

--- a/crates/walletkit-core/Cargo.toml
+++ b/crates/walletkit-core/Cargo.toml
@@ -22,6 +22,7 @@ name = "walletkit_core"
 
 [dependencies]
 alloy-core = { workspace = true }
+async-trait = { workspace = true }
 backon = { workspace = true }
 base64 = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -1482,7 +1482,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("store");
-        store.init(42, 100).expect("init storage");
+        store.init(42, 100).await.expect("init storage");
 
         let artifacts =
             Arc::new(CachingZkArtifacts::new(Arc::new(store.paths().unwrap())));

--- a/crates/walletkit-core/src/authenticator/with_storage.rs
+++ b/crates/walletkit-core/src/authenticator/with_storage.rs
@@ -15,8 +15,8 @@ impl Authenticator {
     /// # Errors
     ///
     /// Returns an error if the leaf index is invalid or storage initialization fails.
-    pub fn init_storage(&self, now: u64) -> Result<(), WalletKitError> {
-        self.store.init(self.leaf_index(), now)?;
+    pub async fn init_storage(&self, now: u64) -> Result<(), WalletKitError> {
+        self.store.init(self.leaf_index(), now).await?;
         Ok(())
     }
 
@@ -29,8 +29,8 @@ impl Authenticator {
     /// # Errors
     ///
     /// Returns an error if the storage destruction fails.
-    pub fn destroy_storage(&self) -> Result<(), WalletKitError> {
-        self.store.destroy_storage()?;
+    pub async fn destroy_storage(&self) -> Result<(), WalletKitError> {
+        self.store.destroy_storage().await?;
         Ok(())
     }
 }
@@ -88,7 +88,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("store");
-        store.init(42, 100).expect("init storage");
+        tokio_test::block_on(store.init(42, 100)).expect("init storage");
 
         let siblings = [FieldElement::from(0u64); TREE_DEPTH];
         let root_fe = FieldElement::from(123u64);

--- a/crates/walletkit-core/src/proof_request_credential_constraints_check.rs
+++ b/crates/walletkit-core/src/proof_request_credential_constraints_check.rs
@@ -232,7 +232,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, now).expect("init");
+        tokio_test::block_on(store.init(42, now)).expect("init");
 
         for &id in issuer_ids {
             let cred: Credential = CoreCredential::new()
@@ -297,7 +297,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init");
+        tokio_test::block_on(store.init(42, 1000)).expect("init");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -635,7 +635,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, now).expect("init");
+        tokio_test::block_on(store.init(42, now)).expect("init");
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(issuer_id)
             .genesis_issued_at(genesis_issued_at)

--- a/crates/walletkit-core/src/storage/credential_storage.rs
+++ b/crates/walletkit-core/src/storage/credential_storage.rs
@@ -12,11 +12,13 @@ use super::paths::StoragePaths;
 use super::traits::StorageProvider;
 #[cfg(not(target_arch = "wasm32"))]
 use super::traits::VaultChangedListener;
-use super::traits::{AtomicBlobStore, DeviceKeystore};
+use super::traits::{AtomicBlobStore, KeySealer};
 use super::types::CredentialRecord;
+use super::StorageLock;
+#[cfg(not(target_arch = "wasm32"))]
+use super::StorageLockGuard;
 use super::ACCOUNT_KEYS_FILENAME;
 use super::{CacheDb, CredentialVault};
-use super::{StorageLock, StorageLockGuard};
 use crate::{Credential, FieldElement};
 use world_id_core::primitives::merkle::AccountInclusionProof;
 use world_id_core::primitives::TREE_DEPTH;
@@ -50,6 +52,9 @@ impl Drop for CleanupFile {
 #[derive(uniffi::Object)]
 pub struct CredentialStore {
     inner: Mutex<CredentialStoreInner>,
+    /// Serializes async storage initialization and destruction without holding
+    /// the synchronous state mutex across a foreign await.
+    lifecycle_lock: tokio::sync::Mutex<()>,
     /// Channel sender for the vault-changed notification thread.
     /// Kept outside `inner` so we can notify after releasing the storage mutex.
     #[cfg(not(target_arch = "wasm32"))]
@@ -64,7 +69,7 @@ impl std::fmt::Debug for CredentialStore {
 
 struct CredentialStoreInner {
     lock: StorageLock,
-    keystore: Arc<dyn DeviceKeystore>,
+    key_sealer: Arc<dyn KeySealer>,
     blob_store: Arc<dyn AtomicBlobStore>,
     paths: StoragePaths,
     state: Option<StorageState>,
@@ -88,7 +93,7 @@ impl CredentialStoreInner {
         let paths = provider.paths();
         Self::new(
             paths.as_ref().clone(),
-            provider.keystore(),
+            provider.key_sealer(),
             provider.blob_store(),
         )
     }
@@ -100,19 +105,20 @@ impl CredentialStoreInner {
     /// Returns an error if the storage lock cannot be opened.
     pub fn new(
         paths: StoragePaths,
-        keystore: Arc<dyn DeviceKeystore>,
+        key_sealer: Arc<dyn KeySealer>,
         blob_store: Arc<dyn AtomicBlobStore>,
     ) -> StorageResult<Self> {
         let lock = StorageLock::open(&paths.lock_path())?;
         Ok(Self {
             lock,
-            keystore,
+            key_sealer,
             blob_store,
             paths,
             state: None,
         })
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn guard(&self) -> StorageResult<StorageLockGuard> {
         self.lock.lock().map_err(Into::into)
     }
@@ -136,13 +142,14 @@ impl CredentialStore {
     #[uniffi::constructor]
     pub fn new_with_components(
         paths: Arc<StoragePaths>,
-        keystore: Arc<dyn DeviceKeystore>,
+        key_sealer: Arc<dyn KeySealer>,
         blob_store: Arc<dyn AtomicBlobStore>,
     ) -> StorageResult<Self> {
         let paths = Arc::try_unwrap(paths).unwrap_or_else(|arc| (*arc).clone());
-        let inner = CredentialStoreInner::new(paths, keystore, blob_store)?;
+        let inner = CredentialStoreInner::new(paths, key_sealer, blob_store)?;
         Ok(Self {
             inner: Mutex::new(inner),
+            lifecycle_lock: tokio::sync::Mutex::new(()),
             #[cfg(not(target_arch = "wasm32"))]
             vault_changed_tx: Mutex::new(None),
         })
@@ -161,6 +168,7 @@ impl CredentialStore {
         let inner = CredentialStoreInner::from_provider(provider.as_ref())?;
         Ok(Self {
             inner: Mutex::new(inner),
+            lifecycle_lock: tokio::sync::Mutex::new(()),
             #[cfg(not(target_arch = "wasm32"))]
             vault_changed_tx: Mutex::new(None),
         })
@@ -180,9 +188,35 @@ impl CredentialStore {
     /// # Errors
     ///
     /// Returns an error if initialization fails or the leaf index mismatches.
-    pub fn init(&self, leaf_index: u64, now: u64) -> StorageResult<()> {
-        let mut inner = self.lock_inner()?;
-        inner.init(leaf_index, now)
+    pub async fn init(&self, leaf_index: u64, now: u64) -> StorageResult<()> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+
+        let (key_sealer, blob_store, lock, paths) = {
+            let mut inner = self.lock_inner()?;
+            if let Some(state) = &mut inner.state {
+                state.vault.init_leaf_index(leaf_index, now)?;
+                state.leaf_index = leaf_index;
+                return Ok(());
+            }
+            (
+                Arc::clone(&inner.key_sealer),
+                Arc::clone(&inner.blob_store),
+                inner.lock.clone(),
+                inner.paths.clone(),
+            )
+        };
+
+        let state = open_storage_state(
+            key_sealer.as_ref(),
+            blob_store.as_ref(),
+            &lock,
+            &paths,
+            leaf_index,
+            now,
+        )
+        .await?;
+        self.lock_inner()?.state = Some(state);
+        Ok(())
     }
 
     /// Lists credential metadata, optionally filtered by issuer schema ID.
@@ -298,8 +332,28 @@ impl CredentialStore {
     ///
     /// Returns an error if the storage lock cannot be acquired or the key
     /// envelope cannot be deleted from the blob store.
-    pub fn destroy_storage(&self) -> StorageResult<()> {
-        self.lock_inner()?.destroy_storage()
+    pub async fn destroy_storage(&self) -> StorageResult<()> {
+        let _lifecycle_guard = self.lifecycle_lock.lock().await;
+        let (blob_store, lock, paths) = {
+            let inner = self.lock_inner()?;
+            (
+                Arc::clone(&inner.blob_store),
+                inner.lock.clone(),
+                inner.paths.clone(),
+            )
+        };
+        let _storage_guard = lock.lock()?;
+
+        // Drop in-memory state first: this zeroizes keys and closes the database
+        // connections before deleting their backing files.
+        self.lock_inner()?.state = None;
+        blob_store.delete(ACCOUNT_KEYS_FILENAME.to_string()).await?;
+
+        // Best-effort removal: deleting the key above cryptographically destroys
+        // the databases even if their encrypted files cannot be removed.
+        super::delete_database_files(&paths.vault_db_path());
+        super::delete_database_files(&paths.cache_db_path());
+        Ok(())
     }
 }
 
@@ -514,30 +568,25 @@ impl CredentialStore {
 }
 
 impl CredentialStoreInner {
-    fn init(&mut self, leaf_index: u64, now: u64) -> StorageResult<()> {
+    #[cfg(test)]
+    async fn init(&mut self, leaf_index: u64, now: u64) -> StorageResult<()> {
         if let Some(state) = &mut self.state {
             state.vault.init_leaf_index(leaf_index, now)?;
             state.leaf_index = leaf_index;
             return Ok(());
         }
 
-        let keys = StorageKeys::init(
-            self.keystore.as_ref(),
-            self.blob_store.as_ref(),
-            &self.lock,
-            now,
-        )?;
-        let k_intermediate = keys.intermediate_key();
-        let vault = CredentialVault::new(&self.paths.vault_db_path(), k_intermediate)?;
-        let cache = CacheDb::new(&self.paths.cache_db_path(), k_intermediate)?;
-        let state = StorageState {
-            keys,
-            vault,
-            cache,
-            leaf_index,
-        };
-        state.vault.init_leaf_index(leaf_index, now)?;
-        self.state = Some(state);
+        self.state = Some(
+            open_storage_state(
+                self.key_sealer.as_ref(),
+                self.blob_store.as_ref(),
+                &self.lock,
+                &self.paths,
+                leaf_index,
+                now,
+            )
+            .await?,
+        );
         Ok(())
     }
 
@@ -801,23 +850,28 @@ impl CredentialStoreInner {
         let state = self.state_mut()?;
         state.vault.danger_delete_all_credentials()
     }
+}
 
-    /// Permanently destroys all storage data: encryption keys, vault, and cache.
-    fn destroy_storage(&mut self) -> StorageResult<()> {
-        let _guard = self.guard()?;
-        // Drop in-memory state: zeroizes keys, closes database connections.
-        self.state = None;
-        // Delete the encryption key envelope. Without this key the database
-        // files are unreadable even if file deletion below fails.
-        self.blob_store.delete(ACCOUNT_KEYS_FILENAME.to_string())?;
-
-        // Best-effort removal: deleting the key above cryptographically destroys
-        // the databases even if their encrypted files cannot be removed.
-        super::delete_database_files(&self.paths.vault_db_path());
-        super::delete_database_files(&self.paths.cache_db_path());
-
-        Ok(())
-    }
+async fn open_storage_state(
+    key_sealer: &dyn KeySealer,
+    blob_store: &dyn AtomicBlobStore,
+    lock: &StorageLock,
+    paths: &StoragePaths,
+    leaf_index: u64,
+    now: u64,
+) -> StorageResult<StorageState> {
+    let keys = StorageKeys::init(key_sealer, blob_store, lock, now).await?;
+    let k_intermediate = keys.intermediate_key();
+    let vault = CredentialVault::new(&paths.vault_db_path(), k_intermediate)?;
+    let cache = CacheDb::new(&paths.cache_db_path(), k_intermediate)?;
+    let state = StorageState {
+        keys,
+        vault,
+        cache,
+        leaf_index,
+    };
+    state.vault.init_leaf_index(leaf_index, now)?;
+    Ok(state)
 }
 
 impl CredentialStore {
@@ -830,6 +884,7 @@ impl CredentialStore {
         let inner = CredentialStoreInner::from_provider(provider)?;
         Ok(Self {
             inner: Mutex::new(inner),
+            lifecycle_lock: tokio::sync::Mutex::new(()),
             #[cfg(not(target_arch = "wasm32"))]
             vault_changed_tx: Mutex::new(None),
         })
@@ -842,12 +897,13 @@ impl CredentialStore {
     /// Returns an error if the storage lock cannot be opened.
     pub fn new(
         paths: StoragePaths,
-        keystore: Arc<dyn DeviceKeystore>,
+        key_sealer: Arc<dyn KeySealer>,
         blob_store: Arc<dyn AtomicBlobStore>,
     ) -> StorageResult<Self> {
-        let inner = CredentialStoreInner::new(paths, keystore, blob_store)?;
+        let inner = CredentialStoreInner::new(paths, key_sealer, blob_store)?;
         Ok(Self {
             inner: Mutex::new(inner),
+            lifecycle_lock: tokio::sync::Mutex::new(()),
             #[cfg(not(target_arch = "wasm32"))]
             vault_changed_tx: Mutex::new(None),
         })
@@ -906,12 +962,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         // Create a FieldElement from a known value
         let nullifier = CoreFieldElement::from(123_456_789u64);
@@ -938,12 +994,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let nullifier = CoreFieldElement::from(999u64);
         let set_time = 1000u64;
@@ -981,12 +1037,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let nullifier = CoreFieldElement::from(555u64);
         let set_time = 3000u64;
@@ -1027,11 +1083,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store).unwrap();
-        inner.init(42, 1000).expect("init storage");
+        let mut inner =
+            CredentialStoreInner::new(paths, key_sealer, blob_store).unwrap();
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let nullifier = CoreFieldElement::from(12345u64);
         let first_set_time = 1000u64;
@@ -1067,7 +1124,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let blinding_factor = FieldElement::from(7u64);
         let cred: Credential = CoreCredential::new()
@@ -1106,12 +1163,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         // Store a test credential
         let issuer_schema_id = 123u64;
@@ -1168,7 +1225,7 @@ mod tests {
         let src_provider = InMemoryStorageProvider::new(&src_root);
         let src_store =
             CredentialStore::from_provider(&src_provider).expect("create src store");
-        src_store.init(42, 1000).expect("init src storage");
+        tokio_test::block_on(src_store.init(42, 1000)).expect("init src storage");
 
         let issuer_schema_id = 100u64;
         let blinding_factor = FieldElement::from(7u64);
@@ -1188,7 +1245,7 @@ mod tests {
         let dst_provider = InMemoryStorageProvider::new(&dst_root);
         let dst_store =
             CredentialStore::from_provider(&dst_provider).expect("create dst store");
-        dst_store.init(42, 1000).expect("init dst storage");
+        tokio_test::block_on(dst_store.init(42, 1000)).expect("init dst storage");
 
         dst_store
             .import_vault_from_backup(&bytes)
@@ -1213,7 +1270,7 @@ mod tests {
         let src_provider = InMemoryStorageProvider::new(&src_root);
         let src_store =
             CredentialStore::from_provider(&src_provider).expect("create src store");
-        src_store.init(42, 1000).expect("init src storage");
+        tokio_test::block_on(src_store.init(42, 1000)).expect("init src storage");
 
         // Store credential A (schema 100) without associated data
         let cred_a: Credential = CoreCredential::new()
@@ -1257,7 +1314,7 @@ mod tests {
         let dst_provider = InMemoryStorageProvider::new(&dst_root);
         let dst_store =
             CredentialStore::from_provider(&dst_provider).expect("create dst store");
-        dst_store.init(42, 1000).expect("init dst storage");
+        tokio_test::block_on(dst_store.init(42, 1000)).expect("init dst storage");
 
         dst_store
             .import_vault_from_backup(&bytes)
@@ -1297,7 +1354,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let blinding_factor = FieldElement::from(7u64);
         let cred: Credential = CoreCredential::new()
@@ -1331,7 +1388,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let result = store.import_vault_from_backup(b"not a sqlite database");
         assert!(result.is_err(), "import from invalid bytes should fail");
@@ -1349,7 +1406,7 @@ mod tests {
         let src_provider = InMemoryStorageProvider::new(&src_root);
         let src_store =
             CredentialStore::from_provider(&src_provider).expect("create src store");
-        src_store.init(42, 1000).expect("init src storage");
+        tokio_test::block_on(src_store.init(42, 1000)).expect("init src storage");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100u64)
@@ -1388,7 +1445,7 @@ mod tests {
         let dst_provider = InMemoryStorageProvider::new(&dst_root);
         let dst_store =
             CredentialStore::from_provider(&dst_provider).expect("create dst store");
-        dst_store.init(42, 1000).expect("init dst storage");
+        tokio_test::block_on(dst_store.init(42, 1000)).expect("init dst storage");
 
         let result = dst_store.import_vault_from_backup(&corrupt_bytes);
         assert!(result.is_err(), "import with corrupt backup should fail");
@@ -1412,12 +1469,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let blinding_factor = FieldElement::from(42u64);
         for issuer_id in [100u64, 200u64] {
@@ -1444,12 +1501,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let deleted = inner
             .danger_delete_all_credentials()
@@ -1466,12 +1523,12 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let paths = provider.paths().as_ref().clone();
-        let keystore = provider.keystore();
+        let key_sealer = provider.key_sealer();
         let blob_store = provider.blob_store();
 
-        let mut inner = CredentialStoreInner::new(paths, keystore, blob_store)
+        let mut inner = CredentialStoreInner::new(paths, key_sealer, blob_store)
             .expect("create inner");
-        inner.init(42, 1000).expect("init storage");
+        tokio_test::block_on(inner.init(42, 1000)).expect("init storage");
 
         let blinding_factor = FieldElement::from(42u64);
         let cred: Credential = CoreCredential::new()
@@ -1505,7 +1562,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init store");
+        tokio_test::block_on(store.init(42, 1000)).expect("init store");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -1539,7 +1596,7 @@ mod tests {
         let src_provider = InMemoryStorageProvider::new(&src_root);
         let src_store =
             CredentialStore::from_provider(&src_provider).expect("create store");
-        src_store.init(42, 1000).expect("init store");
+        tokio_test::block_on(src_store.init(42, 1000)).expect("init store");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -1557,7 +1614,7 @@ mod tests {
         let dst_provider = InMemoryStorageProvider::new(&dst_root);
         let dst_store =
             CredentialStore::from_provider(&dst_provider).expect("create dst store");
-        dst_store.init(42, 1000).expect("init dst store");
+        tokio_test::block_on(dst_store.init(42, 1000)).expect("init dst store");
 
         dst_store
             .import_vault_from_backup(&bytes)
@@ -1581,7 +1638,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init store");
+        tokio_test::block_on(store.init(42, 1000)).expect("init store");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -1619,7 +1676,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init store");
+        tokio_test::block_on(store.init(42, 1000)).expect("init store");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -1669,7 +1726,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let count = Arc::new(AtomicU32::new(0));
         store.set_vault_changed_listener(Arc::new(TestVaultListener(Arc::clone(
@@ -1696,7 +1753,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let count = Arc::new(AtomicU32::new(0));
         store.set_vault_changed_listener(Arc::new(TestVaultListener(Arc::clone(
@@ -1724,7 +1781,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let count = Arc::new(AtomicU32::new(0));
         store.set_vault_changed_listener(Arc::new(TestVaultListener(Arc::clone(
@@ -1753,7 +1810,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         // No listener registered — mutations should still work fine.
         let cred: Credential = CoreCredential::new()
@@ -1774,7 +1831,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let cred: Credential = CoreCredential::new()
             .issuer_schema_id(100)
@@ -1785,7 +1842,7 @@ mod tests {
             .expect("store credential");
 
         // Destroy should succeed.
-        store.destroy_storage().expect("destroy storage");
+        tokio_test::block_on(store.destroy_storage()).expect("destroy storage");
 
         // Database files should be removed from the storage directory.
         let paths = StoragePaths::new(&root);
@@ -1807,7 +1864,7 @@ mod tests {
         );
 
         // Re-initialization should work.
-        store.init(42, 1000).expect("re-init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("re-init storage");
         let list = store
             .list_credentials(None, 1000)
             .expect("list after re-init");
@@ -1826,7 +1883,7 @@ mod tests {
         let root = temp_root_path();
         let provider = InMemoryStorageProvider::new(&root);
         let store = CredentialStore::from_provider(&provider).expect("create store");
-        store.init(42, 1000).expect("init storage");
+        tokio_test::block_on(store.init(42, 1000)).expect("init storage");
 
         let count = Arc::new(AtomicU32::new(0));
         store.set_vault_changed_listener(Arc::new(TestVaultListener(Arc::clone(
@@ -1842,7 +1899,7 @@ mod tests {
             .expect("store credential");
         wait_for_listener_count(&count, 1);
 
-        store.destroy_storage().expect("destroy storage");
+        tokio_test::block_on(store.destroy_storage()).expect("destroy storage");
 
         std::thread::sleep(std::time::Duration::from_millis(50));
 

--- a/crates/walletkit-core/src/storage/error.rs
+++ b/crates/walletkit-core/src/storage/error.rs
@@ -8,9 +8,9 @@ pub type StorageResult<T> = Result<T, StorageError>;
 /// Errors raised by credential storage primitives.
 #[derive(Debug, Error, uniffi::Error)]
 pub enum StorageError {
-    /// Errors coming from the device keystore.
-    #[error("keystore error: {0}")]
-    Keystore(String),
+    /// Errors coming from the key sealer.
+    #[error("key sealer error: {0}")]
+    Sealer(String),
 
     /// Errors coming from the blob store.
     #[error("blob store error: {0}")]
@@ -112,7 +112,7 @@ impl From<uniffi::UnexpectedUniFFICallbackError> for StorageError {
 impl From<walletkit_db::StoreError> for StorageError {
     fn from(err: walletkit_db::StoreError) -> Self {
         match err {
-            walletkit_db::StoreError::Keystore(s) => Self::Keystore(s),
+            walletkit_db::StoreError::Sealer(s) => Self::Sealer(s),
             walletkit_db::StoreError::BlobStore(s) => Self::BlobStore(s),
             walletkit_db::StoreError::Lock(s) => Self::Lock(s),
             walletkit_db::StoreError::Serialization(s) => Self::Serialization(s),

--- a/crates/walletkit-core/src/storage/keys.rs
+++ b/crates/walletkit-core/src/storage/keys.rs
@@ -2,8 +2,8 @@
 //!
 //! [`StorageKeys`] opens (or creates on first use) the account key envelope via
 //! `walletkit-db` and holds the resulting `K_intermediate` in memory for the lifetime
-//! of the storage handle; both databases are opened with it. The `K_device` →
-//! `K_intermediate` hierarchy, envelope sealing, and encryption are described in the
+//! of the storage handle; both databases are opened with it. The sealing-key to
+//! `K_intermediate` hierarchy and envelope encryption are described in the
 //! `walletkit-db` README.
 
 use secrecy::SecretBox;
@@ -11,8 +11,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::{
     error::StorageResult,
-    traits::{AtomicBlobStore, DeviceKeystore},
-    ACCOUNT_KEYS_FILENAME, ACCOUNT_KEY_ENVELOPE_AD,
+    traits::{AtomicBlobStore, KeySealer},
+    ACCOUNT_KEYS_FILENAME, ACCOUNT_KEY_ENVELOPE_CONTEXT,
 };
 use walletkit_db::Lock;
 
@@ -32,20 +32,21 @@ impl StorageKeys {
     ///
     /// Returns an error if the envelope cannot be read, decrypted, or parsed,
     /// or if persistence to the blob store fails.
-    pub fn init(
-        keystore: &dyn DeviceKeystore,
+    pub async fn init(
+        key_sealer: &dyn KeySealer,
         blob_store: &dyn AtomicBlobStore,
         lock: &Lock,
         now: u64,
     ) -> StorageResult<Self> {
         let intermediate_key = walletkit_db::init_or_open_envelope_key(
-            &Ks(keystore),
-            &Bs(blob_store),
+            &KeySealerAdapter(key_sealer),
+            &BlobStoreAdapter(blob_store),
             lock,
             ACCOUNT_KEYS_FILENAME,
-            ACCOUNT_KEY_ENVELOPE_AD,
+            ACCOUNT_KEY_ENVELOPE_CONTEXT,
             now,
-        )?;
+        )
+        .await?;
         Ok(Self { intermediate_key })
     }
 
@@ -58,51 +59,66 @@ impl StorageKeys {
 
 // Trait-object bridge from walletkit-core's uniffi-annotated traits onto
 // walletkit-db's plain-Rust trait surface. Required because Rust's orphan
-// rule prevents a blanket impl across crates. `Keystore::seal` borrows its
-// plaintext (see walletkit-db/src/traits.rs); `Ks::seal` is the single
+// rule prevents a blanket impl across crates. `KeySealer::seal` borrows its
+// plaintext (see walletkit-db/src/traits.rs); `KeySealerAdapter::seal` is the single
 // point where the secret is copied into an owned `Vec<u8>`, because
-// `DeviceKeystore` is a uniffi callback interface and those only support
+// walletkit-core's `KeySealer` is a uniffi callback interface and those only support
 // pass-by-value parameters (no `&[u8]`). That copy — and any further copy
 // the foreign (Swift/Kotlin/etc.) implementation makes on its own side — is
 // outside Rust's control; this is an accepted uniffi limitation, not a bug.
 
-struct Ks<'a>(&'a dyn DeviceKeystore);
-impl walletkit_db::Keystore for Ks<'_> {
-    fn seal(&self, aad: &[u8], pt: &[u8]) -> walletkit_db::StoreResult<Vec<u8>> {
-        self.0
-            .seal(aad.to_vec(), pt.to_vec())
-            .map_err(|e| walletkit_db::StoreError::Keystore(e.to_string()))
-    }
-    fn open_sealed(
+struct KeySealerAdapter<'a>(&'a dyn KeySealer);
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl walletkit_db::KeySealer for KeySealerAdapter<'_> {
+    async fn seal(
         &self,
-        aad: Vec<u8>,
-        ct: Vec<u8>,
+        context: &[u8],
+        plaintext: &[u8],
     ) -> walletkit_db::StoreResult<Vec<u8>> {
         self.0
-            .open_sealed(aad, ct)
-            .map_err(|e| walletkit_db::StoreError::Keystore(e.to_string()))
+            .seal(context.to_vec(), plaintext.to_vec())
+            .await
+            .map_err(|e| walletkit_db::StoreError::Sealer(e.to_string()))
+    }
+    async fn unseal(
+        &self,
+        context: Vec<u8>,
+        ciphertext: Vec<u8>,
+    ) -> walletkit_db::StoreResult<Vec<u8>> {
+        self.0
+            .unseal(context, ciphertext)
+            .await
+            .map_err(|e| walletkit_db::StoreError::Sealer(e.to_string()))
     }
 }
 
-struct Bs<'a>(&'a dyn AtomicBlobStore);
-impl walletkit_db::AtomicBlobStore for Bs<'_> {
-    fn read(&self, path: String) -> walletkit_db::StoreResult<Option<Vec<u8>>> {
+struct BlobStoreAdapter<'a>(&'a dyn AtomicBlobStore);
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl walletkit_db::AtomicBlobStore for BlobStoreAdapter<'_> {
+    async fn read(&self, path: String) -> walletkit_db::StoreResult<Option<Vec<u8>>> {
         self.0
             .read(path)
+            .await
             .map_err(|e| walletkit_db::StoreError::BlobStore(e.to_string()))
     }
-    fn write_atomic(
+    async fn write_atomic(
         &self,
         path: String,
         bytes: Vec<u8>,
     ) -> walletkit_db::StoreResult<()> {
         self.0
             .write_atomic(path, bytes)
+            .await
             .map_err(|e| walletkit_db::StoreError::BlobStore(e.to_string()))
     }
-    fn delete(&self, path: String) -> walletkit_db::StoreResult<()> {
+    async fn delete(&self, path: String) -> walletkit_db::StoreResult<()> {
         self.0
             .delete(path)
+            .await
             .map_err(|e| walletkit_db::StoreError::BlobStore(e.to_string()))
     }
 }
@@ -111,7 +127,7 @@ impl walletkit_db::AtomicBlobStore for Bs<'_> {
 mod tests {
     use super::*;
     use crate::storage::error::StorageError;
-    use crate::storage::tests_utils::{InMemoryBlobStore, InMemoryKeystore};
+    use crate::storage::tests_utils::{InMemoryBlobStore, InMemoryKeySealer};
     use secrecy::ExposeSecret;
     use uuid::Uuid;
     use walletkit_db::Lock;
@@ -122,16 +138,18 @@ mod tests {
         path
     }
 
-    #[test]
-    fn test_storage_keys_round_trip() {
-        let keystore = InMemoryKeystore::new();
+    #[tokio::test]
+    async fn test_storage_keys_round_trip() {
+        let key_sealer = InMemoryKeySealer::new();
         let blob_store = InMemoryBlobStore::new();
         let lock_path = temp_lock_path();
         let lock = Lock::open(&lock_path).expect("open lock");
-        let keys_first =
-            StorageKeys::init(&keystore, &blob_store, &lock, 100).expect("init");
-        let keys_second =
-            StorageKeys::init(&keystore, &blob_store, &lock, 200).expect("init");
+        let keys_first = StorageKeys::init(&key_sealer, &blob_store, &lock, 100)
+            .await
+            .expect("init");
+        let keys_second = StorageKeys::init(&key_sealer, &blob_store, &lock, 200)
+            .await
+            .expect("init");
 
         assert_eq!(
             keys_first.intermediate_key.expose_secret(),
@@ -140,20 +158,22 @@ mod tests {
         let _ = std::fs::remove_file(lock_path);
     }
 
-    #[test]
-    fn test_storage_keys_keystore_mismatch_fails() {
-        let keystore = InMemoryKeystore::new();
+    #[tokio::test]
+    async fn test_storage_keys_sealer_mismatch_fails() {
+        let key_sealer = InMemoryKeySealer::new();
         let blob_store = InMemoryBlobStore::new();
         let lock_path = temp_lock_path();
         let lock = Lock::open(&lock_path).expect("open lock");
-        StorageKeys::init(&keystore, &blob_store, &lock, 123).expect("init");
+        StorageKeys::init(&key_sealer, &blob_store, &lock, 123)
+            .await
+            .expect("init");
 
-        let other_keystore = InMemoryKeystore::new();
-        match StorageKeys::init(&other_keystore, &blob_store, &lock, 456) {
+        let other_key_sealer = InMemoryKeySealer::new();
+        match StorageKeys::init(&other_key_sealer, &blob_store, &lock, 456).await {
             Err(
                 StorageError::Crypto(_)
                 | StorageError::InvalidEnvelope(_)
-                | StorageError::Keystore(_),
+                | StorageError::Sealer(_),
             ) => {}
             Err(err) => panic!("unexpected error: {err}"),
             Ok(_) => panic!("expected error"),
@@ -161,24 +181,28 @@ mod tests {
         let _ = std::fs::remove_file(lock_path);
     }
 
-    #[test]
-    fn test_storage_keys_tampered_envelope_fails() {
-        let keystore = InMemoryKeystore::new();
+    #[tokio::test]
+    async fn test_storage_keys_tampered_envelope_fails() {
+        let key_sealer = InMemoryKeySealer::new();
         let blob_store = InMemoryBlobStore::new();
         let lock_path = temp_lock_path();
         let lock = Lock::open(&lock_path).expect("open lock");
-        StorageKeys::init(&keystore, &blob_store, &lock, 123).expect("init");
+        StorageKeys::init(&key_sealer, &blob_store, &lock, 123)
+            .await
+            .expect("init");
 
         let mut bytes = blob_store
             .read(ACCOUNT_KEYS_FILENAME.to_string())
+            .await
             .expect("read")
             .expect("present");
         bytes[0] ^= 0xFF;
         blob_store
             .write_atomic(ACCOUNT_KEYS_FILENAME.to_string(), bytes)
+            .await
             .expect("write");
 
-        match StorageKeys::init(&keystore, &blob_store, &lock, 456) {
+        match StorageKeys::init(&key_sealer, &blob_store, &lock, 456).await {
             Err(
                 StorageError::Serialization(_)
                 | StorageError::Crypto(_)

--- a/crates/walletkit-core/src/storage/mod.rs
+++ b/crates/walletkit-core/src/storage/mod.rs
@@ -21,7 +21,7 @@
 //!    correctness loss. See [`crate::storage::CacheDb`].
 //!
 //! The encrypted-storage primitives beneath these — the sealed key envelope, the
-//! `K_device` → `K_intermediate` key hierarchy, sqlite3mc encryption, the
+//! sealing-key to `K_intermediate` hierarchy, sqlite3mc encryption, the
 //! cross-process lock, content-addressed blobs, and the threat model are owned by
 //! the [`walletkit-db`](https://docs.rs/crate/walletkit-db/latest) crate.
 //!
@@ -58,9 +58,7 @@ pub use credential_vault::CredentialVault;
 pub use error::{StorageError, StorageResult};
 pub use keys::StorageKeys;
 pub use paths::StoragePaths;
-pub use traits::{
-    AtomicBlobStore, DeviceKeystore, StorageProvider, VaultChangedListener,
-};
+pub use traits::{AtomicBlobStore, KeySealer, StorageProvider, VaultChangedListener};
 pub use types::{
     BlobKind, ContentId, CredentialRecord, Nullifier, ReplayGuardKind,
     ReplayGuardResult, RequestId,
@@ -115,7 +113,7 @@ pub async fn initialize_persistent_storage() -> StorageResult<()> {
 }
 
 pub(crate) const ACCOUNT_KEYS_FILENAME: &str = "account_keys.bin";
-pub(crate) const ACCOUNT_KEY_ENVELOPE_AD: &[u8] = b"worldid:account-key-envelope";
+pub(crate) const ACCOUNT_KEY_ENVELOPE_CONTEXT: &[u8] = b"worldid:account-key-envelope";
 
 #[cfg(test)]
 pub(crate) mod tests_utils;

--- a/crates/walletkit-core/src/storage/tests_utils.rs
+++ b/crates/walletkit-core/src/storage/tests_utils.rs
@@ -19,11 +19,11 @@ use std::path::Path;
 use super::{
     error::StorageError,
     paths::StoragePaths,
-    traits::{DeviceKeystore, StorageProvider},
+    traits::{KeySealer, StorageProvider},
     AtomicBlobStore,
 };
 
-pub struct InMemoryKeystore {
+pub struct InMemoryKeySealer {
     key: [u8; 32],
 }
 
@@ -49,7 +49,7 @@ pub fn cleanup_test_storage(root: &Path) {
     let _ = fs::remove_dir_all(paths.root());
 }
 
-impl InMemoryKeystore {
+impl InMemoryKeySealer {
     pub fn new() -> Self {
         let mut key = [0u8; 32];
         OsRng.fill_bytes(&mut key);
@@ -57,16 +57,18 @@ impl InMemoryKeystore {
     }
 }
 
-impl Default for InMemoryKeystore {
+impl Default for InMemoryKeySealer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl DeviceKeystore for InMemoryKeystore {
-    fn seal(
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl KeySealer for InMemoryKeySealer {
+    async fn seal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         plaintext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         let cipher = XChaCha20Poly1305::new(Key::from_slice(&self.key));
@@ -77,7 +79,7 @@ impl DeviceKeystore for InMemoryKeystore {
                 XNonce::from_slice(&nonce_bytes),
                 Payload {
                     msg: &plaintext,
-                    aad: &associated_data,
+                    aad: &context,
                 },
             )
             .map_err(|err| StorageError::Crypto(err.to_string()))?;
@@ -87,14 +89,14 @@ impl DeviceKeystore for InMemoryKeystore {
         Ok(out)
     }
 
-    fn open_sealed(
+    async fn unseal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         ciphertext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         if ciphertext.len() < 24 {
             return Err(StorageError::InvalidEnvelope(
-                "keystore ciphertext too short".to_string(),
+                "key sealer ciphertext too short".to_string(),
             ));
         }
         let (nonce_bytes, payload) = ciphertext.split_at(24);
@@ -104,7 +106,7 @@ impl DeviceKeystore for InMemoryKeystore {
                 XNonce::from_slice(nonce_bytes),
                 Payload {
                     msg: payload,
-                    aad: &associated_data,
+                    aad: &context,
                 },
             )
             .map_err(|err| StorageError::Crypto(err.to_string()))
@@ -129,8 +131,10 @@ impl Default for InMemoryBlobStore {
     }
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl AtomicBlobStore for InMemoryBlobStore {
-    fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
+    async fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
         let guard = self
             .blobs
             .lock()
@@ -138,7 +142,11 @@ impl AtomicBlobStore for InMemoryBlobStore {
         Ok(guard.get(&path).cloned())
     }
 
-    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> Result<(), StorageError> {
+    async fn write_atomic(
+        &self,
+        path: String,
+        bytes: Vec<u8>,
+    ) -> Result<(), StorageError> {
         self.blobs
             .lock()
             .map_err(|_| StorageError::BlobStore("mutex poisoned".to_string()))?
@@ -146,7 +154,7 @@ impl AtomicBlobStore for InMemoryBlobStore {
         Ok(())
     }
 
-    fn delete(&self, path: String) -> Result<(), StorageError> {
+    async fn delete(&self, path: String) -> Result<(), StorageError> {
         self.blobs
             .lock()
             .map_err(|_| StorageError::BlobStore("mutex poisoned".to_string()))?
@@ -156,7 +164,7 @@ impl AtomicBlobStore for InMemoryBlobStore {
 }
 
 pub struct InMemoryStorageProvider {
-    keystore: Arc<InMemoryKeystore>,
+    key_sealer: Arc<InMemoryKeySealer>,
     blob_store: Arc<InMemoryBlobStore>,
     paths: Arc<StoragePaths>,
 }
@@ -164,7 +172,7 @@ pub struct InMemoryStorageProvider {
 impl InMemoryStorageProvider {
     pub fn new(root: impl AsRef<Path>) -> Self {
         Self {
-            keystore: Arc::new(InMemoryKeystore::new()),
+            key_sealer: Arc::new(InMemoryKeySealer::new()),
             blob_store: Arc::new(InMemoryBlobStore::new()),
             paths: Arc::new(StoragePaths::new(root)),
         }
@@ -172,8 +180,8 @@ impl InMemoryStorageProvider {
 }
 
 impl StorageProvider for InMemoryStorageProvider {
-    fn keystore(&self) -> Arc<dyn DeviceKeystore> {
-        self.keystore.clone()
+    fn key_sealer(&self) -> Arc<dyn KeySealer> {
+        self.key_sealer.clone()
     }
 
     fn blob_store(&self) -> Arc<dyn AtomicBlobStore> {

--- a/crates/walletkit-core/src/storage/traits.rs
+++ b/crates/walletkit-core/src/storage/traits.rs
@@ -1,18 +1,18 @@
 //! Platform interfaces for credential storage.
 //!
 //! These traits are the platform integration boundary. The host selects the storage
-//! root and provides a [`DeviceKeystore`] and [`AtomicBlobStore`]; core storage code
+//! root and provides a [`KeySealer`] and [`AtomicBlobStore`]; core storage code
 //! is root-agnostic and consumes a provider-supplied [`StoragePaths`].
 //!
 //! # Expected platform components
 //!
-//! - **iOS (Swift):** [`DeviceKeystore`] backed by Keychain / Secure Enclave;
+//! - **iOS (Swift):** [`KeySealer`] backed by Keychain / Secure Enclave;
 //!   [`AtomicBlobStore`] over the app container filesystem (atomic replace).
-//! - **Android (Kotlin):** [`DeviceKeystore`] backed by the Android Keystore;
+//! - **Android (Kotlin):** [`KeySealer`] backed by the Android Keystore;
 //!   [`AtomicBlobStore`] over app internal storage (atomic replace).
-//! - **Node.js:** file-backed [`DeviceKeystore`] (development; production can use an
+//! - **Node.js:** file-backed [`KeySealer`] (development; production can use an
 //!   OS keystore); [`AtomicBlobStore`] over app internal storage.
-//! - **Browser (WASM):** host-provided [`DeviceKeystore`] and [`AtomicBlobStore`]
+//! - **Browser (WASM):** host-provided [`KeySealer`] and [`AtomicBlobStore`]
 //!   implementations; sqlite persistence itself uses encrypted OPFS storage.
 
 use std::sync::Arc;
@@ -20,68 +20,73 @@ use std::sync::Arc;
 use super::error::StorageResult;
 use super::paths::StoragePaths;
 
-/// Device keystore interface used to seal and open account keys.
+/// Host interface used to seal and unseal account keys.
 #[uniffi::export(with_foreign)]
-pub trait DeviceKeystore: Send + Sync {
-    /// Seals plaintext under the device-bound key, authenticating `associated_data`.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait KeySealer: Send + Sync {
+    /// Seals plaintext and binds it to `context`.
     ///
-    /// The associated data is not encrypted, but it is integrity-protected as part
-    /// of the seal operation. Any mismatch when opening must fail.
+    /// Implementations may bind the context as AEAD additional authenticated data,
+    /// by selecting a context-specific key, or through an equivalent mechanism.
+    /// Unsealing with a different context must fail.
     ///
     /// # Errors
     ///
-    /// Returns an error if the keystore refuses the operation or the seal fails.
-    fn seal(
+    /// Returns an error if the key sealer refuses the operation or sealing fails.
+    async fn seal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         plaintext: Vec<u8>,
     ) -> StorageResult<Vec<u8>>;
 
-    /// Opens ciphertext under the device-bound key, verifying `associated_data`.
+    /// Unseals ciphertext after verifying its binding to `context`.
     ///
-    /// The same associated data used during sealing must be supplied or the open
-    /// operation must fail.
+    /// The same context used during sealing must be supplied or the operation must
+    /// fail.
     ///
     /// # Errors
     ///
-    /// Returns an error if authentication fails or the keystore cannot open.
-    fn open_sealed(
+    /// Returns an error if authentication fails or the key cannot be unsealed.
+    async fn unseal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         ciphertext: Vec<u8>,
     ) -> StorageResult<Vec<u8>>;
 }
 
 /// Atomic blob store for small binary files (e.g., `account_keys.bin`).
 #[uniffi::export(with_foreign)]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait AtomicBlobStore: Send + Sync {
     /// Reads the blob at `path`, if present.
     ///
     /// # Errors
     ///
     /// Returns an error if the read fails.
-    fn read(&self, path: String) -> StorageResult<Option<Vec<u8>>>;
+    async fn read(&self, path: String) -> StorageResult<Option<Vec<u8>>>;
 
     /// Writes bytes atomically to `path`.
     ///
     /// # Errors
     ///
     /// Returns an error if the write fails.
-    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StorageResult<()>;
+    async fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StorageResult<()>;
 
     /// Deletes the blob at `path`.
     ///
     /// # Errors
     ///
     /// Returns an error if the delete fails.
-    fn delete(&self, path: String) -> StorageResult<()>;
+    async fn delete(&self, path: String) -> StorageResult<()>;
 }
 
 /// Provider responsible for platform-specific storage components and paths.
 #[uniffi::export(with_foreign)]
 pub trait StorageProvider: Send + Sync {
-    /// Returns the device keystore implementation.
-    fn keystore(&self) -> Arc<dyn DeviceKeystore>;
+    /// Returns the key sealer implementation.
+    fn key_sealer(&self) -> Arc<dyn KeySealer>;
 
     /// Returns the blob store implementation.
     fn blob_store(&self) -> Arc<dyn AtomicBlobStore>;

--- a/crates/walletkit-core/tests/common.rs
+++ b/crates/walletkit-core/tests/common.rs
@@ -20,15 +20,15 @@ use chacha20poly1305::{
 use rand::{rngs::OsRng, RngCore};
 use uuid::Uuid;
 use walletkit_core::storage::{
-    AtomicBlobStore, CredentialStore, DeviceKeystore, StorageError, StoragePaths,
+    AtomicBlobStore, CredentialStore, KeySealer, StorageError, StoragePaths,
     StorageProvider,
 };
 
-pub struct InMemoryKeystore {
+pub struct InMemoryKeySealer {
     key: [u8; 32],
 }
 
-impl InMemoryKeystore {
+impl InMemoryKeySealer {
     pub fn new() -> Self {
         let mut key = [0u8; 32];
         OsRng.fill_bytes(&mut key);
@@ -36,16 +36,17 @@ impl InMemoryKeystore {
     }
 }
 
-impl Default for InMemoryKeystore {
+impl Default for InMemoryKeySealer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl DeviceKeystore for InMemoryKeystore {
-    fn seal(
+#[async_trait::async_trait]
+impl KeySealer for InMemoryKeySealer {
+    async fn seal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         plaintext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         let cipher = XChaCha20Poly1305::new(Key::from_slice(&self.key));
@@ -56,7 +57,7 @@ impl DeviceKeystore for InMemoryKeystore {
                 XNonce::from_slice(&nonce_bytes),
                 Payload {
                     msg: &plaintext,
-                    aad: &associated_data,
+                    aad: &context,
                 },
             )
             .map_err(|err| StorageError::Crypto(err.to_string()))?;
@@ -66,14 +67,14 @@ impl DeviceKeystore for InMemoryKeystore {
         Ok(out)
     }
 
-    fn open_sealed(
+    async fn unseal(
         &self,
-        associated_data: Vec<u8>,
+        context: Vec<u8>,
         ciphertext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         if ciphertext.len() < 24 {
             return Err(StorageError::InvalidEnvelope(
-                "keystore ciphertext too short".to_string(),
+                "key sealer ciphertext too short".to_string(),
             ));
         }
         let (nonce_bytes, payload) = ciphertext.split_at(24);
@@ -83,7 +84,7 @@ impl DeviceKeystore for InMemoryKeystore {
                 XNonce::from_slice(nonce_bytes),
                 Payload {
                     msg: payload,
-                    aad: &associated_data,
+                    aad: &context,
                 },
             )
             .map_err(|err| StorageError::Crypto(err.to_string()))
@@ -108,8 +109,9 @@ impl Default for InMemoryBlobStore {
     }
 }
 
+#[async_trait::async_trait]
 impl AtomicBlobStore for InMemoryBlobStore {
-    fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
+    async fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
         let guard = self
             .blobs
             .lock()
@@ -117,7 +119,11 @@ impl AtomicBlobStore for InMemoryBlobStore {
         Ok(guard.get(&path).cloned())
     }
 
-    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> Result<(), StorageError> {
+    async fn write_atomic(
+        &self,
+        path: String,
+        bytes: Vec<u8>,
+    ) -> Result<(), StorageError> {
         self.blobs
             .lock()
             .map_err(|_| StorageError::BlobStore("mutex poisoned".to_string()))?
@@ -125,7 +131,7 @@ impl AtomicBlobStore for InMemoryBlobStore {
         Ok(())
     }
 
-    fn delete(&self, path: String) -> Result<(), StorageError> {
+    async fn delete(&self, path: String) -> Result<(), StorageError> {
         self.blobs
             .lock()
             .map_err(|_| StorageError::BlobStore("mutex poisoned".to_string()))?
@@ -135,7 +141,7 @@ impl AtomicBlobStore for InMemoryBlobStore {
 }
 
 pub struct InMemoryStorageProvider {
-    keystore: Arc<InMemoryKeystore>,
+    key_sealer: Arc<InMemoryKeySealer>,
     blob_store: Arc<InMemoryBlobStore>,
     paths: Arc<StoragePaths>,
 }
@@ -143,7 +149,7 @@ pub struct InMemoryStorageProvider {
 impl InMemoryStorageProvider {
     pub fn new(root: impl AsRef<Path>) -> Self {
         Self {
-            keystore: Arc::new(InMemoryKeystore::new()),
+            key_sealer: Arc::new(InMemoryKeySealer::new()),
             blob_store: Arc::new(InMemoryBlobStore::new()),
             paths: Arc::new(StoragePaths::new(root)),
         }
@@ -151,8 +157,8 @@ impl InMemoryStorageProvider {
 }
 
 impl StorageProvider for InMemoryStorageProvider {
-    fn keystore(&self) -> Arc<dyn DeviceKeystore> {
-        self.keystore.clone()
+    fn key_sealer(&self) -> Arc<dyn KeySealer> {
+        self.key_sealer.clone()
     }
 
     fn blob_store(&self) -> Arc<dyn AtomicBlobStore> {

--- a/crates/walletkit-core/tests/credential_storage_integration.rs
+++ b/crates/walletkit-core/tests/credential_storage_integration.rs
@@ -22,7 +22,7 @@ fn test_storage_flow_end_to_end() {
     let provider = common::InMemoryStorageProvider::new(&root);
     let store = CredentialStore::from_provider(&provider).expect("store");
 
-    store.init(42, 100).expect("init");
+    tokio_test::block_on(store.init(42, 100)).expect("init");
 
     let blinding_factor = CoreFieldElement::random(&mut OsRng);
     let core_cred = CoreCredential::new()

--- a/crates/walletkit-db/Cargo.toml
+++ b/crates/walletkit-db/Cargo.toml
@@ -15,6 +15,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 ciborium = { workspace = true }
 getrandom = { workspace = true }
 hex = { workspace = true }
@@ -33,6 +34,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/walletkit-db/README.md
+++ b/crates/walletkit-db/README.md
@@ -11,17 +11,17 @@ Consumed by `walletkit-core::storage` (credential vault) and by sibling SDKs in 
 Five physical pieces. Knowing what each one is and isn't makes everything else straightforward.
 
 - **Vault** — the encrypted SQLite file on disk (e.g. `account.vault.sqlite`). Opened by `Vault::open`; accessed via `Vault::connection() -> &Connection`. SQLite's WAL-mode file locks serialize cross-process writers; walletkit-db doesn't layer another lock on top.
-- **Envelope** — a small CBOR file (e.g. `account_keys.bin`) holding the sealed 32-byte `K_intermediate`. The seal is done by the host's hardware keystore. Managed by `init_or_open_envelope_key` + `KeyEnvelope`.
+- **Envelope** — a small CBOR file (e.g. `account_keys.bin`) holding the sealed 32-byte `K_intermediate`. The seal is done by the host's `KeySealer`. Managed by `init_or_open_envelope_key` + `KeyEnvelope`.
 - **Lock** — a separate empty file used as a cross-process mutex via `flock` / `LockFileEx`. Acquired internally by `init_or_open_envelope_key` (envelope-init bootstrap race) and by consumers around operations that mix SQL with filesystem state (e.g. plaintext export/import).
 - **`blob_objects` table** — one shared table inside the vault for content-addressed bytes, keyed by SHA-256. Consumer-specific tables reference rows here by `content_id`. Managed by `blobs::*`.
-- **`Keystore` + `AtomicBlobStore`** — two traits the host implements. `Keystore` seals/unseals bytes under `K_device`; `AtomicBlobStore` reads/writes the envelope file. walletkit-db never touches the OS keystore or the filesystem directly.
+- **`KeySealer` + `AtomicBlobStore`** — two async traits the host implements. `KeySealer` seals/unseals bytes using platform key protection; `AtomicBlobStore` reads/writes the envelope file. walletkit-db never touches the OS keystore or the filesystem directly.
 
 ## Architecture
 
 ```mermaid
 flowchart TB
     subgraph Host["Host platform (Kotlin / Swift)"]
-        KS["DeviceKeystore (uniffi)"]
+        KS["KeySealer (uniffi)"]
         BS["AtomicBlobStore (uniffi)"]
     end
     subgraph WKDB["walletkit-db (this crate)"]
@@ -50,21 +50,21 @@ flowchart TB
 Dependency direction is one-way: consumers depend on `walletkit-db`, which
 depends on `walletkit-sqlite`. `walletkit-db` doesn't know about its consumers,
 `uniffi`, or any specific consumer schema. Each consumer brings its own
-filename, AD namespace, lock file, vault file, and SQL schema.
+filename, sealing context, lock file, vault file, and SQL schema.
 
 ## Key hierarchy
 
-- **`K_device`** — root sealing key, provided by the host via the `Keystore` trait. In production deployments this MUST be backed by a non-extractable hardware key (iOS Secure Enclave / Android Keystore) so that even a disk-copy attacker can't recover it. walletkit-db doesn't enforce this; the threat-model rows below assume it.
-- **`K_intermediate`** — 32-byte random key per consumer-vault. Generated once via `getrandom`, sealed under `K_device`, persisted as a CBOR `KeyEnvelope`. Used as the SQLite page-encryption key by sqlite3mc.
-- **AD** — non-secret label bound into the AEAD seal (e.g. `worldid:account-key-envelope`). Per-consumer so envelopes can't be swapped between vaults.
+- **Sealing key** — root key material controlled by the host's `KeySealer`. Native adapters can use a non-extractable hardware key; browser adapters can derive it from a passkey PRF. walletkit-db only relies on the behavioral contract of the sealer.
+- **`K_intermediate`** — 32-byte random key per consumer-vault. Generated once via `getrandom`, sealed by the `KeySealer`, persisted as a CBOR `KeyEnvelope`, and used as the SQLite page-encryption key by sqlite3mc.
+- **Sealing context** — non-secret label bound to the sealed value (e.g. `worldid:account-key-envelope`). An adapter may use AEAD additional authenticated data, context-specific key selection, or an equivalent mechanism. Per-consumer contexts prevent envelope substitution.
 
 ## Startup
 
-**Cold start:** open `Lock` → `init_or_open_envelope_key` generates fresh `K_intermediate`, seals it via `Keystore`, writes the envelope via `AtomicBlobStore`. `Vault::open` opens the SQLite file via `sqlite3mc`, runs the consumer's schema callback, runs `PRAGMA integrity_check`.
+**Cold start:** open `Lock` → `init_or_open_envelope_key` generates fresh `K_intermediate`, seals it via `KeySealer`, writes the envelope via `AtomicBlobStore`. `Vault::open` opens the SQLite file via `sqlite3mc`, runs the consumer's schema callback, runs `PRAGMA integrity_check`.
 
 **Warm start:** same flow, but the envelope already exists. `init_or_open_envelope_key` reads and unseals it to recover the bit-for-bit original `K_intermediate`. Schema callback is idempotent (`CREATE TABLE IF NOT EXISTS`).
 
-**Device wipe / app uninstall:** `K_device` is destroyed. The envelope on disk becomes permanently unsealable. Recovery requires a separate backup path that re-wraps the data under a non-device-bound key.
+**Loss of the sealing capability:** the envelope on disk becomes unsealable. Recovery requires a separate backup path that re-wraps the data under independently recoverable key material.
 
 ## Encryption
 
@@ -72,26 +72,26 @@ filename, AD namespace, lock file, vault file, and SQL schema.
 
 ## Threat model
 
-All rows assume the host's `Keystore` is backed by a non-extractable hardware key. A `Keystore` implementation that keeps `K_device` in RAM, on disk, or anywhere the disk-copy attacker can reach voids the "Safe" rows below.
+All rows assume the host's `KeySealer` protects its key material from an offline disk-copy attacker. An implementation that stores the sealing key alongside the envelope voids the "Safe" rows below.
 
 | Tier | Status | What protects you |
 |---|---|---|
-| Disk copy / lost device / backup extraction | **Safe** | Vault + envelope are encrypted under a key sealed by the hardware-backed `Keystore`; attacker can't unseal without `K_device`. |
-| Code running inside the app session | **Exposed** | Attacker calls the legitimate keystore as the app and unseals envelopes. Defense lives at the keystore-entry access policy layer. |
-| File corruption / envelope swap | **Safe** | Per-page MAC fails; AD binding fails AEAD auth on swapped envelopes. |
-| Hardware keystore compromise | Out of scope | — |
+| Disk copy / lost device / backup extraction | **Safe** | Vault + envelope are encrypted, and the sealing key is unavailable to the disk-copy attacker. |
+| Code running inside the app session | **Exposed** | Attacker calls the legitimate sealer as the app and unseals envelopes. Defense lives in host access policy. |
+| File corruption / envelope swap | **Safe** | Per-page MAC fails; the sealing-context binding rejects substituted envelopes. |
+| Key-sealing mechanism compromise | Out of scope | — |
 
-**Defense-in-depth lever:** host policy on the keystore entry (iOS `kSecAccessControlBiometryCurrentSet`, Android `setUserAuthenticationRequired(true)`). walletkit-db is neutral; the policy lives in the Kotlin/Swift code that creates `K_device`.
+**Defense-in-depth lever:** host policy on the sealing operation, such as iOS `kSecAccessControlBiometryCurrentSet`, Android `setUserAuthenticationRequired(true)`, or passkey user verification. walletkit-db is neutral; the policy lives in the host adapter.
 
 ## Per-consumer isolation
 
 If multiple consumers share the device (today the credential vault; later an OrbKit PCP store, etc.), the host has to give each one its own secrets and its own files:
 
-1. A separate hardware keystore entry (Secure Enclave key / Android Keystore alias).
-2. A separate AD label passed to `init_or_open_envelope_key`.
+1. Separate sealing key material or a context-aware sealer.
+2. A separate sealing context passed to `init_or_open_envelope_key`.
 3. A separate envelope filename, vault file, and lock file.
 
-walletkit-db cryptographically binds operations to AD: an envelope sealed under one AD won't open under another. Everything else is host wiring. Sharing a keystore entry across consumers breaks the isolation.
+walletkit-db requires the sealer to bind operations to context: an envelope sealed under one context won't open under another. Everything else is host wiring. Reusing both sealing key material and context across consumers breaks the isolation.
 
 ## Usage
 
@@ -104,15 +104,15 @@ use walletkit_db::{blobs, init_or_open_envelope_key, Lock, Vault};
 let lock = Lock::open(&paths.lock_path())?;
 
 // 2. Unseal or generate the consumer's intermediate key.
-//    Filename + AD are per-consumer so different vaults never share keys.
+//    Filename + context are per-consumer so different vaults never share keys.
 let k_intermediate = init_or_open_envelope_key(
-    &my_keystore_adapter,
+    &my_key_sealer_adapter,
     &my_blob_store_adapter,
     &lock,
     "my_consumer_keys.bin",
     b"my-consumer:key-envelope",
     now,
-)?;
+).await?;
 
 // 3. Open the encrypted SQLite database with the consumer's own schema.
 let vault = Vault::open(&paths.db_path(), &k_intermediate, |conn| {
@@ -127,15 +127,15 @@ let bytes = blobs::get(conn, &cid)?.expect("present");
 blobs::delete(conn, &cid)?;
 ```
 
-The consumer brings a `Keystore` impl, an `AtomicBlobStore` impl, a `kind: u8` tag space, and its own SQL schema. The crate handles cipher setup, schema dispatch, integrity check, content hashing (`SHA-256("worldid:blob" || [kind] || plaintext)`), CBOR envelope persistence, and the lock.
+The consumer brings a `KeySealer` impl, an `AtomicBlobStore` impl, a `kind: u8` tag space, and its own SQL schema. The crate handles cipher setup, schema dispatch, integrity check, content hashing (`SHA-256("worldid:blob" || [kind] || plaintext)`), CBOR envelope persistence, and the lock.
 
 ## Public surface
 
 - `Vault::open(path, key, ensure_schema) -> StoreResult<Vault>`, `Vault::connection(&self) -> &Connection`.
 - `blobs::{ensure_schema, put, get, delete, compute_content_id}` plus `pub type ContentId = [u8; 32]`.
-- `init_or_open_envelope_key(...) -> StoreResult<SecretBox<[u8; 32]>>`.
+- `init_or_open_envelope_key(...) -> Future<Output = StoreResult<SecretBox<[u8; 32]>>>`.
 - `Lock` / `LockGuard` — native `flock` / `LockFileEx`, no-op on WASM.
-- `Keystore` / `AtomicBlobStore` traits — plain Rust.
+- `KeySealer` / `AtomicBlobStore` traits — async, plain Rust.
 - `StoreError` / `StoreResult`.
 
 Low-level `Connection`, `Transaction`, `Statement`, `Row`, `StepResult`,
@@ -143,7 +143,7 @@ Low-level `Connection`, `Transaction`, `Statement`, `Row`, `StepResult`,
 
 ## On-disk format
 
-Schemas, CBOR envelope layout, content_id derivation, and the `account_keys.bin` / `worldid:account-key-envelope` filename + AD tags are byte-stable. Existing user databases keep working without migration. Frozen-byte tests live next to the code they cover (`blobs.rs`, `envelope.rs`).
+Schemas, CBOR envelope layout, content_id derivation, and the `account_keys.bin` / `worldid:account-key-envelope` filename + context tags are byte-stable. Existing user databases keep working without migration. Frozen-byte tests live next to the code they cover (`blobs.rs`, `envelope.rs`).
 
 ## Platforms
 

--- a/crates/walletkit-db/src/envelope.rs
+++ b/crates/walletkit-db/src/envelope.rs
@@ -1,10 +1,10 @@
 //! Sealed key envelope persisted via [`AtomicBlobStore`].
 //!
-//! A 32-byte intermediate key is sealed under a device-bound [`Keystore`] and
+//! A 32-byte intermediate key is sealed by a host-provided [`KeySealer`] and
 //! persisted as a CBOR-serialized [`KeyEnvelope`]. On subsequent runs the
-//! envelope is read, opened, and the unsealed key returned in a [`SecretBox`].
+//! envelope is read, unsealed, and the key returned in a [`SecretBox`].
 //!
-//! Each consumer chooses its own filename and associated-data namespace so
+//! Each consumer chooses its own filename and sealing context so
 //! independent vaults (e.g. credential vault and `OrbPcpStore`) cannot share
 //! intermediate keys.
 
@@ -14,7 +14,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::error::{StoreError, StoreResult};
 use crate::lock::Lock;
-use crate::traits::{AtomicBlobStore, Keystore};
+use crate::traits::{AtomicBlobStore, KeySealer};
 
 const ENVELOPE_VERSION: u32 = 1;
 
@@ -72,34 +72,35 @@ impl KeyEnvelope {
 
 /// Initialize or open the envelope-sealed intermediate key.
 ///
-/// On first run, generates a fresh 32-byte key, seals it under `keystore`
-/// authenticated by `ad`, persists the envelope at `filename` via
+/// On first run, generates a fresh 32-byte key, seals it with `key_sealer`
+/// bound to `context`, persists the envelope at `filename` via
 /// `blob_store`, and returns the unsealed key.
 ///
 /// On subsequent runs, reads the envelope at `filename`, opens it under
-/// `keystore` authenticated by `ad`, and returns the unsealed key.
+/// `key_sealer` bound to `context`, and returns the unsealed key.
 ///
 /// `lock` is acquired internally to serialize the read-open / generate-write
 /// sequence across processes, and released before this returns.
 ///
 /// # Errors
 ///
-/// Propagates errors from the lock, keystore, blob store, CBOR codec, or
+/// Propagates errors from the lock, key sealer, blob store, CBOR codec, or
 /// RNG.
-pub fn init_or_open_envelope_key(
-    keystore: &dyn Keystore,
+pub async fn init_or_open_envelope_key(
+    key_sealer: &dyn KeySealer,
     blob_store: &dyn AtomicBlobStore,
     lock: &Lock,
     filename: &str,
-    ad: &[u8],
+    context: &[u8],
     now: u64,
 ) -> StoreResult<SecretBox<[u8; 32]>> {
     let _guard = lock.lock()?;
-    if let Some(bytes) = blob_store.read(filename.to_string())? {
+    if let Some(bytes) = blob_store.read(filename.to_string()).await? {
         let envelope = KeyEnvelope::deserialize(&bytes)?;
         let k_intermediate_bytes = Zeroizing::new(
-            keystore
-                .open_sealed(ad.to_vec(), envelope.wrapped_k_intermediate.clone())?,
+            key_sealer
+                .unseal(context.to_vec(), envelope.wrapped_k_intermediate.clone())
+                .await?,
         );
         let k_intermediate = parse_key_32(&k_intermediate_bytes, "intermediate key")?;
         Ok(SecretBox::init_with(|| k_intermediate))
@@ -107,17 +108,17 @@ pub fn init_or_open_envelope_key(
         let mut k_intermediate = Zeroizing::new([0u8; 32]);
         getrandom::fill(k_intermediate.as_mut())
             .map_err(|err| StoreError::Crypto(format!("rng failure: {err}")))?;
-        // `keystore.seal` borrows the plaintext, so `k_intermediate` is
+        // `key_sealer.seal` borrows the plaintext, so `k_intermediate` is
         // never copied into an un-zeroized `Vec<u8>` at this layer. A
-        // `Keystore` bridging to an owned-only interface (e.g. a uniffi
-        // callback like walletkit-core's `DeviceKeystore`) still needs one
+        // `KeySealer` bridging to an owned-only interface (e.g. a uniffi
+        // callback like walletkit-core's `KeySealer`) still needs one
         // owned copy to cross that boundary; that is an accepted,
         // uniffi-imposed limitation (callback interfaces only support
         // pass-by-value), not something fixable from this layer.
-        let wrapped = keystore.seal(ad, k_intermediate.as_slice())?;
+        let wrapped = key_sealer.seal(context, k_intermediate.as_slice()).await?;
         let envelope = KeyEnvelope::new(wrapped, now);
         let bytes = envelope.serialize()?;
-        blob_store.write_atomic(filename.to_string(), bytes)?;
+        blob_store.write_atomic(filename.to_string(), bytes).await?;
         let key_copy = *k_intermediate;
         Ok(SecretBox::init_with(move || key_copy))
     }
@@ -138,7 +139,7 @@ fn parse_key_32(bytes: &[u8], label: &str) -> StoreResult<[u8; 32]> {
 #[cfg(test)]
 mod tests {
     use super::{init_or_open_envelope_key, KeyEnvelope};
-    use crate::{AtomicBlobStore, Keystore, Lock, StoreError, StoreResult};
+    use crate::{AtomicBlobStore, KeySealer, Lock, StoreError, StoreResult};
     use secrecy::ExposeSecret;
     use std::sync::Mutex;
 
@@ -185,23 +186,29 @@ mod tests {
         }
     }
 
-    /// Stub `Keystore` that XORs with a fixed pad. Good enough to verify
-    /// the seal → persist → open round-trip on the envelope wiring.
-    struct XorKeystore {
+    /// Stub `KeySealer` that XORs with a fixed pad. Good enough to verify
+    /// the seal -> persist -> unseal round-trip on the envelope wiring.
+    struct XorKeySealer {
         pad: [u8; 32],
     }
 
-    impl Keystore for XorKeystore {
-        fn seal(&self, _ad: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>> {
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl KeySealer for XorKeySealer {
+        async fn seal(
+            &self,
+            _context: &[u8],
+            plaintext: &[u8],
+        ) -> StoreResult<Vec<u8>> {
             Ok(plaintext
                 .iter()
                 .enumerate()
                 .map(|(i, b)| b ^ self.pad[i % 32])
                 .collect())
         }
-        fn open_sealed(
+        async fn unseal(
             &self,
-            _ad: Vec<u8>,
+            _context: Vec<u8>,
             ciphertext: Vec<u8>,
         ) -> StoreResult<Vec<u8>> {
             Ok(ciphertext
@@ -222,46 +229,50 @@ mod tests {
             }
         }
     }
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     impl AtomicBlobStore for InMemoryBlobs {
-        fn read(&self, path: String) -> StoreResult<Option<Vec<u8>>> {
+        async fn read(&self, path: String) -> StoreResult<Option<Vec<u8>>> {
             Ok(self.inner.lock().unwrap().get(&path).cloned())
         }
-        fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StoreResult<()> {
+        async fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StoreResult<()> {
             self.inner.lock().unwrap().insert(path, bytes);
             Ok(())
         }
-        fn delete(&self, path: String) -> StoreResult<()> {
+        async fn delete(&self, path: String) -> StoreResult<()> {
             self.inner.lock().unwrap().remove(&path);
             Ok(())
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(not(target_arch = "wasm32"))]
-    fn test_init_or_open_envelope_key_round_trip() {
+    async fn test_init_or_open_envelope_key_round_trip() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let lock_path = dir.path().join("envelope.lock");
         let lock = Lock::open(&lock_path).expect("open lock");
 
-        let keystore = XorKeystore { pad: [0xAA; 32] };
+        let key_sealer = XorKeySealer { pad: [0xAA; 32] };
         let blob_store = InMemoryBlobs::new();
         let key_a = init_or_open_envelope_key(
-            &keystore,
+            &key_sealer,
             &blob_store,
             &lock,
             "k.bin",
             b"test-ad",
             100,
         )
+        .await
         .expect("init");
         let key_b = init_or_open_envelope_key(
-            &keystore,
+            &key_sealer,
             &blob_store,
             &lock,
             "k.bin",
             b"test-ad",
             200,
         )
+        .await
         .expect("re-open");
 
         assert_eq!(key_a.expose_secret(), key_b.expose_secret());

--- a/crates/walletkit-db/src/error.rs
+++ b/crates/walletkit-db/src/error.rs
@@ -12,9 +12,9 @@ pub type StoreResult<T> = Result<T, StoreError>;
 /// their own typed error.
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
-    /// Errors coming from the device keystore.
-    #[error("keystore error: {0}")]
-    Keystore(String),
+    /// Errors coming from the key sealer.
+    #[error("key sealer error: {0}")]
+    Sealer(String),
     /// Errors coming from the blob store.
     #[error("blob store error: {0}")]
     BlobStore(String),

--- a/crates/walletkit-db/src/lib.rs
+++ b/crates/walletkit-db/src/lib.rs
@@ -11,7 +11,7 @@
 //!   [`AtomicBlobStore`].
 //! - [`Lock`] / [`LockGuard`] — cross-process exclusive lock (`flock` /
 //!   `LockFileEx` native, no-op on WASM).
-//! - [`Keystore`] / [`AtomicBlobStore`] — plain-Rust trait surface for
+//! - [`KeySealer`] / [`AtomicBlobStore`] — plain-Rust trait surface for
 //!   consumer-supplied platform integrations. Consumers that need FFI define
 //!   their own annotated traits and adapt to these.
 //!
@@ -30,5 +30,5 @@ pub use blobs::{compute_content_id, ContentId};
 pub use envelope::init_or_open_envelope_key;
 pub use error::{StoreError, StoreResult};
 pub use lock::{Lock, LockGuard};
-pub use traits::{AtomicBlobStore, Keystore};
+pub use traits::{AtomicBlobStore, KeySealer};
 pub use vault::Vault;

--- a/crates/walletkit-db/src/traits.rs
+++ b/crates/walletkit-db/src/traits.rs
@@ -4,21 +4,22 @@
 //! existing uniffi-annotated traits so consumers can bridge with a thin
 //! newtype that just delegates and maps errors. (A blanket impl across
 //! crates is blocked by Rust's orphan rule, so consumers do need a small
-//! wrapper.) `Keystore::seal` is the one exception: it borrows its
+//! wrapper.) `KeySealer::seal` is the one exception: it borrows its
 //! plaintext so the secret is never owned by this crate longer than
 //! necessary; a bridge to an owned-only interface (e.g. a uniffi callback)
 //! still needs one copy at that boundary.
 
 use crate::error::StoreResult;
 
-/// Device keystore for sealing and opening secrets under a device-bound key.
+/// Host interface for sealing and unsealing secrets.
 ///
-/// Implementations MUST use an AEAD construction (e.g. AES-GCM or
-/// ChaCha20-Poly1305) so that `aad` (additional authenticated data) is
-/// authenticated as part of the seal: any mismatch when opening must fail.
-pub trait Keystore: Send + Sync {
-    /// Seals plaintext under the device-bound key, authenticating `aad`
-    /// (additional authenticated data).
+/// Implementations must bind sealed values to `context`, whether through AEAD
+/// additional authenticated data, context-specific key selection, or an
+/// equivalent mechanism. Unsealing with a different context must fail.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait KeySealer: Send + Sync {
+    /// Seals plaintext and binds it to `context`.
     ///
     /// `plaintext` is borrowed rather than owned so that callers holding it
     /// in a zeroizing buffer (e.g. `Zeroizing<[u8; 32]>`) never have to
@@ -26,18 +27,22 @@ pub trait Keystore: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns an error if the keystore refuses the operation or the seal
+    /// Returns an error if the key sealer refuses the operation or sealing
     /// fails.
-    fn seal(&self, aad: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>>;
+    async fn seal(&self, context: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>>;
 
-    /// Opens ciphertext under the device-bound key, verifying `aad`. The
-    /// same `aad` supplied at seal time must be supplied here or the open
+    /// Unseals ciphertext after verifying its binding to `context`. The
+    /// same context supplied at seal time must be supplied here or the
     /// operation must fail.
     ///
     /// # Errors
     ///
-    /// Returns an error if authentication fails or the keystore cannot open.
-    fn open_sealed(&self, aad: Vec<u8>, ciphertext: Vec<u8>) -> StoreResult<Vec<u8>>;
+    /// Returns an error if authentication fails or the key cannot be unsealed.
+    async fn unseal(
+        &self,
+        context: Vec<u8>,
+        ciphertext: Vec<u8>,
+    ) -> StoreResult<Vec<u8>>;
 }
 
 /// Atomic blob store for small binary files (e.g. sealed key envelopes).
@@ -51,25 +56,27 @@ pub trait Keystore: Send + Sync {
 /// - **Hosts own where data lives.** iOS sandboxed app-data containers,
 ///   Android per-UID data dirs, iCloud-skip flags, atomic-write
 ///   semantics — all platform-specific. walletkit-db stays neutral.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait AtomicBlobStore: Send + Sync {
     /// Reads the blob at `path`, if present.
     ///
     /// # Errors
     ///
     /// Returns an error if the read fails.
-    fn read(&self, path: String) -> StoreResult<Option<Vec<u8>>>;
+    async fn read(&self, path: String) -> StoreResult<Option<Vec<u8>>>;
 
     /// Writes bytes atomically to `path`.
     ///
     /// # Errors
     ///
     /// Returns an error if the write fails.
-    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StoreResult<()>;
+    async fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StoreResult<()>;
 
     /// Deletes the blob at `path`.
     ///
     /// # Errors
     ///
     /// Returns an error if the delete fails.
-    fn delete(&self, path: String) -> StoreResult<()>;
+    async fn delete(&self, path: String) -> StoreResult<()>;
 }

--- a/crates/walletkit-testkit/Cargo.toml
+++ b/crates/walletkit-testkit/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+async-trait = { workspace = true }
 alloy = { workspace = true, features = ["contract", "json", "getrandom", "signer-local"] }
 alloy-core = { workspace = true }
 eyre = { workspace = true }

--- a/crates/walletkit-testkit/src/authenticator.rs
+++ b/crates/walletkit-testkit/src/authenticator.rs
@@ -47,6 +47,7 @@ pub async fn init_authenticator(
 
     authenticator
         .init_storage(now)
+        .await
         .wrap_err("storage init failed")?;
 
     Ok((authenticator, store))

--- a/crates/walletkit-testkit/src/storage.rs
+++ b/crates/walletkit-testkit/src/storage.rs
@@ -6,29 +6,30 @@ use std::sync::Arc;
 use uuid::Uuid;
 use walletkit_core::authenticator::artifacts::caching::CachingZkArtifacts;
 use walletkit_core::storage::{
-    AtomicBlobStore, CredentialStore, DeviceKeystore, StorageError, StoragePaths,
+    AtomicBlobStore, CredentialStore, KeySealer, StorageError, StoragePaths,
     StorageProvider,
 };
 
-/// No-op device keystore that passes data through without encryption.
+/// No-op key sealer that passes data through without encryption.
 ///
 /// Suitable only for development and testing. In production the real
-/// `DeviceKeystore` is backed by the platform's secure enclave. Used by
+/// `KeySealer` is backed by platform key protection. Used by
 /// [`FsStorageProvider`].
-pub struct NoopDeviceKeystore;
+pub struct NoopKeySealer;
 
-impl DeviceKeystore for NoopDeviceKeystore {
-    fn seal(
+#[async_trait::async_trait]
+impl KeySealer for NoopKeySealer {
+    async fn seal(
         &self,
-        _associated_data: Vec<u8>,
+        _context: Vec<u8>,
         plaintext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         Ok(plaintext)
     }
 
-    fn open_sealed(
+    async fn unseal(
         &self,
-        _associated_data: Vec<u8>,
+        _context: Vec<u8>,
         ciphertext: Vec<u8>,
     ) -> Result<Vec<u8>, StorageError> {
         Ok(ciphertext)
@@ -53,8 +54,9 @@ impl FsAtomicBlobStore {
     }
 }
 
+#[async_trait::async_trait]
 impl AtomicBlobStore for FsAtomicBlobStore {
-    fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
+    async fn read(&self, path: String) -> Result<Option<Vec<u8>>, StorageError> {
         let full = self.base.join(&path);
         match std::fs::read(&full) {
             Ok(bytes) => Ok(Some(bytes)),
@@ -66,7 +68,11 @@ impl AtomicBlobStore for FsAtomicBlobStore {
         }
     }
 
-    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> Result<(), StorageError> {
+    async fn write_atomic(
+        &self,
+        path: String,
+        bytes: Vec<u8>,
+    ) -> Result<(), StorageError> {
         let full = self.base.join(&path);
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -93,7 +99,7 @@ impl AtomicBlobStore for FsAtomicBlobStore {
         Ok(())
     }
 
-    fn delete(&self, path: String) -> Result<(), StorageError> {
+    async fn delete(&self, path: String) -> Result<(), StorageError> {
         let full = self.base.join(&path);
         match std::fs::remove_file(&full) {
             Ok(()) => Ok(()),
@@ -106,10 +112,10 @@ impl AtomicBlobStore for FsAtomicBlobStore {
     }
 }
 
-/// Filesystem [`StorageProvider`] tying together the no-op keystore, fs blob
+/// Filesystem [`StorageProvider`] tying together the no-op key sealer, fs blob
 /// store, and on-disk paths.
 pub struct FsStorageProvider {
-    keystore: Arc<NoopDeviceKeystore>,
+    key_sealer: Arc<NoopKeySealer>,
     blob_store: Arc<FsAtomicBlobStore>,
     paths: Arc<StoragePaths>,
 }
@@ -119,7 +125,7 @@ impl FsStorageProvider {
     #[must_use]
     pub fn open(root: &Path) -> Self {
         Self {
-            keystore: Arc::new(NoopDeviceKeystore),
+            key_sealer: Arc::new(NoopKeySealer),
             blob_store: Arc::new(FsAtomicBlobStore::new(root)),
             paths: Arc::new(StoragePaths::new(root)),
         }
@@ -127,8 +133,8 @@ impl FsStorageProvider {
 }
 
 impl StorageProvider for FsStorageProvider {
-    fn keystore(&self) -> Arc<dyn DeviceKeystore> {
-        self.keystore.clone()
+    fn key_sealer(&self) -> Arc<dyn KeySealer> {
+        self.key_sealer.clone()
     }
 
     fn blob_store(&self) -> Arc<dyn AtomicBlobStore> {


### PR DESCRIPTION
## Summary

- rename `DeviceKeystore` / `Keystore` to `KeySealer`, rename `open_sealed` to `unseal`, and describe the non-secret binding input as `context`
- make `KeySealer` and `AtomicBlobStore` operations async through both the plain Rust and UniFFI adapter layers
- make key-envelope initialization, `StorageKeys::init`, `CredentialStore::init`, and the corresponding `Authenticator` storage lifecycle async
- serialize initialization and destruction without holding the synchronous credential-state mutex across foreign awaits
- update the CLI, testkit, tests, and `walletkit-db` documentation for the new API

The `context` contract is behavioral: unsealing under a different context must fail. Adapters may satisfy it with AEAD AAD, context-specific key selection, or an equivalent mechanism.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `cargo test -p walletkit-db` (11 passed)
- `cargo test -p walletkit-core --lib` (138 passed)
- `cargo test -p walletkit-core --test credential_storage_integration` (1 passed)
- `nix develop .#wasm --command cargo check -p walletkit --features embed-zkeys --target wasm32-unknown-unknown`
- generated Swift and Kotlin bindings inspected for the expected async callback and lifecycle signatures
