### PR TITLE
fix: persist and atomically retrieve credential-associated data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2735,7 +2735,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2910,7 +2910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3885,7 +3885,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4550,7 +4550,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5914,7 +5914,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6223,7 +6223,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -6442,7 +6444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6522,7 +6524,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7831,10 +7833,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9053,7 +9055,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9377,8 +9379,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "world-id-authenticator"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a65b6afa935d2d538ef7eb816abd660cb7b5b6e70094019955880b75fd9c918"
+source = "git+https://github.com/worldcoin/world-id-protocol?rev=8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1#8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -9392,7 +9393,7 @@ dependencies = [
  "hex",
  "ohttp",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "ruint",
  "rustls",
  "secrecy",
@@ -9413,8 +9414,7 @@ dependencies = [
 [[package]]
 name = "world-id-core"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db00ee9ca15e60998adb093170c34703ad41ef7e5df314e22c18f8dd6d6bd6ca"
+source = "git+https://github.com/worldcoin/world-id-protocol?rev=8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1#8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1"
 dependencies = [
  "taceo-eddsa-babyjubjub",
  "world-id-authenticator",
@@ -9426,8 +9426,7 @@ dependencies = [
 [[package]]
 name = "world-id-primitives"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ac44fcbb959d6460462b29ee8798ef28baa13cea47ac8e2e9ea4edb22be3b"
+source = "git+https://github.com/worldcoin/world-id-protocol?rev=8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1#8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -9461,8 +9460,7 @@ dependencies = [
 [[package]]
 name = "world-id-proof"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acca04a42f14cf1a5f3662de82218f5293013196ef6f464480e47172aeb3bad"
+source = "git+https://github.com/worldcoin/world-id-protocol?rev=8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1#8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -9479,7 +9477,7 @@ dependencies = [
  "provekit-verifier",
  "rand 0.8.6",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "ruint",
  "serde",
  "taceo-ark-babyjubjub",
@@ -9499,8 +9497,7 @@ dependencies = [
 [[package]]
 name = "world-id-registries"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3da86a790df7e1962dbba8f05b32c52e2c3fa27bbf5841ccc8d31338b9e67bb"
+source = "git+https://github.com/worldcoin/world-id-protocol?rev=8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1#8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ zeroize = "1"
 zip = { version = "2", default-features = false }
 
 # world-id-protocol crates
-world-id-core = { version = "0.14", default-features = false }
-world-id-proof = { version = "0.14", default-features = false }
+world-id-core = { git = "https://github.com/worldcoin/world-id-protocol", rev = "8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1", default-features = false }
+world-id-proof = { git = "https://github.com/worldcoin/world-id-protocol", rev = "8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1", default-features = false }
 
 # internal
 walletkit-core = { version = "0.21.4", path = "crates/walletkit-core", default-features = false }

--- a/crates/walletkit-core/src/authenticator/mod.rs
+++ b/crates/walletkit-core/src/authenticator/mod.rs
@@ -1434,22 +1434,28 @@ mod tests {
     }
 
     #[cfg(feature = "embed-zkeys")]
+    #[test_case::test_case(0, false; "active authenticator")]
+    #[test_case::test_case(1, true; "revoked authenticator")]
     #[tokio::test]
-    async fn test_init_with_config_and_materials() {
+    async fn test_init_with_config_and_materials(recovery_counter: u64, revoked: bool) {
         use crate::{
             authenticator::artifacts::caching::CachingZkArtifacts,
             storage::tests_utils::{
                 cleanup_test_storage, temp_root_path, InMemoryStorageProvider,
             },
         };
-        use alloy::primitives::address;
+        use alloy::primitives::{address, keccak256};
         use world_id_core::primitives::{Config, ServiceEndpoint};
 
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let mut mock_server = mockito::Server::new_async().await;
-        mock_server
+        let account = mock_server
             .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(format!(
+                "0x{}",
+                hex::encode(&keccak256("getPackedAccountData(address)")[..4])
+            )))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -1457,6 +1463,25 @@ mod tests {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let recovery = mock_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(format!(
+                "0x{}{:064x}",
+                hex::encode(&keccak256("getRecoveryCounter(uint64)")[..4]),
+                1,
+            )))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": format!("0x{recovery_counter:064x}"),
                 })
                 .to_string(),
             )
@@ -1487,14 +1512,23 @@ mod tests {
         let artifacts =
             Arc::new(CachingZkArtifacts::new(Arc::new(store.paths().unwrap())));
 
-        let _authenticator = Authenticator::init(
+        let result = Authenticator::init(
             [2u8; 32].to_vec(),
             &config,
             artifacts,
             Arc::new(store),
         )
-        .await
-        .unwrap();
+        .await;
+        if revoked {
+            assert!(matches!(
+                result,
+                Err(WalletKitError::UnauthorizedAuthenticator)
+            ));
+        } else {
+            assert!(result.is_ok(), "active authenticator must initialize");
+        }
+        account.assert_async().await;
+        recovery.assert_async().await;
         drop(mock_server);
 
         cleanup_test_storage(&root);

--- a/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
+++ b/crates/walletkit-core/src/issuers/recovery_bindings_manager.rs
@@ -282,7 +282,7 @@ mod tests {
         let private_key =
             "d1995ace62b15d907bfb351ffe3cac57a8a84089a1b034101d2d7c78da415d58";
         let private_key_bytes = hex::decode(private_key).unwrap();
-        let (mock_eth_server, eth_mock) = create_mock_eth_server().await;
+        let (mock_eth_server, eth_mock, recovery_mock) = create_mock_eth_server().await;
         let rpc_url = mock_eth_server.url();
         let authenticator =
             create_test_authenticator(&private_key_bytes, rpc_url).await;
@@ -322,6 +322,7 @@ mod tests {
 
         mock.assert_async().await;
         eth_mock.assert_async().await;
+        recovery_mock.assert_async().await;
         drop(pop_api_server);
         drop(mock_eth_server);
     }
@@ -336,7 +337,7 @@ mod tests {
         let private_key =
             "d1995ace62b15d907bfb351ffe3cac57a8a84089a1b034101d2d7c78da415d58";
         let private_key_bytes = hex::decode(private_key).unwrap();
-        let (mock_eth_server, eth_mock) = create_mock_eth_server().await;
+        let (mock_eth_server, eth_mock, recovery_mock) = create_mock_eth_server().await;
         let rpc_url = mock_eth_server.url();
         let authenticator =
             create_test_authenticator(&private_key_bytes, rpc_url).await;
@@ -371,6 +372,7 @@ mod tests {
         let expect_signature = "0x72ec312737276c94e3ac32ab1c393a63b9474480d3a9eb434b8bf6927b7222ef7eb1fea0812ff62a7fb144db9631751e505969162a9c590cabb27bf0bd5005581c";
         assert_eq!(security_token, expect_signature);
         eth_mock.assert_async().await;
+        recovery_mock.assert_async().await;
         drop(mock_eth_server);
     }
 
@@ -403,10 +405,16 @@ mod tests {
         )
     }
 
-    async fn create_mock_eth_server() -> (ServerGuard, mockito::Mock) {
+    async fn create_mock_eth_server() -> (ServerGuard, mockito::Mock, mockito::Mock) {
+        use alloy::primitives::keccak256;
         let mut mock_eth_server = mockito::Server::new_async().await;
         let mock = mock_eth_server
             .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(format!(
+                "0x({}|{})",
+                hex::encode(&keccak256("getPackedAccountData(address)")[..4]),
+                hex::encode(&keccak256("getSignatureNonce(uint64)")[..4]),
+            )))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
@@ -421,6 +429,25 @@ mod tests {
             .expect_at_most(2)
             .create_async()
             .await;
-        (mock_eth_server, mock)
+        let recovery = mock_eth_server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Regex(format!(
+                "0x{}{:064x}",
+                hex::encode(&keccak256("getRecoveryCounter(uint64)")[..4]),
+                42,
+            )))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": format!("0x{:064x}", 0),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        (mock_eth_server, mock, recovery)
     }
 }

--- a/crates/walletkit-core/src/storage/credential_storage.rs
+++ b/crates/walletkit-core/src/storage/credential_storage.rs
@@ -13,7 +13,9 @@ use super::traits::StorageProvider;
 #[cfg(not(target_arch = "wasm32"))]
 use super::traits::{ActivityChangedListener, VaultChangedListener};
 use super::traits::{AtomicBlobStore, DeviceKeystore};
-use super::types::{ActivityEntry, ActivityMetadata, ActivityQuery, CredentialRecord};
+use super::types::{
+    ActivityEntry, ActivityMetadata, ActivityQuery, CredentialData, CredentialRecord,
+};
 use super::ACCOUNT_KEYS_FILENAME;
 use super::{CacheDb, CredentialVault};
 use super::{StorageLock, StorageLockGuard};
@@ -246,6 +248,53 @@ impl CredentialStore {
             .state()?
             .vault
             .fetch_credential_associated_data(issuer_schema_id, now)
+    }
+
+    /// Reads the selected unexpired credential and associated data in one query.
+    ///
+    /// # Errors
+    /// Returns an error if the store is unavailable or the query fails.
+    pub fn fetch_credential_data(
+        &self,
+        issuer_schema_id: u64,
+        now: u64,
+    ) -> StorageResult<Option<CredentialData>> {
+        self.lock_inner()?
+            .state()?
+            .vault
+            .fetch_credential_data(issuer_schema_id, now)
+    }
+
+    /// Repairs issuer-defined data while guarding against a deleted/replaced credential.
+    /// Callers must validate the data's commitment before storing it.
+    ///
+    /// # Errors
+    /// Returns an error if the store is unavailable or the transaction fails.
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "UniFFI accepts owned byte buffers"
+    )]
+    pub fn set_credential_associated_data(
+        &self,
+        credential_id: u64,
+        expected_credential_bytes: Vec<u8>,
+        associated_data: Vec<u8>,
+        now: u64,
+    ) -> StorageResult<bool> {
+        let result = self
+            .lock_inner()?
+            .state()?
+            .vault
+            .set_credential_associated_data(
+                credential_id,
+                &expected_credential_bytes,
+                &associated_data,
+                now,
+            );
+        if matches!(result, Ok(true)) {
+            self.notify_vault_changed();
+        }
+        result
     }
 
     /// Deletes a credential by ID.

--- a/crates/walletkit-core/src/storage/credential_storage.rs
+++ b/crates/walletkit-core/src/storage/credential_storage.rs
@@ -228,6 +228,26 @@ impl CredentialStore {
             .map(|(credential, _blinding_factor)| std::sync::Arc::new(credential)))
     }
 
+    /// Retrieves associated data from the most recent non-expired credential.
+    ///
+    /// Returns `None` if that credential has no associated data or no usable
+    /// credential exists. Never falls back to an older credential's data.
+    /// Consumers must validate the issuer-defined data format and commitment.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store is uninitialized or the query fails.
+    pub fn fetch_credential_associated_data(
+        &self,
+        issuer_schema_id: u64,
+        now: u64,
+    ) -> StorageResult<Option<Vec<u8>>> {
+        self.lock_inner()?
+            .state()?
+            .vault
+            .fetch_credential_associated_data(issuer_schema_id, now)
+    }
+
     /// Deletes a credential by ID.
     ///
     /// # Errors

--- a/crates/walletkit-core/src/storage/credential_vault/mod.rs
+++ b/crates/walletkit-core/src/storage/credential_vault/mod.rs
@@ -298,7 +298,7 @@ impl CredentialVault {
              FROM credential_records cr
              INNER JOIN blob_objects blob ON cr.credential_blob_cid = blob.content_id
              WHERE cr.expires_at > ?1 AND cr.issuer_schema_id = ?2
-             ORDER BY cr.updated_at DESC
+             ORDER BY cr.updated_at DESC, cr.credential_id DESC
              LIMIT 1";
 
         let mut stmt = self
@@ -315,6 +315,45 @@ impl CredentialVault {
                 Ok(Some((credential_blob, blinding_factor)))
             }
             StepResult::Done => Ok(None),
+        }
+    }
+
+    /// Retrieves the associated data of the credential selected for proof generation.
+    ///
+    /// Missing data on the selected credential returns `None`; an older credential's
+    /// data must never be substituted. The issuer defines the format and commitment
+    /// scheme, which the consumer must validate before using these bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn fetch_credential_associated_data(
+        &self,
+        issuer_schema_id: u64,
+        now: u64,
+    ) -> StorageResult<Option<Vec<u8>>> {
+        let mut stmt = self
+            .vault
+            .connection()
+            .prepare(
+                "SELECT data.bytes
+                 FROM credential_records cr
+                 LEFT JOIN blob_objects data ON cr.associated_data_cid = data.content_id
+                 WHERE cr.expires_at > ?1 AND cr.issuer_schema_id = ?2
+                 ORDER BY cr.updated_at DESC, cr.credential_id DESC
+                 LIMIT 1",
+            )
+            .map_err(|err| map_db_err(&err))?;
+        stmt.bind_values(params![
+            to_i64(now, "now")?,
+            to_i64(issuer_schema_id, "issuer_schema_id")?
+        ])
+        .map_err(|err| map_db_err(&err))?;
+        match stmt.step().map_err(|err| map_db_err(&err))? {
+            StepResult::Row(row) if !row.is_column_null(0) => {
+                Ok(Some(row.column_blob(0)))
+            }
+            StepResult::Row(_) | StepResult::Done => Ok(None),
         }
     }
 

