### PR TITLE
fix(sqlite): isolate native SQLite symbols from host apps

### DIFF
--- a/crates/walletkit-sqlite/Cargo.toml
+++ b/crates/walletkit-sqlite/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+# Opt-in native static-library regression host; keep it out of browser tests.
+native-link-probe = []
+
 [dependencies]
 hex = { workspace = true }
 secrecy = { workspace = true }
@@ -36,3 +40,8 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
+
+[[example]]
+name = "native_link_probe"
+crate-type = ["staticlib"]
+required-features = ["native-link-probe"]

--- a/crates/walletkit-sqlite/README.md
+++ b/crates/walletkit-sqlite/README.md
@@ -13,3 +13,32 @@ Browser hosts must run WalletKit in a dedicated worker and await
 the credential store. The page key remains in Rust memory for the unlocked
 store lifetime; persistent connections fail closed until the encrypted OPFS
 VFS is installed.
+
+## Native SQLite isolation
+
+Native apps may also link system SQLite or another SQLite distribution. The
+bundled sqlite3mc API has internal C linkage, and Rust uses only the
+`walletkit_sqlite3_*` wrappers in `src/native_sqlite.c`. This prevents link
+order from substituting the host engine for WalletKit's encrypted engine or
+replacing the host engine with WalletKit's copy. New native FFI functions must
+add a matching prefixed wrapper; visibility attributes alone do not isolate
+symbols when linking static archives.
+
+The amalgamation, cipher configuration, key encoding, and on-disk formats are
+unchanged. Cipher validation remains enabled. A pre-existing plaintext store
+is rejected, not silently accepted, reset, or migrated; any recovery or
+migration policy requires separate data-preservation review.
+
+On macOS, run the link-order regressions with synthetic disposable data:
+
+```sh
+bash crates/walletkit-sqlite/examples/test_native_linking.sh
+bash crates/walletkit-sqlite/examples/test_native_linking.sh release
+```
+
+Run both profiles when changing native linkage. The tests check the static
+archive for unprefixed SQLite API symbols, link with Apple's SQLite in both library orders
+with dead stripping enabled, and verify that both engines remain independent.
+They also cover encrypted reopening, wrong-key rejection, and preservation of
+existing database bytes after failed opens. These probes do not replace
+upgrade/downgrade and end-to-end account-flow testing before an SDK rollout.

--- a/crates/walletkit-sqlite/build.rs
+++ b/crates/walletkit-sqlite/build.rs
@@ -24,6 +24,7 @@ const EXPECTED_SHA256: &str =
 
 fn main() {
     println!("cargo:rerun-if-env-changed=DOCS_RS");
+    println!("cargo:rerun-if-changed=src/native_sqlite.c");
 
     if std::env::var_os("DOCS_RS").is_some() {
         return;
@@ -59,7 +60,7 @@ fn build_sqlite3mc() {
         );
     }
 
-    compile(&amalgamation_c, &source_dir);
+    compile(&source_dir);
 }
 
 fn download(dest: &Path) {
@@ -104,12 +105,12 @@ fn extract(zip_path: &Path, dest_dir: &Path) {
     }
 }
 
