### PR TITLE
Loosen the cipher restriction

### DIFF
--- a/crates/walletkit-sqlite/src/cipher.rs
+++ b/crates/walletkit-sqlite/src/cipher.rs
@@ -104,13 +104,21 @@ fn configure_connection(
     Ok(())
 }
 
-/// Selects and verifies the on-disk cipher before the key activates it.
+/// Selects the on-disk cipher and verifies it whenever `SQLite` reports one.
 ///
 /// Pinning the cipher prevents a future compile-time default change from
 /// silently creating or interpreting databases with a different format.
+///
+/// Where sqlite3mc's pragmas are not registered, `PRAGMA cipher` is an
+/// unrecognized pragma and yields no row. That is accepted rather than
+/// failing the open, matching the behaviour of releases before 0.22.0.
 fn ensure_cipher(conn: &Connection) -> DbResult<()> {
     conn.execute_batch(&format!("PRAGMA cipher = '{CIPHER_CHACHA20}';"))?;
-    let actual = conn.query_row("PRAGMA cipher;", &[], |row| Ok(row.column_text(0)))?;
+    let Some(actual) =
+        conn.query_row_optional("PRAGMA cipher;", &[], |row| Ok(row.column_text(0)))?
+    else {
+        return Ok(());
+    };
     if actual.eq_ignore_ascii_case(CIPHER_CHACHA20) {
         Ok(())
     } else {
@@ -400,6 +408,21 @@ mod tests {
     use crate::test_utils::init_sqlite;
     use crate::Connection;
     use secrecy::SecretBox;
+
+    #[test]
+    fn unrecognized_pragma_yields_no_row() {
+        init_sqlite();
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        let result = conn
+            .query_row_optional("PRAGMA walletkit_not_a_real_pragma;", &[], |row| {
+                Ok(row.column_text(0))
+            })
+            .expect("query");
+        assert!(
+            result.is_none(),
+            "an unrecognized pragma must yield no row; ensure_cipher relies on this"
+        );
+    }
 
     #[test]
     fn test_cipher_encrypted_round_trip() {


### PR DESCRIPTION
v0.22.0 introduced a protection to ensure the vault data is encrypted. Due to some linker issues with Apple's libsqlite vs Rust's sqlite3mc, it seems the vault data is, unfortunately, unencrypted today.

I am loosening this restriction temporarily back to a state that allows the unencrypted vault because we need a migration. New vaults would be okay, but the existing unencrypted vaults become inaccessible with the cipher ensure as it was.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Weakens a guard that ensured ChaCha20 via sqlite3mc, so mis-linked or plaintext vaults may open without failing cipher verification until encryption is restored.
> 
> **Overview**
> **Relaxes sqlite3mc cipher enforcement** so encrypted DB opens no longer fail when `PRAGMA cipher` is not implemented (e.g. Apple builds using system SQLite without sqlite3mc pragmas).
> 
> `ensure_cipher` still sets `PRAGMA cipher = 'chacha20'` and **only errors** if SQLite returns a cipher name that disagrees; if the read returns **no row** (unrecognized pragma), open continues—restoring pre-0.22.0 behavior so existing unencrypted vaults stay reachable while a migration path is prepared.
> 
> Adds `unrecognized_pragma_yields_no_row` to lock in the “no row” semantics that this branch depends on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a13f8defbd5c45f7c9f37c6b284ebd6a441fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->