--- a/crates/walletkit-core/src/storage/credential_vault/mod.rs
+++ b/crates/walletkit-core/src/storage/credential_vault/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 use std::path::Path;
 
 use crate::storage::error::{StorageError, StorageResult};
-use crate::storage::types::{BlobKind, CredentialRecord};
+use crate::storage::types::{BlobKind, CredentialData, CredentialRecord};
 use schema::{ensure_schema, VAULT_SCHEMA_VERSION};
 use secrecy::SecretBox;
 use walletkit_db::{blobs, Vault};
@@ -219,6 +219,82 @@ impl CredentialVault {
         }
 
         Ok(records)
+    }
+
+    /// Atomically reads the selected credential and its associated data.
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub fn fetch_credential_data(
+        &self,
+        issuer_schema_id: u64,
+        now: u64,
+    ) -> StorageResult<Option<CredentialData>> {
+        let mut stmt = self.vault.connection().prepare(
+            "SELECT cr.credential_id, credential.bytes, data.bytes
+             FROM credential_records cr
+             JOIN blob_objects credential ON cr.credential_blob_cid = credential.content_id
+             LEFT JOIN blob_objects data ON cr.associated_data_cid = data.content_id
+             WHERE cr.expires_at > ?1 AND cr.issuer_schema_id = ?2
+             ORDER BY cr.updated_at DESC, cr.credential_id DESC LIMIT 1"
+        ).map_err(|err| map_db_err(&err))?;
+        stmt.bind_values(params![
+            to_i64(now, "now")?,
+            to_i64(issuer_schema_id, "issuer_schema_id")?
+        ])
+        .map_err(|err| map_db_err(&err))?;
+        match stmt.step().map_err(|err| map_db_err(&err))? {
+            StepResult::Row(row) => Ok(Some(CredentialData {
+                credential_id: to_u64(row.column_i64(0), "credential_id")?,
+                credential_bytes: row.column_blob(1),
+                associated_data: if row.is_column_null(2) {
+                    None
+                } else {
+                    Some(row.column_blob(2))
+                },
+            })),
+            StepResult::Done => Ok(None),
+        }
+    }
+
+    /// Repairs associated data only if this ID still contains the expected unexpired credential.
+    /// Does not change credential selection order or the blinding factor.
+    ///
+    /// # Errors
+    /// Returns an error if the transaction fails.
+    pub fn set_credential_associated_data(
+        &self,
+        credential_id: u64,
+        expected_credential_bytes: &[u8],
+        associated_data: &[u8],
+        now: u64,
+    ) -> StorageResult<bool> {
+        let conn = self.vault.connection();
+        let tx = conn.transaction().map_err(|err| map_db_err(&err))?;
+        let matches: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM credential_records cr
+             JOIN blob_objects credential ON cr.credential_blob_cid = credential.content_id
+             WHERE cr.credential_id = ?1 AND credential.bytes = ?2 AND cr.expires_at > ?3",
+            params![to_i64(credential_id, "credential_id")?, expected_credential_bytes, to_i64(now, "now")?],
+            |row| Ok(row.column_i64(0))
+        ).map_err(|err| map_db_err(&err))?;
+        if matches != 1 {
+            return Ok(false);
+        }
+        let cid =
+            blobs::put(conn, BlobKind::AssociatedData as u8, associated_data, now)?;
+        tx.execute(
+            "UPDATE credential_records SET associated_data_cid = ?1 WHERE credential_id = ?2",
+            params![cid.as_slice(), to_i64(credential_id, "credential_id")?]
+        ).map_err(|err| map_db_err(&err))?;
+        tx.execute(
+            "DELETE FROM blob_objects WHERE blob_kind = ?1 AND NOT EXISTS (
+                SELECT 1 FROM credential_records cr WHERE cr.associated_data_cid = blob_objects.content_id
+             )",
+            params![BlobKind::AssociatedData.as_i64()]
+        ).map_err(|err| map_db_err(&err))?;
+        tx.commit().map_err(|err| map_db_err(&err))?;
+        Ok(true)
     }
 
     /// Deletes a credential record by ID.

