### PR TITLE
fix: cache session seed keyed by rpId

### DIFF
--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -643,18 +643,21 @@ impl Authenticator {
         }
 
         // Get cached `session_id_r_seed` if session ID is provided in the proof request
+        let rp_id = proof_request.0.rp_id.into_inner();
         let session_id_r_seed =
             proof_request
                 .0
                 .session_id
                 .existing()
-                .and_then(|session_id| {
-                    match self.store.get_session_seed(session_id.oprf_seed, now) {
-                        Ok(seed) => seed,
-                        Err(err) => {
-                            tracing::warn!(error = %err, "failed to load cached session seed, continuing without");
-                            None
-                        }
+                .and_then(|session_id| match self.store.get_session_seed(
+                    rp_id,
+                    session_id.oprf_seed,
+                    now,
+                ) {
+                    Ok(seed) => seed,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "failed to load cached session seed, continuing without");
+                        None
                     }
                 });
 
@@ -672,10 +675,12 @@ impl Authenticator {
         // session_id, so use the session_id generated in the proof response.
         if let Some(seed) = result.session_id_r_seed {
             if let Some(session_id) = result.proof_response.session_id {
-                if let Err(err) =
-                    self.store
-                        .store_session_seed(session_id.oprf_seed, seed, now)
-                {
+                if let Err(err) = self.store.store_session_seed(
+                    rp_id,
+                    session_id.oprf_seed,
+                    seed,
+                    now,
+                ) {
                     tracing::error!("error caching session_id_r_seed: {}", err);
                 }
             }

--- a/crates/walletkit-core/src/storage/cache/mod.rs
+++ b/crates/walletkit-core/src/storage/cache/mod.rs
@@ -72,7 +72,7 @@ impl CacheDb {
         merkle::put(self.vault.connection(), proof_bytes, now, ttl_seconds)
     }
 
-    /// Fetches a cached `session_id_r_seed` for the given `oprf_seed`.
+    /// Fetches a cached `session_id_r_seed` for the given RP and `oprf_seed`.
     ///
     /// Returns `None` when missing or expired.
     ///
@@ -81,27 +81,31 @@ impl CacheDb {
     /// Returns an error if the query fails.
     pub fn session_seed_get(
         &self,
+        rp_id: u64,
         oprf_seed: [u8; 32],
         now: u64,
     ) -> StorageResult<Option<[u8; 32]>> {
-        session::get(self.vault.connection(), oprf_seed, now)
+        let key = util::session_cache_key(rp_id, oprf_seed);
+        session::get(self.vault.connection(), &key, now)
     }
 
-    /// Stores a `session_id_r_seed` keyed by `oprf_seed` with a TTL.
+    /// Stores a `session_id_r_seed` keyed by RP and `oprf_seed` with a TTL.
     ///
     /// # Errors
     ///
     /// Returns an error if the insert fails.
     pub fn session_seed_put(
         &self,
+        rp_id: u64,
         oprf_seed: [u8; 32],
         session_id_r_seed: [u8; 32],
         now: u64,
         ttl_seconds: u64,
     ) -> StorageResult<()> {
+        let key = util::session_cache_key(rp_id, oprf_seed);
         session::put(
             self.vault.connection(),
-            oprf_seed,
+            &key,
             session_id_r_seed,
             now,
             ttl_seconds,
@@ -247,7 +251,7 @@ mod tests {
         let oprf_seed = [0x01u8; 32];
         let r_seed = [0x02u8; 32];
         let now = 1_000;
-        db.session_seed_put(oprf_seed, r_seed, now, 1000)
+        db.session_seed_put(1, oprf_seed, r_seed, now, 1000)
             .expect("put session seed");
         drop(db);
 
@@ -255,7 +259,7 @@ mod tests {
 
         let db = CacheDb::new(&path, &key).expect("rebuild cache");
         let value = db
-            .session_seed_get(oprf_seed, now)
+            .session_seed_get(1, oprf_seed, now)
             .expect("get session seed");
         assert!(value.is_none());
         cleanup_cache_files(&path);
@@ -287,11 +291,11 @@ mod tests {
         let oprf_seed = [0x55u8; 32];
         let r_seed = [0x66u8; 32];
         let now = 100;
-        db.session_seed_put(oprf_seed, r_seed, now, 10)
+        db.session_seed_put(1, oprf_seed, r_seed, now, 10)
             .expect("put session seed");
-        let hit = db.session_seed_get(oprf_seed, now).expect("get");
+        let hit = db.session_seed_get(1, oprf_seed, now).expect("get");
         assert_eq!(hit, Some(r_seed));
-        let miss = db.session_seed_get(oprf_seed, now + 11).expect("get");
+        let miss = db.session_seed_get(1, oprf_seed, now + 11).expect("get");
         assert!(miss.is_none());
         cleanup_cache_files(&path);
         cleanup_lock_file(&lock_path);
@@ -307,7 +311,7 @@ mod tests {
         db.record_activity(&sample_new_activity_entry(), 1000)
             .expect("record activity");
 
-        db.session_seed_put([0x01u8; 32], [0x02u8; 32], 1000, 1000)
+        db.session_seed_put(1, [0x01u8; 32], [0x02u8; 32], 1000, 1000)
             .expect("put session seed");
 
         drop(db);
@@ -324,7 +328,7 @@ mod tests {
         let db = CacheDb::new(&path, &key).expect("reopen cache after version bump");
 
         let seed = db
-            .session_seed_get([0x01u8; 32], 1000)
+            .session_seed_get(1, [0x01u8; 32], 1000)
             .expect("get session seed");
 
         assert!(

--- a/crates/walletkit-core/src/storage/cache/schema.rs
+++ b/crates/walletkit-core/src/storage/cache/schema.rs
@@ -5,9 +5,9 @@
 //!
 //! The keys adhere to the following schema:
 //!
-//! - `0x01` — Merkle inclusion proof; at most one entry; value is the proof bytes.
-//! - `0x02 || oprf_seed` — session seed; value is the `session_id_r_seed`.
-//! - `0x03 || nullifier` — replay guard; value is a presence marker.
+//! - Merkle Inclusion Proof: `0x01`; at most one entry; value is the proof bytes.
+//! - Session Seeds: `0x02 || rp_id (8-byte big-endian) || oprf_seed`; value is the `session_id_r_seed`.
+//! - Nullifier Replay Guards: `0x03 || nullifier`; value is a presence marker.
 
 pub(super) const CACHE_KEY_PREFIX_MERKLE: u8 = 0x01;
 pub(super) const CACHE_KEY_PREFIX_SESSION: u8 = 0x02;

--- a/crates/walletkit-core/src/storage/cache/session.rs
+++ b/crates/walletkit-core/src/storage/cache/session.rs
@@ -3,43 +3,100 @@
 use crate::storage::error::StorageResult;
 use walletkit_sqlite::Connection;
 
-use super::util::{
+use crate::storage::cache::util::{
     cache_entry_times, get_cache_entry, parse_fixed_bytes, prune_expired_entries,
-    session_cache_key, upsert_cache_entry,
+    upsert_cache_entry,
 };
 
-/// Fetches a cached `session_id_r_seed` for the given `oprf_seed`, if still valid.
+/// Fetches a cached `session_id_r_seed` for the given key, if still valid.
 ///
 /// # Errors
 ///
 /// Returns an error if the query fails or the cached bytes are malformed.
 pub(super) fn get(
     conn: &Connection,
-    oprf_seed: [u8; 32],
+    key: &[u8],
     now: u64,
 ) -> StorageResult<Option<[u8; 32]>> {
-    let key = session_cache_key(oprf_seed);
-    let raw = get_cache_entry(conn, key.as_slice(), now, None)?;
+    let raw = get_cache_entry(conn, key, now, None)?;
     match raw {
         Some(bytes) => Ok(Some(parse_fixed_bytes::<32>(&bytes, "session_id_r_seed")?)),
         None => Ok(None),
     }
 }
 
-/// Stores a `session_id_r_seed` keyed by `oprf_seed` with a TTL.
+/// Stores a `session_id_r_seed` under the given key with a TTL.
 ///
 /// # Errors
 ///
 /// Returns an error if pruning or insert fails.
 pub(super) fn put(
     conn: &Connection,
-    oprf_seed: [u8; 32],
+    key: &[u8],
     session_id_r_seed: [u8; 32],
     now: u64,
     ttl_seconds: u64,
 ) -> StorageResult<()> {
-    let key = session_cache_key(oprf_seed);
     prune_expired_entries(conn, now)?;
     let times = cache_entry_times(now, ttl_seconds)?;
-    upsert_cache_entry(conn, key.as_slice(), session_id_r_seed.as_ref(), times)
+    upsert_cache_entry(conn, key, session_id_r_seed.as_ref(), times)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::CacheDb;
+    use secrecy::SecretBox;
+    use walletkit_sqlite::params;
+
+    #[test]
+    fn session_seeds_are_isolated_by_rp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = SecretBox::init_with(|| [0x11; 32]);
+        let db = CacheDb::new(&dir.path().join("cache.sqlite"), &key).expect("cache");
+        let oprf_seed = [0x22; 32];
+        let seed_a = [0x33; 32];
+        let seed_b = [0x44; 32];
+
+        db.session_seed_put(1, oprf_seed, seed_a, 100, 10)
+            .expect("put A");
+        assert_eq!(db.session_seed_get(2, oprf_seed, 100).expect("get B"), None);
+        db.session_seed_put(2, oprf_seed, seed_b, 100, 10)
+            .expect("put B");
+        assert_eq!(
+            db.session_seed_get(1, oprf_seed, 100).expect("get A"),
+            Some(seed_a)
+        );
+        assert_eq!(
+            db.session_seed_get(2, oprf_seed, 100).expect("get B"),
+            Some(seed_b)
+        );
+        assert_eq!(
+            db.session_seed_get(1, [0x55; 32], 100).expect("other seed"),
+            None
+        );
+    }
+
+    #[test]
+    fn unscoped_session_seeds_are_ignored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = SecretBox::init_with(|| [0x11; 32]);
+        let db = CacheDb::new(&dir.path().join("cache.sqlite"), &key).expect("cache");
+        let mut old_key = [0x22; 33];
+        old_key[0] = 0x02;
+        let seed = [0x33; 32];
+        db.vault.connection().execute(
+            "INSERT INTO cache_entries (key_bytes, value_bytes, inserted_at, expires_at)
+             VALUES (?1, ?2, 100, 110)",
+            params![old_key.as_slice(), seed.as_slice()],
+        ).expect("insert unscoped seed");
+
+        assert_eq!(
+            db.session_seed_get(1, [0x22; 32], 100).expect("get A"),
+            None
+        );
+        assert_eq!(
+            db.session_seed_get(2, [0x22; 32], 100).expect("get B"),
+            None
+        );
+    }
 }

--- a/crates/walletkit-core/src/storage/cache/util.rs
+++ b/crates/walletkit-core/src/storage/cache/util.rs
@@ -206,8 +206,10 @@ fn cache_key_with_prefix(prefix: u8, payload: &[u8]) -> Vec<u8> {
 }
 
 /// Builds the cache key for a session key entry.
-pub(super) fn session_cache_key(rp_id: [u8; 32]) -> Vec<u8> {
-    cache_key_with_prefix(CACHE_KEY_PREFIX_SESSION, rp_id.as_ref())
+pub(super) fn session_cache_key(rp_id: u64, oprf_seed: [u8; 32]) -> Vec<u8> {
+    let mut key = cache_key_with_prefix(CACHE_KEY_PREFIX_SESSION, &rp_id.to_be_bytes());
+    key.extend_from_slice(&oprf_seed);
+    key
 }
 
 /// Builds the cache key for a replay-guard nullifier entry.
@@ -235,4 +237,20 @@ pub(super) fn to_u64(value: i64, label: &str) -> StorageResult<u64> {
     u64::try_from(value).map_err(|_| {
         StorageError::CacheDb(format!("{label} out of range for u64: {value}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::cache::util::session_cache_key;
+
+    #[test]
+    fn session_cache_key_bytes() {
+        assert_eq!(
+            hex::encode(session_cache_key(0x0102_0304_0506_0708, [0x22; 32])),
+            concat!(
+                "020102030405060708",
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            )
+        );
+    }
 }

--- a/crates/walletkit-core/src/storage/credential_storage.rs
+++ b/crates/walletkit-core/src/storage/credential_storage.rs
@@ -483,25 +483,27 @@ impl CredentialStore {
     /// Returns an error if the store is not initialized or the insert fails.
     pub fn store_session_seed(
         &self,
+        rp_id: u64,
         oprf_seed: CoreFieldElement,
         session_id_r_seed: CoreFieldElement,
         now: u64,
     ) -> StorageResult<()> {
         self.lock_inner()?
-            .store_session_seed(oprf_seed, session_id_r_seed, now)
+            .store_session_seed(rp_id, oprf_seed, session_id_r_seed, now)
     }
 
-    /// Retrieves the `session_id_r_seed` for a given `oprf_seed`, if not expired.
+    /// Retrieves the `session_id_r_seed` for a given RP and `oprf_seed`, if not expired.
     ///
     /// # Errors
     ///
     /// Returns an error if the store is not initialized or the query fails.
     pub fn get_session_seed(
         &self,
+        rp_id: u64,
         oprf_seed: CoreFieldElement,
         now: u64,
     ) -> StorageResult<Option<CoreFieldElement>> {
-        self.lock_inner()?.get_session_seed(oprf_seed, now)
+        self.lock_inner()?.get_session_seed(rp_id, oprf_seed, now)
     }
 
     /// Fetches a cached Merkle proof if it remains valid beyond `valid_before`.
@@ -760,12 +762,14 @@ impl CredentialStoreInner {
 
     fn store_session_seed(
         &mut self,
+        rp_id: u64,
         oprf_seed: CoreFieldElement,
         session_id_r_seed: CoreFieldElement,
         now: u64,
     ) -> StorageResult<()> {
         let state = self.state_mut()?;
         state.cache.session_seed_put(
+            rp_id,
             oprf_seed.to_be_bytes(),
             session_id_r_seed.to_be_bytes(),
             now,
@@ -775,11 +779,15 @@ impl CredentialStoreInner {
 
     fn get_session_seed(
         &self,
+        rp_id: u64,
         oprf_seed: CoreFieldElement,
         now: u64,
     ) -> StorageResult<Option<CoreFieldElement>> {
         let state = self.state()?;
-        let Some(bytes) = state.cache.session_seed_get(oprf_seed.to_be_bytes(), now)?
+        let Some(bytes) =
+            state
+                .cache
+                .session_seed_get(rp_id, oprf_seed.to_be_bytes(), now)?
         else {
             return Ok(None);
         };

--- a/crates/walletkit-core/tests/proof_generation_integration.rs
+++ b/crates/walletkit-core/tests/proof_generation_integration.rs
@@ -150,7 +150,7 @@ async fn e2e_session_proof() -> Result<()> {
         .session_id
         .expect("create-session response should include session_id");
     let cached_seed = store
-        .get_session_seed(session_id.oprf_seed, now)
+        .get_session_seed(create_request.rp_id.into_inner(), session_id.oprf_seed, now)
         .wrap_err("get_session_seed failed")?;
     assert!(
         cached_seed.is_some(),


### PR DESCRIPTION
### Context
The session seeds are implicitly RP-scoped. The derivation through the OPRF path keys RP information to each seed. However, when pulling from cache, a seed may be pulled for a different RP than the one making the request. This fixes it.

### Changes
The seed is now cached keyed by the `rpId` as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-proof caching semantics (old entries ignored); incorrect cross-RP reuse before this fix could have affected session proof correctness.
> 
> **Overview**
> Fixes **cross-RP session seed cache collisions** by including the proof request’s **`rp_id`** whenever `session_id_r_seed` is read or written during `generate_proof`.
> 
> Cache keys change from `0x02 || oprf_seed` to **`0x02 || rp_id (big-endian u64) || oprf_seed`** via `session_cache_key`; `CredentialStore` / `CacheDb` APIs now take `rp_id`, and legacy unscoped rows are **not** returned. Tests cover RP isolation, key encoding, and the integration path that asserts seeds are cached after create-session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d475cf99bc4df5042c65a650f02726d1d01ff138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->