### PR TITLE
ci: limit rust build concurrency to avoid runner oom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,9 @@ jobs:
   test:
     name: Tests
     runs-on: arc-public-2xlarge-arm64-runner
+    env:
+      # Limit parallel linking on runners with a 32 GiB memory cap.
+      CARGO_BUILD_JOBS: "2"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
     runs-on: arc-public-2xlarge-arm64-runner
 
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable


### PR DESCRIPTION
This PR limits concurrent Cargo builds in the Rust CI matrix to reduce memory pressure during linking.

- Set `CARGO_BUILD_JOBS=2` for both the test build and the build without default features.
- Disable matrix `fail-fast` so one failed toolchain does not cancel the others.

Context: [main CI](https://github.com/worldcoin/walletkit/actions/runs/34290816205) lost its 1.94.1 runner while building the tests. [Datadog kernel logs](https://app.datadoghq.com/logs?from_ts=1788910080000&live=false&query=kube_node%3Aip-10-55-134-199.eu-central-1.compute.internal+%28OOM+OR+OOMKilled+OR+%22Out+of+memory%22+OR+%22Killed+process%22%29&stream_sort=desc&to_ts=1788910740000) confirm a memory-cgroup OOM at 2026-09-08 23:36:07 UTC killed linker/compiler processes and `Runner.Worker`. The runner container had a 32 GiB memory limit and exited with code 137. Reducing build concurrency trades build speed for lower peak memory use.

Validation: workflow YAML parses, and a structural comparison confirms only build concurrency and matrix cancellation behavior changed. CI validation on the affected runner type is pending.