--- a/crates/walletkit-core/src/storage/credential_vault/tests.rs
+++ b/crates/walletkit-core/src/storage/credential_vault/tests.rs
@@ -149,6 +149,71 @@ fn test_store_credential_with_associated_data() {
 }
 
 #[test]
+fn associated_data_follows_selected_credential_without_stale_fallback() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let key = SecretBox::init_with(|| [0x42; 32]);
+    let vault = CredentialVault::new(&directory.path().join("vault.sqlite"), &key)
+        .expect("open vault");
+    let insert = |issuer, expiry, bytes, data, now| {
+        vault
+            .store_credential(
+                issuer,
+                sample_blinding_factor(),
+                1,
+                expiry,
+                bytes,
+                data,
+                now,
+            )
+            .expect("store")
+    };
+    insert(1, 500, vec![1], Some(vec![11]), 100);
+    insert(2, 500, vec![2], Some(vec![22]), 101);
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 102).unwrap(),
+        Some(vec![11])
+    );
+    assert_eq!(
+        vault.fetch_credential_associated_data(3, 102).unwrap(),
+        None
+    );
+    // Same-second inserts select the newer row for both proof and data.
+    let newer = insert(1, 400, vec![3], None, 100);
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 102).unwrap(),
+        None
+    );
+    assert_eq!(
+        vault
+            .fetch_credential_and_blinding_factor(1, 102)
+            .unwrap()
+            .unwrap()
+            .0,
+        vec![3]
+    );
+    vault.delete_credential(newer).expect("delete newer");
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 102).unwrap(),
+        Some(vec![11])
+    );
+    // An empty blob is present data, not SQL NULL.
+    insert(1, 300, vec![4], Some(vec![]), 103);
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 104).unwrap(),
+        Some(vec![])
+    );
+    // Expiration uses the same exclusive upper bound as proof generation.
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 300).unwrap(),
+        Some(vec![11])
+    );
+    assert_eq!(
+        vault.fetch_credential_associated_data(1, 500).unwrap(),
+        None
+    );
+}
+
+#[test]
 fn test_content_id_deduplication() {
     let path = temp_vault_path();
     let lock_path = temp_lock_path();

--- a/crates/walletkit-core/src/storage/credential_vault/tests.rs
+++ b/crates/walletkit-core/src/storage/credential_vault/tests.rs
@@ -721,3 +721,97 @@ fn test_vault_corruption_handling() {
     cleanup_vault_files(&path);
     cleanup_lock_file(&lock_path);
 }
+
+#[test]
+fn credential_data_snapshot_and_conditional_repair_preserve_selection() {
+    let path = temp_vault_path();
+    let key = SecretBox::init_with(|| [0x42; 32]);
+    let vault = CredentialVault::new(&path, &key).unwrap();
+    let first = vault
+        .store_credential(
+            1,
+            sample_blinding_factor(),
+            1,
+            500,
+            vec![1],
+            Some(vec![10]),
+            100,
+        )
+        .unwrap();
+    let second = vault
+        .store_credential(1, sample_blinding_factor(), 1, 500, vec![2], None, 100)
+        .unwrap();
+    let snapshot = vault.fetch_credential_data(1, 101).unwrap().unwrap();
+    assert_eq!(snapshot.credential_id, second);
+    assert_eq!(snapshot.credential_bytes, vec![2]);
+    assert!(snapshot.associated_data.is_none());
+    assert!(!vault
+        .set_credential_associated_data(second, &[1], &[99], 102)
+        .unwrap());
+    assert!(vault
+        .set_credential_associated_data(first, &[1], &[11], 103)
+        .unwrap());
+    // Repairing an older record must not move it ahead of the selected one.
+    assert_eq!(
+        vault
+            .fetch_credential_data(1, 104)
+            .unwrap()
+            .unwrap()
+            .credential_id,
+        second
+    );
+    assert!(vault
+        .set_credential_associated_data(second, &[2], &[22], 105)
+        .unwrap());
+    assert_eq!(
+        vault
+            .fetch_credential_data(1, 106)
+            .unwrap()
+            .unwrap()
+            .associated_data,
+        Some(vec![22])
+    );
+    assert_eq!(
+        vault
+            .fetch_credential_and_blinding_factor(1, 106)
+            .unwrap()
+            .unwrap()
+            .1,
+        sample_blinding_factor()
+    );
+    drop(vault);
+    let reopened = CredentialVault::new(&path, &key).unwrap();
+    assert_eq!(
+        reopened
+            .fetch_credential_data(1, 107)
+            .unwrap()
+            .unwrap()
+            .associated_data,
+        Some(vec![22])
+    );
+    drop(reopened);
+    cleanup_vault_files(&path);
+}
+
+#[test]
+fn associated_data_repair_rejects_deleted_and_expired_records() {
+    let path = temp_vault_path();
+    let key = SecretBox::init_with(|| [0x42; 32]);
+    let vault = CredentialVault::new(&path, &key).unwrap();
+    let expired = vault
+        .store_credential(1, sample_blinding_factor(), 1, 101, vec![1], None, 100)
+        .unwrap();
+    assert!(!vault
+        .set_credential_associated_data(expired, &[1], &[10], 101)
+        .unwrap());
+    let deleted = vault
+        .store_credential(1, sample_blinding_factor(), 1, 500, vec![2], None, 100)
+        .unwrap();
+    vault.delete_credential(deleted).unwrap();
+    assert!(!vault
+        .set_credential_associated_data(deleted, &[2], &[20], 102)
+        .unwrap());
+    assert!(vault.fetch_credential_data(1, 102).unwrap().is_none());
+    drop(vault);
+    cleanup_vault_files(&path);
+}

--- a/crates/walletkit-core/src/storage/types.rs
+++ b/crates/walletkit-core/src/storage/types.rs
@@ -4,6 +4,18 @@ use strum::{Display, EnumString};
 
 use super::error::{StorageError, StorageResult};
 
+/// One atomic snapshot of the selected credential and its issuer-defined data.
+/// Biometric payloads may be present; intentionally does not implement Debug.
+#[derive(Clone, PartialEq, Eq, uniffi::Record)]
+pub struct CredentialData {
+    /// Vault record ID, used for conditional associated-data repair.
+    pub credential_id: u64,
+    /// The exact serialized credential stored in the vault.
+    pub credential_bytes: Vec<u8>,
+    /// Optional issuer-defined payload; consumers must verify its commitment.
+    pub associated_data: Option<Vec<u8>>,
+}
+
 /// Kind of blob stored in the vault.
 ///
 /// Blob records (stored in the `blob_objects` table) carry a kind tag that

--- a/swift/host-cc.sh
+++ b/swift/host-cc.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Host build dependencies must execute on macOS, even during an iOS cross-build.
+# Keep the selected Xcode (DEVELOPER_DIR), but remove the target SDK/deployment
+# overrides before resolving its native C compiler. Do not disable compiler checks.
+unset IPHONEOS_DEPLOYMENT_TARGET SDKROOT
+exec xcrun --sdk macosx clang "$@"

--- a/xtask/src/swift/build.rs
+++ b/xtask/src/swift/build.rs
@@ -162,6 +162,10 @@ fn resolve_output_dir(output_dir: Option<&Path>) -> PathBuf {
 
 fn configure_ios_build(sh: &Shell, profile: Profile) {
     sh.set_var("IPHONEOS_DEPLOYMENT_TARGET", "13.0");
+    // Cargo also compiles host build dependencies. Without a separate host compiler,
+    // Clang inherits the iOS deployment target and emits iOS executables for native
+    // dependency probes (including aws-lc-sys's mandatory memcmp check).
+    sh.set_var("HOST_CC", sh.current_dir().join("swift/host-cc.sh"));
     // aws-lc-sys references Linux-only entropy definitions while compiling an
     // unreachable iOS code path. Keep this workaround scoped to aws-lc-sys.
     sh.set_var(
@@ -418,6 +422,32 @@ fn framework_info_plist(platform: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn host_compiler_ignores_ios_deployment_environment() -> Result<()> {
+        let sh = Shell::new()?;
+        let directory = sh.create_temp_dir()?;
+        let source = directory.path().join("host-check.c");
+        let executable = directory.path().join("host-check");
+        sh.write_file(
+            &source,
+            "#include <TargetConditionals.h>\n\
+             #if !TARGET_OS_OSX\n\
+             #error Host probes must target macOS\n\
+             #endif\n\
+             int main(void) { return 0; }\n",
+        )?;
+        let sdk = cmd!(sh, "xcrun --sdk iphoneos --show-sdk-path").read()?;
+        let compiler =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../swift/host-cc.sh");
+        cmd!(sh, "{compiler} -O3 {source} -o {executable}")
+            .env("IPHONEOS_DEPLOYMENT_TARGET", "13.0")
+            .env("SDKROOT", sdk)
+            .run()?;
+        cmd!(sh, "{executable}").run()?;
+        Ok(())
+    }
 
     #[test]
     fn relative_output_directories_are_resolved_under_swift() {


### PR DESCRIPTION
A v4-only consumer needs the exact credential and its associated biometric data to survive recovery and restore. Expose the selected unexpired credential’s data through CredentialStore/UniFFI, including an atomic `CredentialData` snapshot. Deterministic same-second ordering matches proof generation; missing data never borrows an older credential’s payload.

Add conditional associated-data repair guarded by record ID, exact credential bytes and expiry. Repairs preserve the blinding factor and selection order, clean orphaned data, and notify backup observers. Existing schema and frozen backup format remain unchanged. Biometric snapshots deliberately omit Debug. Consumers must validate the issuer-defined format and commitment before using or repairing data; the Orb claim verification and iOS integration are separate companion changes for MCORE-1907.

Validation: all 23 credential-vault tests pass, including reopening, atomic snapshots, stale/deleted/expired repair, ordering and frozen backup bytes. Formatting and strict walletkit-core library Clippy pass with Rust 1.94.1. New generated Swift/Kotlin binding checks are running in CI. No release or deployment performed.

The candidate also pins the protocol recovery branch at `8920ae9c463c98e62b0836d1ef9d9b6c2749b5f1` so the generated SDK includes authoritative recovery-counter checks and revoked-authenticator handling (worldcoin/world-id-protocol#982). All 23 vault tests and strict library Clippy pass against this exact revision. Replace the temporary Git pin with the coordinated published protocol version before the production crates release.