-fn compile(amalgamation_c: &Path, include_dir: &Path) {
+fn compile(include_dir: &Path) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     let mut build = cc::Build::new();
     build
-        .file(amalgamation_c)
+        .file("src/native_sqlite.c")
         .include(include_dir)
         // Core SQLite configuration
         .define("SQLITE_CORE", None)

--- a/crates/walletkit-sqlite/examples/native_link_host.c
+++ b/crates/walletkit-sqlite/examples/native_link_host.c
@@ -1,0 +1,34 @@
+#include <sqlite3.h>
+#include <stdio.h>
+
+extern int walletkit_native_link_probe(void);
+
+int main(void) {
+    sqlite3 *db = NULL;
+    sqlite3_stmt *statement = NULL;
+    if (sqlite3_open(":memory:", &db) != SQLITE_OK) {
+        fprintf(stderr, "Host SQLite open failed\n");
+        sqlite3_close(db);
+        return 1;
+    }
+    if (sqlite3_prepare_v2(db, "PRAGMA cipher", -1, &statement, NULL) != SQLITE_OK ||
+        sqlite3_step(statement) != SQLITE_DONE) {
+        fprintf(stderr, "WalletKit replaced the host's SQLite engine\n");
+        sqlite3_finalize(statement);
+        sqlite3_close(db);
+        return 1;
+    }
+    sqlite3_finalize(statement);
+    printf("Host SQLite: %s; cipher unavailable as expected\n", sqlite3_libversion());
+    int result = walletkit_native_link_probe();
+    if (sqlite3_exec(db, "CREATE TABLE host (id INTEGER); INSERT INTO host VALUES (1);",
+                     NULL, NULL, NULL) != SQLITE_OK || sqlite3_changes(db) != 1) {
+        fprintf(stderr, "Host SQLite failed after WalletKit used its own engine\n");
+        result = 1;
+    }
+    if (sqlite3_close(db) != SQLITE_OK) {
+        fprintf(stderr, "Host SQLite close failed\n");
+        result = 1;
+    }
+    return result;
+}

--- a/crates/walletkit-sqlite/examples/native_link_probe.rs
+++ b/crates/walletkit-sqlite/examples/native_link_probe.rs
@@ -1,0 +1,69 @@
+//! Native link-order regression probe using disposable, synthetic database data.
+
+use secrecy::SecretBox;
+use walletkit_sqlite::{cipher, Connection};
+
+/// Exercises encrypted storage in a host that also links an unrelated `SQLite`.
+/// Returns zero on success; reports an actionable error and returns one otherwise.
+#[no_mangle]
+pub extern "C" fn walletkit_native_link_probe() -> i32 {
+    match probe() {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("WalletKit SQLite link regression: {error}");
+            1
+        }
+    }
+}
+
+fn probe() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("encrypted.sqlite");
+    let key = SecretBox::init_with(|| [0xAB; 32]);
+
+    {
+        let conn = cipher::open_encrypted(&path, &key, false)?;
+        let cipher =
+            conn.query_row("PRAGMA cipher", &[], |row| Ok(row.column_text(0)))?;
+        if cipher != "chacha20" {
+            return Err("WalletKit did not select its chacha20 cipher".into());
+        }
+        conn.execute_batch("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('synthetic-test-record');")?;
+    }
+
+    let original_bytes = std::fs::read(&path)?;
+    if original_bytes.starts_with(b"SQLite format 3\0") {
+        return Err("encrypted database has a plaintext SQLite header".into());
+    }
+    let wrong_key = SecretBox::init_with(|| [0xCD; 32]);
+    if cipher::open_encrypted(&path, &wrong_key, false).is_ok() {
+        return Err("encrypted database accepted the wrong key".into());
+    }
+    if std::fs::read(&path)? != original_bytes {
+        return Err("failed wrong-key open modified the database".into());
+    }
+    {
+        let conn = cipher::open_encrypted(&path, &key, false)?;
+        let value = conn
+            .query_row("SELECT value FROM probe", &[], |row| Ok(row.column_text(0)))?;
+        if value != "synthetic-test-record" {
+            return Err("correct-key reopen did not preserve the record".into());
+        }
+    }
+
+    // Do not silently reset or reinterpret any pre-existing plaintext store.
+    let plaintext_path = dir.path().join("plaintext.sqlite");
+    Connection::open(&plaintext_path, false)?
+        .execute_batch("CREATE TABLE existing (value TEXT); INSERT INTO existing VALUES ('preserve-me');")?;
+    let plaintext_bytes = std::fs::read(&plaintext_path)?;
+    if cipher::open_encrypted(&plaintext_path, &key, false).is_ok() {
+        return Err("plaintext store was silently accepted as encrypted".into());
+    }
+    if std::fs::read(&plaintext_path)? != plaintext_bytes {
+        return Err("failed plaintext-store open modified existing data".into());
+    }
+    println!(
+        "PASS: encrypted reopen, wrong-key rejection, and existing-data preservation"
+    );
+    Ok(())
+}

