### PR TITLE
ci: use 8xlarge runners for Rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: arc-public-2xlarge-arm64-runner
-    env:
-      # Limit parallel linking on runners with a 32 GiB memory cap.
-      CARGO_BUILD_JOBS: "2"
+    runs-on: arc-public-8xlarge-arm64-runner
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Move the Rust test matrix from `arc-public-2xlarge-arm64-runner` to `arc-public-8xlarge-arm64-runner`, increasing the runner container limits from 8 CPUs / 32 GiB to 32 CPUs / 128 GiB. Remove the `CARGO_BUILD_JOBS=2` cap introduced in #519 so Cargo can use its default build parallelism. Keep matrix `fail-fast: false`.

The 32 GiB runners have hit memory-cgroup OOMs during Rust linking. Their workspace is RAM-backed, so build artifacts also consume the container memory budget. The larger runner provides additional headroom; its workspace remains RAM-backed, so CI still needs to validate peak memory with default parallelism.

Validation: workflow YAML parses; a structural comparison confirms only the test runner selection and job-level concurrency environment changed; `git diff --check` passes. CI validation on the larger runner is pending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions runner sizing and build concurrency env change; no application, auth, or release logic is touched.
> 
> **Overview**
> The **Tests** job in CI now runs on `arc-public-8xlarge-arm64-runner` instead of `arc-public-2xlarge-arm64-runner`, giving the Rust matrix (stable, nightly, MSRV) more CPU and memory headroom for builds and linking.
> 
> The job-level **`CARGO_BUILD_JOBS=2`** limit is removed so Cargo can use its default parallelism again. That cap had been added to reduce memory pressure on the smaller runners; the larger runner is meant to avoid link-time OOMs without throttling builds. The matrix still uses **`fail-fast: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f23647f4e5d5db2673fdf6decf92c1f5c7d0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->