### PR TITLE
Add synchronous browser storage primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9363,6 +9363,7 @@ dependencies = [
 name = "walletkit-db"
 version = "0.22.0"
 dependencies = [
+ "chacha20poly1305 0.10.1",
  "ciborium",
  "getrandom 0.3.4",
  "hex",

--- a/crates/walletkit-core/src/storage/browser.rs
+++ b/crates/walletkit-core/src/storage/browser.rs
@@ -1,0 +1,96 @@
+//! FFI adapters for synchronous Rust platform components.
+
+use super::{AtomicBlobStore, DeviceKeystore, StorageError, StorageResult};
+use secrecy::SecretBox;
+use std::{path::PathBuf, sync::Arc};
+use walletkit_db::{AtomicBlobStore as _, Keystore as _};
+use zeroize::Zeroizing;
+
+/// Synchronous software keystore backed by a host-provided secret.
+#[derive(uniffi::Object)]
+pub struct SecretDeviceKeystore(walletkit_db::SecretKeystore);
+
+#[uniffi::export]
+impl SecretDeviceKeystore {
+    /// Creates a keystore from a 32-byte host-provided secret.
+    /// The host must retain/recover the same secret for subsequent unlocks.
+    ///
+    /// # Errors
+    /// Returns an error if the secret is not exactly 32 bytes.
+    #[uniffi::constructor]
+    pub fn new(secret: Vec<u8>) -> StorageResult<Self> {
+        let secret = Zeroizing::new(secret);
+        if secret.len() != 32 {
+            return Err(StorageError::Keystore("expected a 32-byte secret".into()));
+        }
+        let key = SecretBox::init_with(|| {
+            let mut key = [0; 32];
+            key.copy_from_slice(&secret);
+            key
+        });
+        Ok(Self(walletkit_db::SecretKeystore::new(key)))
+    }
+
+    /// Returns this keystore as the platform interface used by credential storage.
+    #[must_use]
+    pub fn as_device_keystore(self: Arc<Self>) -> Arc<dyn DeviceKeystore> {
+        self
+    }
+}
+
+impl DeviceKeystore for SecretDeviceKeystore {
+    fn seal(
+        &self,
+        associated_data: Vec<u8>,
+        plaintext: Vec<u8>,
+    ) -> StorageResult<Vec<u8>> {
+        let plaintext = Zeroizing::new(plaintext);
+        Ok(self.0.seal(&associated_data, &plaintext)?)
+    }
+    fn open_sealed(
+        &self,
+        associated_data: Vec<u8>,
+        ciphertext: Vec<u8>,
+    ) -> StorageResult<Vec<u8>> {
+        Ok(self.0.open_sealed(associated_data, ciphertext)?)
+    }
+}
+
+/// `SQLite`-backed storage for already-sealed blobs.
+#[derive(uniffi::Object)]
+pub struct SqliteAtomicBlobStore(walletkit_db::SqliteBlobStore);
+
+#[uniffi::export]
+impl SqliteAtomicBlobStore {
+    /// Creates a `SQLite` blob store with a connection opened and closed per operation.
+    ///
+    /// Browser callers must await `initialize_persistent_storage` first.
+    /// Only sealed data belongs in this unencrypted database.
+    ///
+    /// # Errors
+    /// Returns an error if the database cannot be opened or initialized.
+    #[uniffi::constructor]
+    pub fn new(path: String) -> StorageResult<Self> {
+        Ok(Self(walletkit_db::SqliteBlobStore::new(PathBuf::from(
+            path,
+        ))?))
+    }
+
+    /// Returns this store as the platform interface used by credential storage.
+    #[must_use]
+    pub fn as_atomic_blob_store(self: Arc<Self>) -> Arc<dyn AtomicBlobStore> {
+        self
+    }
+}
+
+impl AtomicBlobStore for SqliteAtomicBlobStore {
+    fn read(&self, path: String) -> StorageResult<Option<Vec<u8>>> {
+        Ok(self.0.read(path)?)
+    }
+    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StorageResult<()> {
+        Ok(self.0.write_atomic(path, bytes)?)
+    }
+    fn delete(&self, path: String) -> StorageResult<()> {
+        Ok(self.0.delete(path)?)
+    }
+}

--- a/crates/walletkit-core/src/storage/mod.rs
+++ b/crates/walletkit-core/src/storage/mod.rs
@@ -45,6 +45,7 @@
 //! Encryption, the sealed-envelope threat model, and integrity checks are covered by
 //! the `walletkit-db` README.
 
+mod browser;
 pub mod cache;
 pub mod credential_storage;
 pub mod credential_vault;
@@ -57,6 +58,7 @@ pub mod paths;
 pub mod traits;
 pub mod types;
 
+pub use browser::{SecretDeviceKeystore, SqliteAtomicBlobStore};
 pub use cache::CacheDb;
 pub use credential_storage::CredentialStore;
 pub use credential_vault::CredentialVault;

--- a/crates/walletkit-db/Cargo.toml
+++ b/crates/walletkit-db/Cargo.toml
@@ -15,6 +15,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+chacha20poly1305 = { workspace = true }
 ciborium = { workspace = true }
 getrandom = { workspace = true }
 hex = { workspace = true }

--- a/crates/walletkit-db/README.md
+++ b/crates/walletkit-db/README.md
@@ -148,3 +148,15 @@ Schemas, CBOR envelope layout, content_id derivation, and the `account_keys.bin`
 ## Platforms
 
 Native (macOS, Linux, Windows): static `sqlite3mc` from the build script. `wasm32-unknown-unknown`: `sqlite-wasm-rs` with the `sqlite3mc` feature; `Lock` collapses to a no-op.
+
+### Synchronous browser components
+
+`SecretKeystore` uses a host-supplied 32-byte key and XChaCha20-Poly1305 with
+fresh random nonces and authenticated associated data. Its versioned sealed
+payload has a frozen-byte test. Existing envelope CBOR and content IDs are unchanged.
+
+`SqliteBlobStore` stores opaque, already-sealed values in a separate database.
+It retains only a path, opening and closing a connection for each operation.
+A write/delete is a single SQLite transaction; no filesystem lock is layered on
+ordinary writes. Browser initialization must first install the OPFS SAH pool.
+The pool keeps its access handles even while no SQLite connection is open.

--- a/crates/walletkit-db/src/lib.rs
+++ b/crates/walletkit-db/src/lib.rs
@@ -23,6 +23,8 @@ pub mod blobs;
 mod envelope;
 mod error;
 mod lock;
+mod secret_keystore;
+mod sqlite_blob_store;
 mod traits;
 mod vault;
 
@@ -30,5 +32,7 @@ pub use blobs::{compute_content_id, ContentId};
 pub use envelope::init_or_open_envelope_key;
 pub use error::{StoreError, StoreResult};
 pub use lock::{Lock, LockGuard};
+pub use secret_keystore::SecretKeystore;
+pub use sqlite_blob_store::SqliteBlobStore;
 pub use traits::{AtomicBlobStore, Keystore};
 pub use vault::Vault;

--- a/crates/walletkit-db/src/secret_keystore.rs
+++ b/crates/walletkit-db/src/secret_keystore.rs
@@ -1,0 +1,107 @@
+//! Synchronous AEAD using a host-supplied secret. No browser callbacks.
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit, Payload},
+    XChaCha20Poly1305, XNonce,
+};
+use secrecy::{ExposeSecret, SecretBox};
+
+use crate::{Keystore, StoreError, StoreResult};
+
+// Sealed bytes: version (1 byte) || XChaCha nonce (24 bytes) || ciphertext/tag.
+const VERSION: u8 = 1;
+const NONCE_LEN: usize = 24;
+
+/// Software keystore. The host must supply the same secret on every unlock.
+/// This does not provide hardware-bound key isolation.
+pub struct SecretKeystore {
+    key: SecretBox<[u8; 32]>,
+}
+
+impl SecretKeystore {
+    /// Takes ownership of the host's wrapping key.
+    #[must_use]
+    pub const fn new(key: SecretBox<[u8; 32]>) -> Self {
+        Self { key }
+    }
+
+    fn seal_with_nonce(
+        &self,
+        aad: &[u8],
+        plaintext: &[u8],
+        nonce: &[u8; NONCE_LEN],
+    ) -> StoreResult<Vec<u8>> {
+        let ciphertext = XChaCha20Poly1305::new(self.key.expose_secret().into())
+            .encrypt(
+                XNonce::from_slice(nonce),
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
+            .map_err(|_| StoreError::Crypto("secret keystore seal failed".into()))?;
+        let mut result = Vec::with_capacity(1 + NONCE_LEN + ciphertext.len());
+        result.push(VERSION);
+        result.extend_from_slice(nonce);
+        result.extend_from_slice(&ciphertext);
+        Ok(result)
+    }
+}
+
+impl Keystore for SecretKeystore {
+    fn seal(&self, aad: &[u8], plaintext: &[u8]) -> StoreResult<Vec<u8>> {
+        let mut nonce = [0; NONCE_LEN];
+        getrandom::fill(&mut nonce).map_err(|e| StoreError::Crypto(e.to_string()))?;
+        self.seal_with_nonce(aad, plaintext, &nonce)
+    }
+
+    fn open_sealed(&self, aad: Vec<u8>, ciphertext: Vec<u8>) -> StoreResult<Vec<u8>> {
+        if ciphertext.len() < 1 + NONCE_LEN + 16 || ciphertext[0] != VERSION {
+            return Err(StoreError::InvalidEnvelope(
+                "invalid secret keystore payload".into(),
+            ));
+        }
+        XChaCha20Poly1305::new(self.key.expose_secret().into())
+            .decrypt(
+                XNonce::from_slice(&ciphertext[1..=NONCE_LEN]),
+                Payload {
+                    msg: &ciphertext[1 + NONCE_LEN..],
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| {
+                StoreError::Crypto("secret keystore authentication failed".into())
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sealed_bytes_are_frozen() {
+        let ks = SecretKeystore::new(SecretBox::init_with(|| [7; 32]));
+        let sealed = ks.seal_with_nonce(b"account", b"secret", &[9; 24]).unwrap();
+        assert_eq!(hex::encode(sealed), "01090909090909090909090909090909090909090909090909cd1781f819deeeac4cc72e0b84d4612cb2daa5dedca9");
+    }
+
+    #[test]
+    fn authenticates_key_aad_and_ciphertext() {
+        let ks = SecretKeystore::new(SecretBox::init_with(|| [7; 32]));
+        let sealed = ks.seal(b"account", b"secret").unwrap();
+        assert_eq!(
+            ks.open_sealed(b"account".to_vec(), sealed.clone()).unwrap(),
+            b"secret"
+        );
+        assert!(ks.open_sealed(b"other".to_vec(), sealed.clone()).is_err());
+        let other = SecretKeystore::new(SecretBox::init_with(|| [8; 32]));
+        assert!(other
+            .open_sealed(b"account".to_vec(), sealed.clone())
+            .is_err());
+        let mut tampered = sealed;
+        *tampered.last_mut().unwrap() ^= 1;
+        assert!(ks.open_sealed(b"account".to_vec(), tampered).is_err());
+        assert!(ks.open_sealed(vec![], vec![]).is_err());
+    }
+}

--- a/crates/walletkit-db/src/sqlite_blob_store.rs
+++ b/crates/walletkit-db/src/sqlite_blob_store.rs
@@ -1,0 +1,85 @@
+//! Atomic storage for sealed blobs. Each operation owns a short-lived connection.
+
+use crate::{AtomicBlobStore, StoreResult};
+use std::path::PathBuf;
+use walletkit_sqlite::{params, plaintext::open_plaintext, Connection};
+
+/// Stores opaque blobs in a separate, unencrypted `SQLite` database.
+///
+/// Callers must seal secrets before writing them. The store retains only a path;
+/// statements and connections are dropped before each operation returns.
+pub struct SqliteBlobStore {
+    path: PathBuf,
+}
+
+impl SqliteBlobStore {
+    /// Creates the blob table. On WASM, initialize the OPFS pool first.
+    ///
+    /// # Errors
+    /// Returns an error if opening or creating the database fails.
+    pub fn new(path: PathBuf) -> StoreResult<Self> {
+        let store = Self { path };
+        store.connect()?.execute_batch("CREATE TABLE IF NOT EXISTS atomic_blobs (path TEXT PRIMARY KEY NOT NULL, bytes BLOB NOT NULL) WITHOUT ROWID;")?;
+        Ok(store)
+    }
+
+    fn connect(&self) -> StoreResult<Connection> {
+        Ok(open_plaintext(&self.path, false)?)
+    }
+}
+
+impl AtomicBlobStore for SqliteBlobStore {
+    fn read(&self, path: String) -> StoreResult<Option<Vec<u8>>> {
+        Ok(self.connect()?.query_row_optional(
+            "SELECT bytes FROM atomic_blobs WHERE path=?1",
+            params![path],
+            |row| Ok(row.column_blob(0)),
+        )?)
+    }
+
+    fn write_atomic(&self, path: String, bytes: Vec<u8>) -> StoreResult<()> {
+        // A single autocommit statement is one atomic SQLite transaction.
+        self.connect()?.execute("INSERT INTO atomic_blobs(path, bytes) VALUES (?1, ?2) ON CONFLICT(path) DO UPDATE SET bytes=excluded.bytes", params![path, bytes])?;
+        Ok(())
+    }
+
+    fn delete(&self, path: String) -> StoreResult<()> {
+        self.connect()?
+            .execute("DELETE FROM atomic_blobs WHERE path=?1", params![path])?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reopens_replaces_and_deletes_without_retaining_a_connection() {
+        walletkit_sqlite::test_utils::init_sqlite();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("envelopes.sqlite");
+        let store = SqliteBlobStore::new(path.clone()).unwrap();
+        assert_eq!(store.read("key".into()).unwrap(), None);
+        store.write_atomic("key".into(), vec![0, 1, 255]).unwrap();
+        let reopened = SqliteBlobStore::new(path.clone()).unwrap();
+        assert_eq!(reopened.read("key".into()).unwrap(), Some(vec![0, 1, 255]));
+        reopened.write_atomic("key".into(), vec![]).unwrap();
+        assert_eq!(store.read("key".into()).unwrap(), Some(vec![]));
+        store.delete("key".into()).unwrap();
+        store.delete("key".into()).unwrap();
+        assert_eq!(reopened.read("key".into()).unwrap(), None);
+        // An exclusive connection can operate while both store objects exist.
+        let conn = Connection::open(&path, false).unwrap();
+        let schema = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE name='atomic_blobs'",
+                &[],
+                |row| Ok(row.column_text(0)),
+            )
+            .unwrap();
+        assert_eq!(schema, "CREATE TABLE atomic_blobs (path TEXT PRIMARY KEY NOT NULL, bytes BLOB NOT NULL) WITHOUT ROWID");
+        conn.execute_batch("PRAGMA locking_mode=EXCLUSIVE; BEGIN EXCLUSIVE; COMMIT;")
+            .unwrap();
+    }
+}

--- a/crates/walletkit-sqlite/README.md
+++ b/crates/walletkit-sqlite/README.md
@@ -13,3 +13,9 @@ Browser hosts must run WalletKit in a dedicated worker and await
 the credential store. The page key remains in Rust memory for the unlocked
 store lifetime; persistent connections fail closed until the encrypted OPFS
 VFS is installed.
+
+`cipher::open_encrypted` and `plaintext::open_plaintext` share verified connection
+settings for journaling, durability, foreign keys, secure deletion and in-memory
+temporary storage. The plaintext path selects the unencrypted OPFS VFS on WASM
+and is used for already-sealed envelope blobs. Encryption key setup stays in
+`cipher`; `Connection` provides the underlying opening and SQL operations.

--- a/crates/walletkit-sqlite/src/cipher.rs
+++ b/crates/walletkit-sqlite/src/cipher.rs
@@ -43,10 +43,6 @@ use super::connection::Connection;
 use super::error::{DbResult, Error};
 
 const CIPHER_CHACHA20: &str = "chacha20";
-const FOREIGN_KEYS_ON: i64 = 1;
-const SYNCHRONOUS_FULL: i64 = 2;
-const SECURE_DELETE_ON: i64 = 1;
-const TEMP_STORE_MEMORY: i64 = 2;
 
 /// Opens a database, applies the encryption key, and configures the connection.
 ///
@@ -66,42 +62,15 @@ pub fn open_encrypted(
     #[cfg(not(target_arch = "wasm32"))]
     let conn = Connection::open(path, read_only)?;
     #[cfg(target_arch = "wasm32")]
-    let conn = Connection::open_with_opfs_vfs(path, read_only)?;
-    configure_connection(&conn, k_intermediate)?;
+    let conn = Connection::open_with_opfs_vfs(
+        path,
+        read_only,
+        crate::opfs::ENCRYPTED_VFS_NAME,
+    )?;
+    ensure_cipher(&conn)?;
+    apply_key(&conn, k_intermediate)?;
+    crate::config::configure_connection(&conn)?;
     Ok(conn)
-}
-
-/// Configures durable journal settings, foreign keys, and secure deletion.
-///
-/// - Native uses WAL for concurrent readers during writes.
-/// - WASM uses a rollback journal because SAH-pool has no WAL shared-memory
-///   methods; WAL would require exclusive locking and provide no concurrency.
-/// - `synchronous = FULL` -- maximizes crash consistency by flushing required
-///   journal writes before the transaction is reported as committed.
-/// - `foreign_keys = ON` -- enforces referential integrity constraints.
-/// - `secure_delete = ON` -- overwrites deleted content with zeroes so
-///   sensitive data does not linger in free pages.
-fn configure_connection(
-    conn: &Connection,
-    k_intermediate: &SecretBox<[u8; 32]>,
-) -> DbResult<()> {
-    ensure_cipher(conn)?;
-    apply_key(conn, k_intermediate)?;
-
-    #[cfg(not(target_arch = "wasm32"))]
-    ensure_journal_mode(conn, "WAL")?;
-    // SAH-pool does not expose WAL shared-memory methods. WAL would therefore
-    // require locking_mode=EXCLUSIVE before the first database access and
-    // provide no concurrency benefit, so WASM deliberately uses the rollback
-    // journal until benchmarks justify that extra complexity.
-    #[cfg(target_arch = "wasm32")]
-    ensure_journal_mode(conn, "DELETE")?;
-
-    ensure_foreign_keys(conn)?;
-    ensure_synchronous_full(conn)?;
-    ensure_secure_delete(conn)?;
-    ensure_temp_store_memory(conn)?;
-    Ok(())
 }
 
 /// Selects and verifies the on-disk cipher before the key activates it.
@@ -158,107 +127,6 @@ fn apply_key(conn: &Connection, k_intermediate: &SecretBox<[u8; 32]>) -> DbResul
     // k_intermediate, key_hex, and pragma are all Zeroizing — zeroed on drop
     // regardless of which exit path we took.
     Ok(())
-}
-
-/// Ensures the target-specific journal policy actually took effect.
-///
-/// Assigning `journal_mode` returns the effective mode because `SQLite` may
-/// retain the previous mode when the requested transition is unavailable.
-fn ensure_journal_mode(conn: &Connection, requested: &str) -> DbResult<()> {
-    let actual =
-        conn.query_row(&format!("PRAGMA journal_mode = {requested};"), &[], |row| {
-            Ok(row.column_text(0))
-        })?;
-    if actual.eq_ignore_ascii_case(requested) {
-        Ok(())
-    } else {
-        Err(Error::new(
-            -1,
-            format!(
-                "could not ensure journal mode {requested}: SQLite selected {actual}"
-            ),
-        ))
-    }
-}
-
-/// Enables foreign-key enforcement for every connection.
-///
-/// `SQLite` defaults this setting to off and may silently ignore the assignment
-/// inside a transaction or when foreign-key support was omitted at build time.
-fn ensure_foreign_keys(conn: &Connection) -> DbResult<()> {
-    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-    let actual =
-        conn.query_row("PRAGMA foreign_keys;", &[], |row| Ok(row.column_i64(0)))?;
-    if actual == FOREIGN_KEYS_ON {
-        Ok(())
-    } else {
-        Err(Error::new(
-            -1,
-            format!(
-                "could not ensure PRAGMA foreign_keys = ON: expected {FOREIGN_KEYS_ON}, got {actual}"
-            ),
-        ))
-    }
-}
-
-/// Uses `SQLite`'s strongest ordinary durability policy.
-///
-/// `FULL` ensures `SQLite` flushes journal content before reporting a transaction
-/// as committed, reducing the risk of corruption after a crash or power loss.
-fn ensure_synchronous_full(conn: &Connection) -> DbResult<()> {
-    conn.execute_batch("PRAGMA synchronous = FULL;")?;
-    let actual =
-        conn.query_row("PRAGMA synchronous;", &[], |row| Ok(row.column_i64(0)))?;
-    if actual == SYNCHRONOUS_FULL {
-        Ok(())
-    } else {
-        Err(Error::new(
-            -1,
-            format!(
-                "could not ensure PRAGMA synchronous = FULL: expected {SYNCHRONOUS_FULL}, got {actual}"
-            ),
-        ))
-    }
-}
-
-/// Overwrites deleted content instead of leaving it in reusable database pages.
-///
-/// This limits plaintext remnants while the encrypted database is open and
-/// accessible with its key.
-fn ensure_secure_delete(conn: &Connection) -> DbResult<()> {
-    conn.execute_batch("PRAGMA secure_delete = ON;")?;
-    let actual =
-        conn.query_row("PRAGMA secure_delete;", &[], |row| Ok(row.column_i64(0)))?;
-    if actual == SECURE_DELETE_ON {
-        Ok(())
-    } else {
-        Err(Error::new(
-            -1,
-            format!(
-                "could not ensure PRAGMA secure_delete = ON: expected {SECURE_DELETE_ON}, got {actual}"
-            ),
-        ))
-    }
-}
-
-/// Keeps temporary tables and indices in memory.
-///
-/// `sqlite3mc` does not encrypt temporary databases, so allowing temporary
-/// storage to spill to a filesystem could expose plaintext at rest.
-fn ensure_temp_store_memory(conn: &Connection) -> DbResult<()> {
-    conn.execute_batch("PRAGMA temp_store = MEMORY;")?;
-    let actual =
-        conn.query_row("PRAGMA temp_store;", &[], |row| Ok(row.column_i64(0)))?;
-    if actual == TEMP_STORE_MEMORY {
-        Ok(())
-    } else {
-        Err(Error::new(
-            -1,
-            format!(
-                "could not ensure PRAGMA temp_store = MEMORY: expected {TEMP_STORE_MEMORY}, got {actual}"
-            ),
-        ))
-    }
 }
 
 /// Creates a plaintext (unencrypted) copy of an already-open encrypted database.

--- a/crates/walletkit-sqlite/src/config.rs
+++ b/crates/walletkit-sqlite/src/config.rs
@@ -1,0 +1,176 @@
+//! Shared connection policy for encrypted and plaintext databases.
+
+use crate::{Connection, DbResult, Error};
+
+const FOREIGN_KEYS_ON: i64 = 1;
+const SYNCHRONOUS_FULL: i64 = 2;
+const SECURE_DELETE_ON: i64 = 1;
+const TEMP_STORE_MEMORY: i64 = 2;
+
+/// Configures durable journal settings, foreign keys, and secure deletion.
+///
+/// - Native uses WAL for concurrent readers during writes.
+/// - WASM uses a rollback journal because SAH-pool has no WAL shared-memory
+///   methods; WAL would require exclusive locking and provide no concurrency.
+/// - `synchronous = FULL` -- maximizes crash consistency by flushing required
+///   journal writes before the transaction is reported as committed.
+/// - `foreign_keys = ON` -- enforces referential integrity constraints.
+/// - `secure_delete = ON` -- overwrites deleted content with zeroes so
+///   sensitive data does not linger in free pages.
+pub fn configure_connection(conn: &Connection) -> DbResult<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    ensure_journal_mode(conn, "WAL")?;
+    // SAH-pool does not expose WAL shared-memory methods. WAL would therefore
+    // require locking_mode=EXCLUSIVE before the first database access and
+    // provide no concurrency benefit, so WASM deliberately uses the rollback
+    // journal until benchmarks justify that extra complexity.
+    #[cfg(target_arch = "wasm32")]
+    ensure_journal_mode(conn, "DELETE")?;
+
+    ensure_foreign_keys(conn)?;
+    ensure_synchronous_full(conn)?;
+    ensure_secure_delete(conn)?;
+    ensure_temp_store_memory(conn)?;
+    Ok(())
+}
+
+/// Ensures the target-specific journal policy actually took effect.
+///
+/// Assigning `journal_mode` returns the effective mode because `SQLite` may
+/// retain the previous mode when the requested transition is unavailable.
+fn ensure_journal_mode(conn: &Connection, requested: &str) -> DbResult<()> {
+    let actual =
+        conn.query_row(&format!("PRAGMA journal_mode = {requested};"), &[], |row| {
+            Ok(row.column_text(0))
+        })?;
+    if actual.eq_ignore_ascii_case(requested) {
+        Ok(())
+    } else {
+        Err(Error::new(
+            -1,
+            format!(
+                "could not ensure journal mode {requested}: SQLite selected {actual}"
+            ),
+        ))
+    }
+}
+
+/// Enables foreign-key enforcement for every connection.
+///
+/// `SQLite` defaults this setting to off and may silently ignore the assignment
+/// inside a transaction or when foreign-key support was omitted at build time.
+fn ensure_foreign_keys(conn: &Connection) -> DbResult<()> {
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    let actual =
+        conn.query_row("PRAGMA foreign_keys;", &[], |row| Ok(row.column_i64(0)))?;
+    if actual == FOREIGN_KEYS_ON {
+        Ok(())
+    } else {
+        Err(Error::new(
+            -1,
+            format!(
+                "could not ensure PRAGMA foreign_keys = ON: expected {FOREIGN_KEYS_ON}, got {actual}"
+            ),
+        ))
+    }
+}
+
+/// Uses `SQLite`'s strongest ordinary durability policy.
+///
+/// `FULL` ensures `SQLite` flushes journal content before reporting a transaction
+/// as committed, reducing the risk of corruption after a crash or power loss.
+fn ensure_synchronous_full(conn: &Connection) -> DbResult<()> {
+    conn.execute_batch("PRAGMA synchronous = FULL;")?;
+    let actual =
+        conn.query_row("PRAGMA synchronous;", &[], |row| Ok(row.column_i64(0)))?;
+    if actual == SYNCHRONOUS_FULL {
+        Ok(())
+    } else {
+        Err(Error::new(
+            -1,
+            format!(
+                "could not ensure PRAGMA synchronous = FULL: expected {SYNCHRONOUS_FULL}, got {actual}"
+            ),
+        ))
+    }
+}
+
+/// Overwrites deleted content instead of leaving it in reusable database pages.
+///
+/// This limits plaintext remnants while the encrypted database is open and
+/// accessible with its key.
+fn ensure_secure_delete(conn: &Connection) -> DbResult<()> {
+    conn.execute_batch("PRAGMA secure_delete = ON;")?;
+    let actual =
+        conn.query_row("PRAGMA secure_delete;", &[], |row| Ok(row.column_i64(0)))?;
+    if actual == SECURE_DELETE_ON {
+        Ok(())
+    } else {
+        Err(Error::new(
+            -1,
+            format!(
+                "could not ensure PRAGMA secure_delete = ON: expected {SECURE_DELETE_ON}, got {actual}"
+            ),
+        ))
+    }
+}
+
+/// Keeps temporary tables and indices in memory.
+///
+/// `sqlite3mc` does not encrypt temporary databases, so allowing temporary
+/// storage to spill to a filesystem could expose plaintext at rest.
+fn ensure_temp_store_memory(conn: &Connection) -> DbResult<()> {
+    conn.execute_batch("PRAGMA temp_store = MEMORY;")?;
+    let actual =
+        conn.query_row("PRAGMA temp_store;", &[], |row| Ok(row.column_i64(0)))?;
+    if actual == TEMP_STORE_MEMORY {
+        Ok(())
+    } else {
+        Err(Error::new(
+            -1,
+            format!(
+                "could not ensure PRAGMA temp_store = MEMORY: expected {TEMP_STORE_MEMORY}, got {actual}"
+            ),
+        ))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::{
+        cipher::open_encrypted, plaintext::open_plaintext, test_utils::init_sqlite,
+    };
+    use secrecy::SecretBox;
+
+    #[test]
+    fn both_open_paths_enforce_connection_policy() {
+        init_sqlite();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let key = SecretBox::init_with(|| [0xAB; 32]);
+        let encrypted =
+            open_encrypted(&dir.path().join("encrypted.sqlite"), &key, false)
+                .expect("open encrypted");
+        let plaintext = open_plaintext(&dir.path().join("plaintext.sqlite"), false)
+            .expect("open plaintext");
+        for conn in [encrypted, plaintext] {
+            for (pragma, expected) in
+                [("synchronous", 2), ("secure_delete", 1), ("temp_store", 2)]
+            {
+                let actual = conn
+                    .query_row(&format!("PRAGMA {pragma}"), &[], |row| {
+                        Ok(row.column_i64(0))
+                    })
+                    .expect("read setting");
+                assert_eq!(actual, expected, "{pragma}");
+            }
+            let journal = conn
+                .query_row("PRAGMA journal_mode", &[], |row| Ok(row.column_text(0)))
+                .expect("read journal mode");
+            assert_eq!(journal, "wal");
+            conn.execute_batch("CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(parent_id INTEGER REFERENCES parent(id));").expect("create tables");
+            assert!(
+                conn.execute_batch("INSERT INTO child VALUES (1)").is_err(),
+                "foreign keys must be enforced"
+            );
+        }
+    }
+}

--- a/crates/walletkit-sqlite/src/connection.rs
+++ b/crates/walletkit-sqlite/src/connection.rs
@@ -31,7 +31,11 @@ impl Connection {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub(crate) fn open_with_opfs_vfs(path: &Path, read_only: bool) -> DbResult<Self> {
+    pub(crate) fn open_with_opfs_vfs(
+        path: &Path,
+        read_only: bool,
+        vfs: &str,
+    ) -> DbResult<Self> {
         if !crate::opfs::is_installed() {
             return Err(Error::new(
                 -1,
@@ -39,7 +43,7 @@ impl Connection {
             ));
         }
 
-        Self::open_with_vfs(path, read_only, Some(crate::opfs::ENCRYPTED_VFS_NAME))
+        Self::open_with_vfs(path, read_only, Some(vfs))
     }
 
     /// Opens (or creates) a database using an explicitly selected VFS.

--- a/crates/walletkit-sqlite/src/lib.rs
+++ b/crates/walletkit-sqlite/src/lib.rs
@@ -14,9 +14,11 @@
 mod ffi;
 
 pub mod cipher;
+mod config;
 pub mod error;
 #[cfg(target_arch = "wasm32")]
 pub mod opfs;
+pub mod plaintext;
 pub mod test_utils;
 
 mod connection;

--- a/crates/walletkit-sqlite/src/opfs.rs
+++ b/crates/walletkit-sqlite/src/opfs.rs
@@ -13,9 +13,10 @@ use sqlite_wasm_vfs::sahpool::{
 
 use crate::{error::DbResult, Error};
 
-const OPFS_VFS_NAME: &str = "opfs-sahpool";
+pub(crate) const OPFS_VFS_NAME: &str = "opfs-sahpool";
 const OPFS_DIRECTORY: &str = ".walletkit-opfs-sahpool";
-const OPFS_MINIMUM_CAPACITY: u32 = 6;
+// Vault, cache and envelope DBs, their rollback journals, plus two spare slots.
+const OPFS_MINIMUM_CAPACITY: u32 = 8;
 
 /// `SQLite3MC`'s encrypted wrapper around the SAH-pool VFS.
 pub(crate) const ENCRYPTED_VFS_NAME: &str = "multipleciphers-opfs-sahpool";

--- a/crates/walletkit-sqlite/src/plaintext.rs
+++ b/crates/walletkit-sqlite/src/plaintext.rs
@@ -1,0 +1,49 @@
+//! Persistent, unencrypted databases with the standard connection policy.
+
+use std::path::Path;
+
+use crate::{config::configure_connection, Connection, DbResult};
+
+/// Opens an unencrypted database and applies the shared connection settings.
+///
+/// Uses the native filesystem or, on WASM, the initialized OPFS SAH pool.
+/// Callers storing secrets must seal them before writing to this database.
+///
+/// # Errors
+/// Returns an error if storage is unavailable, opening fails, or the connection
+/// settings cannot be applied and verified.
+pub fn open_plaintext(path: &Path, read_only: bool) -> DbResult<Connection> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let conn = Connection::open(path, read_only)?;
+    #[cfg(target_arch = "wasm32")]
+    let conn =
+        Connection::open_with_opfs_vfs(path, read_only, crate::opfs::OPFS_VFS_NAME)?;
+    configure_connection(&conn)?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::open_plaintext;
+    use crate::test_utils::init_sqlite;
+
+    #[test]
+    fn plaintext_database_reopens_without_a_key() {
+        init_sqlite();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("plaintext.sqlite");
+        {
+            let conn = open_plaintext(&path, false).expect("open plaintext");
+            conn.execute_batch("CREATE TABLE items(value TEXT NOT NULL); INSERT INTO items VALUES ('sealed blob');").expect("write");
+        }
+        assert!(std::fs::read(&path)
+            .expect("read file")
+            .starts_with(b"SQLite format 3\0"));
+        let conn = open_plaintext(&path, true).expect("reopen read only");
+        let value = conn
+            .query_row("SELECT value FROM items", &[], |row| Ok(row.column_text(0)))
+            .expect("read");
+        assert_eq!(value, "sealed blob");
+        assert!(conn.execute_batch("DELETE FROM items").is_err());
+    }
+}


### PR DESCRIPTION
Add synchronous Rust storage components for browser hosts and share SQLite connection configuration between encrypted vaults and plaintext blob databases.

- Add a software keystore backed by a host-supplied secret and a SQLite atomic blob store, with UniFFI constructors for both.
- Open and close the blob database connection on every operation. The database stores already-sealed blobs.
- Extract common SQLite configuration and plaintext opening alongside the encryption-specific code, including OPFS SAH pool support.
- Keep generic storage primitives in walletkit-db and the UniFFI adapters in walletkit-core.

This PR sits above #522 and below #523. Native primitive tests live alongside the implementations; browser integration coverage remains in #523 with its browser test harness. The split preserves the previously tested combined tree.