--- a/crates/walletkit-sqlite/examples/test_native_linking.sh
+++ b/crates/walletkit-sqlite/examples/test_native_linking.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run on macOS: exercise the same static-library/system-SQLite collision as iOS.
+set -euo pipefail
+
+if [[ "$(uname -s)" != Darwin ]]; then
+  echo "This regression test requires the Apple linker and system SQLite." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$repo_root"
+profile="${1:-dev}"
+case "$profile" in
+  dev) profile_dir=debug ;;
+  release) profile_dir=release ;;
+  *) echo "Usage: bash $0 [dev|release]" >&2; exit 1 ;;
+esac
+cargo build --locked -p walletkit-sqlite --example native_link_probe --features native-link-probe --profile "$profile"
+
+target_dir="${CARGO_TARGET_DIR:-target}"
+output_dir="$target_dir/native-link-probe/$profile_dir"
+archive="$target_dir/$profile_dir/examples/libnative_link_probe.a"
+host_source="crates/walletkit-sqlite/examples/native_link_host.c"
+mkdir -p "$output_dir"
+
+# Static archive visibility matters: a hidden global symbol can still collide
+# during the final app link. The standard SQLite API must have local linkage.
+nm -g "$archive" > "$output_dir/symbols.txt" 2> "$output_dir/nm.log"
+if grep -E ' [A-Za-z] _sqlite3_' "$output_dir/symbols.txt"; then
+  echo "WalletKit still exposes or references unprefixed SQLite API symbols." >&2
+  exit 1
+fi
+
+clang "$host_source" -Wl,-dead_strip -lsqlite3 "$archive" \
+  -framework Security -framework CoreFoundation -o "$output_dir/system-first"
+"$output_dir/system-first"
+
+clang "$host_source" -Wl,-dead_strip "$archive" -lsqlite3 \
+  -framework Security -framework CoreFoundation -o "$output_dir/walletkit-first"
+"$output_dir/walletkit-first"
+
+echo "PASS: both link orders preserve separate host and WalletKit SQLite engines"

