### PR TITLE
Update worldchain URLs to the ones in worldchain domain.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-WORLDCHAIN_SEPOLIA_RPC_URL=https://worldchain-sepolia.g.alchemy.com/public # substitute with your own RPC in case of rate limits
-WORLDCHAIN_RPC_URL=https://worldchain-mainnet.g.alchemy.com/public
+WORLDCHAIN_SEPOLIA_RPC_URL=https://rpc.worldchain-sepolia.worldcoin.org # substitute with your own RPC in case of rate limits
+WORLDCHAIN_RPC_URL=https://rpc.worldchain.worldcoin.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,8 @@ jobs:
 
       - name: Run tests
         env:
-          WORLDCHAIN_SEPOLIA_RPC_URL: ${{ secrets.WORLDCHAIN_SEPOLIA_RPC_URL || 'https://worldchain-sepolia.g.alchemy.com/public' }}
-          WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://worldchain-mainnet.g.alchemy.com/public' }}
+          WORLDCHAIN_SEPOLIA_RPC_URL: ${{ secrets.WORLDCHAIN_SEPOLIA_RPC_URL || 'https://rpc.worldchain-sepolia.worldcoin.org' }}
+          WORLDCHAIN_RPC_URL: ${{ secrets.WORLDCHAIN_RPC_URL || 'https://rpc.worldchain.worldcoin.org' }}
         run: |
           cargo nextest run --workspace --all-features
 

--- a/crates/walletkit-core/tests/authenticator_integration.rs
+++ b/crates/walletkit-core/tests/authenticator_integration.rs
@@ -16,9 +16,8 @@ use world_id_core::world_id_registry::WorldIdRegistry;
 
 fn setup_anvil() -> AnvilInstance {
     dotenvy::dotenv().ok();
-    let rpc_url = std::env::var("WORLDCHAIN_RPC_URL").unwrap_or_else(|_| {
-        "https://worldchain-mainnet.g.alchemy.com/public".to_string()
-    });
+    let rpc_url = std::env::var("WORLDCHAIN_RPC_URL")
+        .unwrap_or_else(|_| "https://rpc.worldchain.worldcoin.org".to_string());
 
     let anvil = alloy::node_bindings::Anvil::new().fork(rpc_url).spawn();
     println!(

--- a/crates/walletkit-testkit/src/env.rs
+++ b/crates/walletkit-testkit/src/env.rs
@@ -15,8 +15,7 @@ pub const STAGING_RP_SIGNING_KEY: [u8; 32] =
     hex!("1111111111111111111111111111111111111111111111111111111111111111");
 
 /// Default RPC URL for World Chain Mainnet (chain 480).
-pub const DEFAULT_WORLDCHAIN_RPC_URL: &str =
-    "https://worldchain-mainnet.g.alchemy.com/public";
+pub const DEFAULT_WORLDCHAIN_RPC_URL: &str = "https://rpc.worldchain.worldcoin.org";
 
 /// Hosted faux-issuer endpoint (staging).
 pub const FAUX_ISSUER_URL: &str = "https://faux-issuer.us.id-infra.worldcoin.dev/issue";


### PR DESCRIPTION
Update worldchain URLs to the ones in worldchain domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only URL swaps for dev/CI/test defaults; no application logic or auth changes.
> 
> **Overview**
> **Replaces default World Chain RPC endpoints** from Alchemy public URLs with the official `worldcoin.org` RPC hosts for mainnet and Sepolia.
> 
> Updates are limited to **defaults and examples**: `.env.example`, CI test job fallbacks when secrets are unset (`WORLDCHAIN_RPC_URL` / `WORLDCHAIN_SEPOLIA_RPC_URL`), `DEFAULT_WORLDCHAIN_RPC_URL` in `walletkit-testkit`, and the Anvil fork fallback in the authenticator integration test. Secret overrides in CI behavior are unchanged—only the public fallback URLs differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40859b3570232bd32d24010822daba5a49d1daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->