### PR TITLE
fix: nix pill the agents + fix nix/docker.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,28 @@
 # WalletKit Agent Guidelines
 
-## UniFFI Naming
+## Build environment
 
-Never name a UniFFI-exported method `to_string`. UniFFI maps Rust's `to_string` to Kotlin's `toString`, which conflicts with `Any.toString()` and causes a compilation error (`'toString' hides member of supertype 'Any' and needs 'override' modifier`). Use a descriptive name instead (e.g., `to_hex_string`, `to_decimal_string`, `to_json`).
+Dependency and build setup can be complex, especially for cross-compilation.
+Use the devshells provided by `flake.nix`: `default` for host development,
+`android` for Android, and `wasm` for WebAssembly. From the repository root:
 
-## Coding style
+```bash
+nix develop .#wasm
+nix develop .#android --command cargo xtask kotlin build
+```
 
-- **On-disk format is byte-stable.** Schemas, CBOR layouts, and `compute_content_id` derivations are part of the contract. Existing user databases must keep opening without migration; guard format-sensitive code with frozen-byte tests next to it.
-- **Don't layer a flock around SQLite writes.** WAL mode serializes writers itself. The `Lock` primitive is only for the envelope-init bootstrap and operations that mix SQL with filesystem state.
-- **Per-consumer isolation is host wiring.** Separate keystore entry, AD label, and envelope/vault/lock files. `walletkit-db` enforces only the AEAD-AD binding.
-- **`walletkit-db` is consumer-agnostic.** It owns `blob_objects` and the storage primitives (vault, envelope, lock, traits). Credential-specific tables, schemas, and APIs live in `walletkit-core/storage/credential_vault`. Don't put consumer logic in `walletkit-db`, and don't put primitives in consumer crates.
-- **`#[expect(lint, reason = "...")]` over `#[allow(lint)]`.** `#[expect]` fails to compile when the suppression is no longer needed, so dead suppressions don't accumulate.
-- **Put wiring constants in the file that uses them.** A `const` used only as a parameter to one module's functions (e.g. `BACKUP_TABLES` passed into `export_plaintext`) lives in that module. Identity-style constants (schema versions, protocol tags) stay with the thing they identify.
-- **Tests live with the code they test.** Either `#[cfg(test)] mod tests` inside the source file, or a sibling `tests.rs` when the parent is one logical unit (single struct, single concept). Don't centralize tests for multiple source files into one `tests.rs`.
+If Nix is not installed locally, use `nix/docker.sh` with the same arguments
+(requires Docker, plus host Git for worktrees):
+
+```bash
+nix/docker.sh develop .#wasm
+```
+
+The Docker wrapper runs Linux/amd64, using emulation on ARM hosts. Swift/iOS
+builds require macOS and Xcode; use `cargo xtask swift` on the host.
+See [nix/README.md](nix/README.md) for platform support and build commands.
+
+## Compatibility pitfalls
+
+- Preserve the on-disk format: schemas, CBOR layouts, and `compute_content_id` derivations must remain compatible with existing databases. Guard format-sensitive changes with frozen-byte tests next to the code.
+- Never name a UniFFI-exported method `to_string`: its Kotlin binding conflicts with `Any.toString()`. Use a descriptive name such as `to_hex_string`, `to_decimal_string`, or `to_json`.

--- a/nix/README.md
+++ b/nix/README.md
@@ -35,7 +35,8 @@ nix develop .#android --command cargo xtask kotlin local 0.3.1  # publish to Mav
 ## No Nix installed? Use Docker
 
 `nix/docker.sh` proxies Nix commands into a `nixos/nix` container — the only
-host dependency is Docker. Its arguments intentionally match the native Nix CLI:
+host dependency is Docker (plus Git when using a worktree). Its arguments
+intentionally match the native Nix CLI:
 
 ```bash
 nix/docker.sh develop .#android --command cargo xtask kotlin build
@@ -51,6 +52,9 @@ Silicon and is slower than `nix develop` directly.
 
 Notes:
 
+- Checkouts are mounted at their original host paths. For Git worktrees, the
+  wrapper also mounts the shared Git metadata directory so Nix can resolve the
+  flake's Git source. These paths must be accessible to Docker's file sharing.
 - The Nix store is kept in the `walletkit-nix-store-amd64` Docker volume, so
   toolchains download only on the first run. Remove it with `docker volume rm
   walletkit-nix-store-amd64` to reclaim the space. Cargo uses the corresponding

--- a/nix/docker.sh
+++ b/nix/docker.sh
@@ -13,7 +13,16 @@ set -euo pipefail
 # Swift builds are not provided by the flake because they depend on macOS and
 # the host Xcode configuration; use `cargo xtask swift` on macOS instead.
 
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+CDPATH= cd -P "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Keep host paths intact: a linked worktree's .git file points outside the
+# checkout, and Git's metadata points back to the checkout at its host path.
+VOLUME_FLAGS=(--volume "$PWD:$PWD")
+if [[ -f .git ]]; then
+  GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+  GIT_COMMON_DIR="$(CDPATH= cd -P "$GIT_COMMON_DIR" && pwd)"
+  VOLUME_FLAGS+=(--volume "$GIT_COMMON_DIR:$GIT_COMMON_DIR")
+fi
 
 TTY_FLAGS=(-i)
 if [[ -t 0 && -t 1 ]]; then
@@ -29,10 +38,10 @@ fi
 # Note: the container runs as root, so on Linux hosts files created in target/
 # will be root-owned.
 exec docker run --rm "${TTY_FLAGS[@]}" --platform linux/amd64 \
-  --volume "$PWD:/src" \
+  "${VOLUME_FLAGS[@]}" \
   --volume walletkit-nix-store-amd64:/nix \
   --volume walletkit-cargo-home-amd64:/root/.cargo \
-  --workdir /src \
+  --workdir "$PWD" \
   nixos/nix:2.34.8 \
   nix --extra-experimental-features 'nix-command flakes' \
   --option filter-syscalls false \


### PR DESCRIPTION
`nix/docker.sh develop .#wasm` fails in linked Git worktrees because mounting only the checkout at `/src` leaves its `.git` pointer referencing an unavailable host path. Mount the checkout and shared Git metadata at their original host paths so Nix can resolve the Git source. Resolve the checkout path independently of `CDPATH`.

Simplify `AGENTS.md` around the provided Nix devshells and Docker fallback, retaining the storage compatibility and UniFFI naming warnings. Document worktree mounts and the host Git requirement in the Nix README.

Validation:
- Opened the wasm devshell through Docker from this linked worktree; Git resolved the checkout and `rustc --version` succeeded.
- Evaluated a fixture flake through Docker from both normal and linked checkouts, with spaces in paths, invocation outside the checkout, and `CDPATH` set.
- `bash -n nix/docker.sh` and `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local dev Docker wrapper only; no runtime, auth, or storage behavior changes.
> 
> **Overview**
> **Fixes `nix/docker.sh` for linked Git worktrees** by mounting the checkout at its real host path (not a fixed `/src` path), optionally mounting Git’s common metadata directory when `.git` is a file, and resolving the repo root with `CDPATH=` cleared so `CDPATH` cannot break path resolution. The container **workdir** now matches that host path.
> 
> **Agent and Nix docs** are reshaped: `AGENTS.md` leads with flake devshells and the Docker fallback, and keeps only short **compatibility pitfalls** (on-disk format + UniFFI `to_string`). `nix/README.md` notes the host **Git** requirement for worktrees and explains the dual volume mounts for flake Git source resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86386bc9e3778985341f80f7ae9133764577cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->