--- a/crates/walletkit-sqlite/src/ffi.rs
+++ b/crates/walletkit-sqlite/src/ffi.rs
@@ -441,13 +441,16 @@ mod raw {
     type sqlite3_stmt = c_void;
 
     extern "C" {
+        #[link_name = "walletkit_sqlite3_open_v2"]
         pub fn sqlite3_open_v2(
             filename: *const c_char,
             pp_db: *mut *mut sqlite3,
             flags: c_int,
             z_vfs: *const c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_close_v2"]
         pub fn sqlite3_close_v2(db: *mut sqlite3) -> c_int;
+        #[link_name = "walletkit_sqlite3_exec"]
         pub fn sqlite3_exec(
             db: *mut sqlite3,
             sql: *const c_char,
@@ -455,7 +458,9 @@ mod raw {
             arg: *mut c_void,
             errmsg: *mut *mut c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_free"]
         pub fn sqlite3_free(ptr: *mut c_void);
+        #[link_name = "walletkit_sqlite3_prepare_v2"]
         pub fn sqlite3_prepare_v2(
             db: *mut sqlite3,
             z_sql: *const c_char,
@@ -463,14 +468,19 @@ mod raw {
             pp_stmt: *mut *mut sqlite3_stmt,
             pz_tail: *mut *const c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_step"]
         pub fn sqlite3_step(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_reset"]
         pub fn sqlite3_reset(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_finalize"]
         pub fn sqlite3_finalize(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_int64"]
         pub fn sqlite3_bind_int64(
             stmt: *mut sqlite3_stmt,
             index: c_int,
             value: i64,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_blob"]
         pub fn sqlite3_bind_blob(
             stmt: *mut sqlite3_stmt,
             index: c_int,
@@ -478,6 +488,7 @@ mod raw {
             n: c_int,
             destructor: isize,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_text"]
         pub fn sqlite3_bind_text(
             stmt: *mut sqlite3_stmt,
             index: c_int,
@@ -485,21 +496,31 @@ mod raw {
             n: c_int,
             destructor: isize,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_null"]
         pub fn sqlite3_bind_null(stmt: *mut sqlite3_stmt, index: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_int64"]
         pub fn sqlite3_column_int64(stmt: *mut sqlite3_stmt, i_col: c_int) -> i64;
+        #[link_name = "walletkit_sqlite3_column_blob"]
         pub fn sqlite3_column_blob(
             stmt: *mut sqlite3_stmt,
             i_col: c_int,
         ) -> *const c_void;
+        #[link_name = "walletkit_sqlite3_column_bytes"]
         pub fn sqlite3_column_bytes(stmt: *mut sqlite3_stmt, i_col: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_text"]
         pub fn sqlite3_column_text(
             stmt: *mut sqlite3_stmt,
             i_col: c_int,
         ) -> *const c_char;
+        #[link_name = "walletkit_sqlite3_column_type"]
         pub fn sqlite3_column_type(stmt: *mut sqlite3_stmt, i_col: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_count"]
         pub fn sqlite3_column_count(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_errmsg"]
         pub fn sqlite3_errmsg(db: *mut sqlite3) -> *const c_char;
+        #[link_name = "walletkit_sqlite3_changes"]
         pub fn sqlite3_changes(db: *mut sqlite3) -> c_int;
+        #[link_name = "walletkit_sqlite3_last_insert_rowid"]
         pub fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> i64;
     }
 }

--- a/crates/walletkit-sqlite/src/native_sqlite.c
+++ b/crates/walletkit-sqlite/src/native_sqlite.c
@@ -1,0 +1,96 @@
+/*
+ * Keep SQLite's C API local to this translation unit. Visibility attributes alone
+ * do not prevent a static-library consumer from resolving sqlite3_* against a
+ * different SQLite implementation. Only the WalletKit-prefixed wrappers below
+ * cross the Rust FFI boundary; every handle stays with its creating engine.
+ *
+ * Compile the unchanged, checksum-verified amalgamation with the existing
+ * cipher/settings. This changes linkage only, not encryption or disk formats.
+ */
+#define SQLITE_API static
+#define SQLITE_EXTERN
+#include "sqlite3mc_amalgamation.c"
+
+int walletkit_sqlite3_open_v2(const char *filename, sqlite3 **db, int flags, const char *vfs) {
+    return sqlite3_open_v2(filename, db, flags, vfs);
+}
+
+int walletkit_sqlite3_close_v2(sqlite3 *db) {
+    return sqlite3_close_v2(db);
+}
+
+int walletkit_sqlite3_exec(sqlite3 *db, const char *sql, int (*callback)(void *, int, char **, char **), void *arg, char **error) {
+    return sqlite3_exec(db, sql, callback, arg, error);
+}
+
+void walletkit_sqlite3_free(void *pointer) {
+    sqlite3_free(pointer);
+}
+
+int walletkit_sqlite3_prepare_v2(sqlite3 *db, const char *sql, int length, sqlite3_stmt **statement, const char **tail) {
+    return sqlite3_prepare_v2(db, sql, length, statement, tail);
+}
+
+int walletkit_sqlite3_step(sqlite3_stmt *statement) {
+    return sqlite3_step(statement);
+}
+
+int walletkit_sqlite3_reset(sqlite3_stmt *statement) {
+    return sqlite3_reset(statement);
+}
+
+int walletkit_sqlite3_finalize(sqlite3_stmt *statement) {
+    return sqlite3_finalize(statement);
+}
+
+int walletkit_sqlite3_bind_int64(sqlite3_stmt *statement, int index, sqlite3_int64 value) {
+    return sqlite3_bind_int64(statement, index, value);
+}
+
+int walletkit_sqlite3_bind_blob(sqlite3_stmt *statement, int index, const void *value, int length, sqlite3_destructor_type destructor) {
+    return sqlite3_bind_blob(statement, index, value, length, destructor);
+}
+
+int walletkit_sqlite3_bind_text(sqlite3_stmt *statement, int index, const char *value, int length, sqlite3_destructor_type destructor) {
+    return sqlite3_bind_text(statement, index, value, length, destructor);
+}
+
+int walletkit_sqlite3_bind_null(sqlite3_stmt *statement, int index) {
+    return sqlite3_bind_null(statement, index);
+}
+
+sqlite3_int64 walletkit_sqlite3_column_int64(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_int64(statement, column);
+}
+
+const void * walletkit_sqlite3_column_blob(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_blob(statement, column);
+}
+
+int walletkit_sqlite3_column_bytes(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_bytes(statement, column);
+}
+
+const unsigned char * walletkit_sqlite3_column_text(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_text(statement, column);
+}
+
+int walletkit_sqlite3_column_type(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_type(statement, column);
+}
+
+int walletkit_sqlite3_column_count(sqlite3_stmt *statement) {
+    return sqlite3_column_count(statement);
+}
+
+const char * walletkit_sqlite3_errmsg(sqlite3 *db) {
+    return sqlite3_errmsg(db);
+}
+
+int walletkit_sqlite3_changes(sqlite3 *db) {
+    return sqlite3_changes(db);
+}
+
+sqlite3_int64 walletkit_sqlite3_last_insert_rowid(sqlite3 *db) {
+    return sqlite3_last_insert_rowid(db);
+}


### PR DESCRIPTION
## Why

WalletKit's native static library exports and references generic `sqlite3_*` symbols. When an Apple host also links system SQLite, link order can select the host's unencrypted engine for WalletKit's calls. A synthetic native reproducer against unchanged 0.22.0 produces:

```text
vault db error: sqlite error 101: query returned no rows
```

The missing row is from `PRAGMA cipher`: system SQLite does not implement it. Reversing link order selects sqlite3mc but can replace the host's SQLite too. Isolated Rust unit tests do not catch this.

Removing cipher validation is not a fix: a disposable experiment without the check initialized successfully but wrote plaintext SQLite and accepted an incorrect key. No real wallet data was used or inspected.

## What

- Compile the existing checksum-verified sqlite3mc amalgamation with its SQLite API local to one C translation unit. Keep the existing SQLite version and compilation settings.
- Expose 21 `walletkit_sqlite3_*` wrappers and bind the existing native Rust FFI to those names. Handles and allocations stay with the engine that created them, independent of host link order.
- Keep cipher validation, key handling, and on-disk formats unchanged. WASM bindings are unchanged. No dependency upgrades, activity backport, migration, vault deletion, or identity reset is included.
- Add an opt-in native static-library test host and scripts for debug/release regressions. **CI wiring is not included:** the available GitHub OAuth credential rejected workflow changes. A maintainer can add both documented commands to the macOS Swift job with a bounded step timeout; until then these link-order tests must be run manually.
- Document the linkage boundary and the requirement to add a prefixed wrapper for future native FFI functions. This isolates the SQLite API; it does not claim to namespace every third-party crypto symbol in the amalgamation.

## Test

Passed locally on this PR's source, with the pinned Rust 1.94.1 toolchain:

- `cargo test -p walletkit-sqlite -p walletkit-db --locked`: 10 SQLite tests and 11 database tests pass.
- `bash crates/walletkit-sqlite/examples/test_native_linking.sh`: passes.
- `bash crates/walletkit-sqlite/examples/test_native_linking.sh release`: passes with the workspace's optimized/LTO profile.
- `cargo clippy -p walletkit-sqlite --all-targets --all-features --locked -- -D warnings`: passes.
- `cargo fmt --all -- --check`, ShellCheck, and `git diff --check`: pass.
- Downstream required `make swiftlint-changed`: no changed Swift files.

The native tests inspect defined and undefined global archive symbols, link Apple's SQLite before and after WalletKit with dead stripping enabled, and check that the host retains its own engine. They verify encrypted persistence/reopening, wrong-key rejection, and byte preservation after failed wrong-key and plaintext-store opens. All data and keys are synthetic and temporary.

Additional supporting validation, **on a separate 0.21.4 activity-backport candidate using the same isolation mechanism, not this PR head**: all three release iOS archive slices built; the ARM simulator archive passed an engine-isolation probe in both link orders; a downstream World ID app build succeeded. This does not establish end-to-end account compatibility for this PR.

The local linker emits a nonfatal macOS deployment-target warning (26.5 archive versus 26.0 host); all probes pass. Linux/Android/browser CI and a full Swift build of this PR head remain to be checked.

## Risk

**Security-sensitive native storage/dependency change; keep this PR draft until deliberate review.** Encryption parameters and serialization are not intentionally changed, but this changes which SQLite engine actually executes in host apps.

- [ ] Explicit human acknowledgment and approval for GUARD-01 (cryptography), GUARD-02 (storage preservation), and GUARD-06 (security dependency build/linkage).
- [ ] Assess whether any deployed app previously wrote stores through the wrong engine. Existing plaintext stores are preserved and rejected; this PR does not define a recovery/migration policy. Do not delete or reset them to make initialization succeed.
- [ ] Validate existing encrypted-store upgrade/downgrade behavior and real initialization, proof, and credential-activity flows before distribution.
- [ ] Wire both native regression profiles into macOS CI and verify cross-platform and Swift CI, then use a narrow internal rollout with the previous SDK artifact retained and a tested, data-preserving rollback path. An activity/UI flag cannot undo a shared SDK linkage change.
