### PR TITLE
fix(db): isolate native SQLite on v0.21.4

### DIFF
--- a/SQLITE_ISOLATION_BACKPORT.md
+++ b/SQLITE_ISOLATION_BACKPORT.md
@@ -1,0 +1,58 @@
+# Native SQLite isolation for v0.21.4
+
+This candidate starts at `v0.21.4` (`f0e3795`) and changes only the native
+SQLite linkage and engine validation, with regression tests and documentation.
+Credential activity history is backported separately in PR #533.
+
+Native apps can link both WalletKit's bundled sqlite3mc and another SQLite
+implementation. The original generic `sqlite3_*` symbols allow host link order
+to select the wrong engine. v0.21.4 does not check cipher availability, so
+successful initialization alone does not establish that encryption is active.
+
+The fix gives the bundled SQLite API internal C linkage and exposes the 21
+`walletkit_sqlite3_*` wrappers used by Rust. Every SQLite handle and allocation
+stays with its creating engine. The encrypted open path verifies the ChaCha20
+cipher before applying a key or initializing a schema.
+
+The SQLite amalgamation, build settings, dependency lockfile, workspace
+manifest, toolchain pins, cipher parameters, key encoding, and vault/envelope
+formats remain those of v0.21.4. Future native FFI functions must add a matching
+prefixed C wrapper. This isolates SQLite's API, not every third-party crypto
+symbol in the amalgamation.
+
+## Validation
+
+On macOS with the pinned Rust toolchain, run:
+
+```sh
+cargo test -p walletkit-db --locked
+cargo clippy -p walletkit-db --all-targets --locked -- -D warnings
+bash crates/walletkit-db/examples/test_native_linking.sh
+bash crates/walletkit-db/examples/test_native_linking.sh release
+```
+
+The probes check defined and undefined global archive symbols, link Apple's
+SQLite before and after WalletKit with dead stripping enabled, and verify
+independent host and WalletKit engines. They test encrypted persistence and
+reopening, wrong-key rejection, and unchanged file bytes after failed
+wrong-key and plaintext-store opens. All data and keys are synthetic.
+
+Results from the earlier combined activity/SQLite candidate are not results
+for this fix-only revision. The PR description records validation after the
+split. These probes do not replace testing existing stores and real app flows.
+
+The new linking tests currently run manually. GitHub rejected workflow edits
+with the available push credential, so the CI workflow remains unchanged.
+Before release, a maintainer with workflow-write access should add both
+profiles to the macOS Swift job with a bounded step timeout.
+
+## Before distribution
+
+Review the native storage/encryption linkage change and test existing
+encrypted-store upgrade/downgrade and real initialization/proof flows. The
+low-level encrypted-open checks preserve and reject plaintext stores; recovery
+policy and host-level error handling require separate review.
+
+The source retains v0.21.4 version numbers. Assign a distinct reviewed version
+before publishing, use a narrow internal rollout, and retain the prior SDK
+artifact with a tested data-preserving rollback path.

--- a/crates/walletkit-db/Cargo.toml
+++ b/crates/walletkit-db/Cargo.toml
@@ -41,3 +41,7 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
+
+[[example]]
+name = "native_link_probe"
+crate-type = ["staticlib"]

--- a/crates/walletkit-db/build.rs
+++ b/crates/walletkit-db/build.rs
@@ -24,6 +24,7 @@ const EXPECTED_SHA256: &str =
 
 fn main() {
     println!("cargo:rerun-if-env-changed=DOCS_RS");
+    println!("cargo:rerun-if-changed=src/native_sqlite.c");
 
     if std::env::var_os("DOCS_RS").is_some() {
         return;
@@ -59,7 +60,7 @@ fn build_sqlite3mc() {
         );
     }
 
-    compile(&amalgamation_c, &source_dir);
+    compile(&source_dir);
 }
 
 fn download(dest: &Path) {
@@ -104,12 +105,12 @@ fn extract(zip_path: &Path, dest_dir: &Path) {
     }
 }
 
-fn compile(amalgamation_c: &Path, include_dir: &Path) {
+fn compile(include_dir: &Path) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     let mut build = cc::Build::new();
     build
-        .file(amalgamation_c)
+        .file("src/native_sqlite.c")
         .include(include_dir)
         // Core SQLite configuration
         .define("SQLITE_CORE", None)

--- a/crates/walletkit-db/examples/native_link_host.c
+++ b/crates/walletkit-db/examples/native_link_host.c
@@ -1,0 +1,33 @@
+#include <sqlite3.h>
+#include <stdio.h>
+
+extern int walletkit_native_link_probe(void);
+
+int main(void) {
+    sqlite3 *db = NULL;
+    sqlite3_stmt *statement = NULL;
+    if (sqlite3_open(":memory:", &db) != SQLITE_OK) {
+        fprintf(stderr, "Host SQLite open failed\n");
+        return 1;
+    }
+    if (sqlite3_prepare_v2(db, "PRAGMA cipher", -1, &statement, NULL) != SQLITE_OK ||
+        sqlite3_step(statement) != SQLITE_DONE) {
+        fprintf(stderr, "WalletKit replaced the host's SQLite engine\n");
+        sqlite3_finalize(statement);
+        sqlite3_close(db);
+        return 1;
+    }
+    sqlite3_finalize(statement);
+    printf("Host SQLite: %s; cipher unavailable as expected\n", sqlite3_libversion());
+    int result = walletkit_native_link_probe();
+    if (sqlite3_exec(db, "CREATE TABLE host (id INTEGER); INSERT INTO host VALUES (1);",
+                     NULL, NULL, NULL) != SQLITE_OK || sqlite3_changes(db) != 1) {
+        fprintf(stderr, "Host SQLite failed after WalletKit used its own engine\n");
+        result = 1;
+    }
+    if (sqlite3_close(db) != SQLITE_OK) {
+        fprintf(stderr, "Host SQLite close failed\n");
+        result = 1;
+    }
+    return result;
+}

--- a/crates/walletkit-db/examples/native_link_probe.rs
+++ b/crates/walletkit-db/examples/native_link_probe.rs
@@ -1,0 +1,69 @@
+//! Native link-order regression probe using disposable, synthetic database data.
+
+use secrecy::SecretBox;
+use walletkit_db::{cipher, Connection};
+
+/// Exercises encrypted storage in a host that also links an unrelated `SQLite`.
+/// Returns zero on success; reports an actionable error and returns one otherwise.
+#[no_mangle]
+pub extern "C" fn walletkit_native_link_probe() -> i32 {
+    match probe() {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("WalletKit SQLite link regression: {error}");
+            1
+        }
+    }
+}
+
+fn probe() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("encrypted.sqlite");
+    let key = SecretBox::init_with(|| [0xAB; 32]);
+
+    {
+        let conn = cipher::open_encrypted(&path, &key, false)?;
+        let cipher =
+            conn.query_row("PRAGMA cipher", &[], |row| Ok(row.column_text(0)))?;
+        if cipher != "chacha20" {
+            return Err("WalletKit did not select its chacha20 cipher".into());
+        }
+        conn.execute_batch("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('synthetic-test-record');")?;
+    }
+
+    let original_bytes = std::fs::read(&path)?;
+    if original_bytes.starts_with(b"SQLite format 3\0") {
+        return Err("encrypted database has a plaintext SQLite header".into());
+    }
+    let wrong_key = SecretBox::init_with(|| [0xCD; 32]);
+    if cipher::open_encrypted(&path, &wrong_key, false).is_ok() {
+        return Err("encrypted database accepted the wrong key".into());
+    }
+    if std::fs::read(&path)? != original_bytes {
+        return Err("failed wrong-key open modified the database".into());
+    }
+    {
+        let conn = cipher::open_encrypted(&path, &key, false)?;
+        let value = conn
+            .query_row("SELECT value FROM probe", &[], |row| Ok(row.column_text(0)))?;
+        if value != "synthetic-test-record" {
+            return Err("correct-key reopen did not preserve the record".into());
+        }
+    }
+
+    // Do not silently reset or reinterpret any pre-existing plaintext store.
+    let plaintext_path = dir.path().join("plaintext.sqlite");
+    Connection::open(&plaintext_path, false)?
+        .execute_batch("CREATE TABLE existing (value TEXT); INSERT INTO existing VALUES ('preserve-me');")?;
+    let plaintext_bytes = std::fs::read(&plaintext_path)?;
+    if cipher::open_encrypted(&plaintext_path, &key, false).is_ok() {
+        return Err("plaintext store was silently accepted as encrypted".into());
+    }
+    if std::fs::read(&plaintext_path)? != plaintext_bytes {
+        return Err("failed plaintext-store open modified existing data".into());
+    }
+    println!(
+        "PASS: encrypted reopen, wrong-key rejection, and existing-data preservation"
+    );
+    Ok(())
+}

--- a/crates/walletkit-db/examples/test_native_linking.sh
+++ b/crates/walletkit-db/examples/test_native_linking.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run on macOS: exercise the same static-library/system-SQLite collision as iOS.
+set -euo pipefail
+
+if [[ "$(uname -s)" != Darwin ]]; then
+  echo "This regression test requires the Apple linker and system SQLite." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$repo_root"
+profile="${1:-dev}"
+case "$profile" in
+  dev) profile_dir=debug ;;
+  release) profile_dir=release ;;
+  *) echo "Usage: bash $0 [dev|release]" >&2; exit 1 ;;
+esac
+cargo build --locked -p walletkit-db --example native_link_probe --profile "$profile"
+
+target_dir="${CARGO_TARGET_DIR:-target}"
+output_dir="$target_dir/native-link-probe/$profile_dir"
+archive="$target_dir/$profile_dir/examples/libnative_link_probe.a"
+host_source="crates/walletkit-db/examples/native_link_host.c"
+mkdir -p "$output_dir"
+
+# Static archive visibility matters: a hidden global symbol can still collide
+# during the final app link. The standard SQLite API must have local linkage.
+nm -g "$archive" > "$output_dir/symbols.txt" 2> "$output_dir/nm.log"
+if grep -E ' [A-Za-z] _sqlite3_' "$output_dir/symbols.txt"; then
+  echo "WalletKit still exposes or references unprefixed SQLite API symbols." >&2
+  exit 1
+fi
+
+clang "$host_source" -Wl,-dead_strip -lsqlite3 "$archive" \
+  -framework Security -framework CoreFoundation -o "$output_dir/system-first"
+"$output_dir/system-first"
+
+clang "$host_source" -Wl,-dead_strip "$archive" -lsqlite3 \
+  -framework Security -framework CoreFoundation -o "$output_dir/walletkit-first"
+"$output_dir/walletkit-first"
+
+echo "PASS: both link orders preserve separate host and WalletKit SQLite engines"

--- a/crates/walletkit-db/src/native_sqlite.c
+++ b/crates/walletkit-db/src/native_sqlite.c
@@ -1,0 +1,96 @@
+/*
+ * Keep SQLite's C API local to this translation unit. Visibility attributes alone
+ * do not prevent a static-library consumer from resolving sqlite3_* against a
+ * different SQLite implementation. Only the WalletKit-prefixed wrappers below
+ * cross the Rust FFI boundary; every handle stays with its creating engine.
+ *
+ * Compile the unchanged, checksum-verified amalgamation with the existing
+ * cipher/settings. This changes linkage only, not encryption or disk formats.
+ */
+#define SQLITE_API static
+#define SQLITE_EXTERN
+#include "sqlite3mc_amalgamation.c"
+
+int walletkit_sqlite3_open_v2(const char *filename, sqlite3 **db, int flags, const char *vfs) {
+    return sqlite3_open_v2(filename, db, flags, vfs);
+}
+
+int walletkit_sqlite3_close_v2(sqlite3 *db) {
+    return sqlite3_close_v2(db);
+}
+
+int walletkit_sqlite3_exec(sqlite3 *db, const char *sql, int (*callback)(void *, int, char **, char **), void *arg, char **error) {
+    return sqlite3_exec(db, sql, callback, arg, error);
+}
+
+void walletkit_sqlite3_free(void *pointer) {
+    sqlite3_free(pointer);
+}
+
+int walletkit_sqlite3_prepare_v2(sqlite3 *db, const char *sql, int length, sqlite3_stmt **statement, const char **tail) {
+    return sqlite3_prepare_v2(db, sql, length, statement, tail);
+}
+
+int walletkit_sqlite3_step(sqlite3_stmt *statement) {
+    return sqlite3_step(statement);
+}
+
+int walletkit_sqlite3_reset(sqlite3_stmt *statement) {
+    return sqlite3_reset(statement);
+}
+
+int walletkit_sqlite3_finalize(sqlite3_stmt *statement) {
+    return sqlite3_finalize(statement);
+}
+
+int walletkit_sqlite3_bind_int64(sqlite3_stmt *statement, int index, sqlite3_int64 value) {
+    return sqlite3_bind_int64(statement, index, value);
+}
+
+int walletkit_sqlite3_bind_blob(sqlite3_stmt *statement, int index, const void *value, int length, sqlite3_destructor_type destructor) {
+    return sqlite3_bind_blob(statement, index, value, length, destructor);
+}
+
+int walletkit_sqlite3_bind_text(sqlite3_stmt *statement, int index, const char *value, int length, sqlite3_destructor_type destructor) {
+    return sqlite3_bind_text(statement, index, value, length, destructor);
+}
+
+int walletkit_sqlite3_bind_null(sqlite3_stmt *statement, int index) {
+    return sqlite3_bind_null(statement, index);
+}
+
+sqlite3_int64 walletkit_sqlite3_column_int64(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_int64(statement, column);
+}
+
+const void * walletkit_sqlite3_column_blob(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_blob(statement, column);
+}
+
+int walletkit_sqlite3_column_bytes(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_bytes(statement, column);
+}
+
+const unsigned char * walletkit_sqlite3_column_text(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_text(statement, column);
+}
+
+int walletkit_sqlite3_column_type(sqlite3_stmt *statement, int column) {
+    return sqlite3_column_type(statement, column);
+}
+
+int walletkit_sqlite3_column_count(sqlite3_stmt *statement) {
+    return sqlite3_column_count(statement);
+}
+
+const char * walletkit_sqlite3_errmsg(sqlite3 *db) {
+    return sqlite3_errmsg(db);
+}
+
+int walletkit_sqlite3_changes(sqlite3 *db) {
+    return sqlite3_changes(db);
+}
+
+sqlite3_int64 walletkit_sqlite3_last_insert_rowid(sqlite3 *db) {
+    return sqlite3_last_insert_rowid(db);
+}

--- a/crates/walletkit-db/src/sqlite/cipher.rs
+++ b/crates/walletkit-db/src/sqlite/cipher.rs
@@ -12,19 +12,22 @@
 //! 1. **Open** -- `sqlite3_open_v2` creates or opens the database file.
 //!    At this point the file is opaque (encrypted) and no data can be read.
 //!
-//! 2. **Key** -- `PRAGMA key = "x'<hex>'"` passes the 32-byte
+//! 2. **Cipher** -- select and verify the `ChaCha20` cipher before applying a
+//!    key. A host-provided `SQLite` engine without encryption must fail closed.
+//!
+//! 3. **Key** -- `PRAGMA key = "x'<hex>'"` passes the 32-byte
 //!    `K_intermediate` (hex-encoded) to `sqlite3mc` as a raw key. The `x'...'`
 //!    syntax tells `sqlite3mc` to use the bytes directly as the page-encryption
 //!    key, bypassing the passphrase KDF (PBKDF2-SHA256) that a plain-string
 //!    key would otherwise be run through. After this point, every page read
 //!    from disk is decrypted and every page written to disk is encrypted.
 //!
-//! 3. **Verify** -- We immediately read from `sqlite_master` to confirm
+//! 4. **Verify** -- We immediately read from `sqlite_master` to confirm
 //!    the key is correct. If the key is wrong, `sqlite3mc` returns
 //!    `SQLITE_NOTADB` because the decrypted page header won't match the
 //!    expected `SQLite` magic bytes. We surface this as a clear error.
 //!
-//! 4. **Configure** -- WAL journal mode and `synchronous=FULL` are set for
+//! 5. **Configure** -- WAL journal mode and `synchronous=FULL` are set for
 //!    crash consistency. Foreign keys are enabled.
 //!
 //! The default cipher is **ChaCha20-Poly1305** (authenticated encryption).
@@ -41,8 +44,8 @@ use super::error::{DbResult, Error};
 
 /// Opens a database, applies the encryption key, and configures the connection.
 ///
-/// This is the standard open sequence for encrypted databases: open -> key ->
-/// verify -> configure (WAL + foreign keys).
+/// This is the standard open sequence for encrypted databases: open -> cipher ->
+/// key -> verify -> configure (WAL + foreign keys).
 ///
 /// See the [module-level documentation](self) for the full encryption flow.
 ///
@@ -55,6 +58,20 @@ pub fn open_encrypted(
     read_only: bool,
 ) -> DbResult<Connection> {
     let conn = Connection::open(path, read_only)?;
+    // A host application can link another SQLite implementation. Fail before
+    // applying a key or writing a schema if the encrypted engine is unavailable.
+    conn.execute_batch("PRAGMA cipher = 'chacha20';")?;
+    let cipher =
+        conn.query_row_optional("PRAGMA cipher;", &[], |row| Ok(row.column_text(0)))?;
+    if !cipher
+        .as_deref()
+        .is_some_and(|name| name.eq_ignore_ascii_case("chacha20"))
+    {
+        return Err(Error::new(
+            -1,
+            "required sqlite3mc chacha20 cipher is unavailable; verify WalletKit SQLite symbol isolation",
+        ));
+    }
     apply_key(&conn, k_intermediate)?;
     configure_connection(&conn)?;
     Ok(conn)

--- a/crates/walletkit-db/src/sqlite/ffi.rs
+++ b/crates/walletkit-db/src/sqlite/ffi.rs
@@ -436,13 +436,16 @@ mod raw {
     type sqlite3_stmt = c_void;
 
     extern "C" {
+        #[link_name = "walletkit_sqlite3_open_v2"]
         pub fn sqlite3_open_v2(
             filename: *const c_char,
             pp_db: *mut *mut sqlite3,
             flags: c_int,
             z_vfs: *const c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_close_v2"]
         pub fn sqlite3_close_v2(db: *mut sqlite3) -> c_int;
+        #[link_name = "walletkit_sqlite3_exec"]
         pub fn sqlite3_exec(
             db: *mut sqlite3,
             sql: *const c_char,
@@ -450,7 +453,9 @@ mod raw {
             arg: *mut c_void,
             errmsg: *mut *mut c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_free"]
         pub fn sqlite3_free(ptr: *mut c_void);
+        #[link_name = "walletkit_sqlite3_prepare_v2"]
         pub fn sqlite3_prepare_v2(
             db: *mut sqlite3,
             z_sql: *const c_char,
@@ -458,14 +463,19 @@ mod raw {
             pp_stmt: *mut *mut sqlite3_stmt,
             pz_tail: *mut *const c_char,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_step"]
         pub fn sqlite3_step(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_reset"]
         pub fn sqlite3_reset(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_finalize"]
         pub fn sqlite3_finalize(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_int64"]
         pub fn sqlite3_bind_int64(
             stmt: *mut sqlite3_stmt,
             index: c_int,
             value: i64,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_blob"]
         pub fn sqlite3_bind_blob(
             stmt: *mut sqlite3_stmt,
             index: c_int,
@@ -473,6 +483,7 @@ mod raw {
             n: c_int,
             destructor: isize,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_text"]
         pub fn sqlite3_bind_text(
             stmt: *mut sqlite3_stmt,
             index: c_int,
@@ -480,21 +491,31 @@ mod raw {
             n: c_int,
             destructor: isize,
         ) -> c_int;
+        #[link_name = "walletkit_sqlite3_bind_null"]
         pub fn sqlite3_bind_null(stmt: *mut sqlite3_stmt, index: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_int64"]
         pub fn sqlite3_column_int64(stmt: *mut sqlite3_stmt, i_col: c_int) -> i64;
+        #[link_name = "walletkit_sqlite3_column_blob"]
         pub fn sqlite3_column_blob(
             stmt: *mut sqlite3_stmt,
             i_col: c_int,
         ) -> *const c_void;
+        #[link_name = "walletkit_sqlite3_column_bytes"]
         pub fn sqlite3_column_bytes(stmt: *mut sqlite3_stmt, i_col: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_text"]
         pub fn sqlite3_column_text(
             stmt: *mut sqlite3_stmt,
             i_col: c_int,
         ) -> *const c_char;
+        #[link_name = "walletkit_sqlite3_column_type"]
         pub fn sqlite3_column_type(stmt: *mut sqlite3_stmt, i_col: c_int) -> c_int;
+        #[link_name = "walletkit_sqlite3_column_count"]
         pub fn sqlite3_column_count(stmt: *mut sqlite3_stmt) -> c_int;
+        #[link_name = "walletkit_sqlite3_errmsg"]
         pub fn sqlite3_errmsg(db: *mut sqlite3) -> *const c_char;
+        #[link_name = "walletkit_sqlite3_changes"]
         pub fn sqlite3_changes(db: *mut sqlite3) -> c_int;
+        #[link_name = "walletkit_sqlite3_last_insert_rowid"]
         pub fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> i64;
     }
 }


### PR DESCRIPTION
Prevent native WalletKit **v0.21.4** from resolving SQLite calls to a host app's unrelated SQLite engine. The original generic `sqlite3_*` symbols allow link order to select the wrong engine; v0.21.4 also lacks a cipher-availability check, so successful initialization does not establish that encryption is active.

This PR targets `codex/backport-base-v0.21.4`, pinned to release commit `f0e3795d31985b839d372fbd19a6f92b7bda6a0d`. It is independent of the activity backport in #533. PR #532 separately addresses current `main`.

## Changes

- Give the bundled SQLite API internal C linkage and expose 21 WalletKit-prefixed wrappers for Rust. Keep handles and allocations within their creating engine.
- Select and verify the ChaCha20 cipher before applying a database key or initializing a schema.
- Add debug/release native hosts that check defined and undefined global SQLite symbols and exercise both library orders with Apple's SQLite and dead stripping enabled.
- Check independent engines, encrypted persistence/reopening, wrong-key rejection, and preservation of existing file bytes after failed wrong-key and plaintext-store opens, using synthetic data only.

SQLite source/version, compilation settings, encryption parameters, key encoding, vault/envelope formats, dependency lockfile, workspace manifest, and toolchain pins remain those of v0.21.4. This PR contains no credential activity changes or other 0.22.0 functionality.

## Validation

- `cargo test -p walletkit-db --locked`: all 20 tests pass, including frozen envelope bytes/content IDs and encrypted storage tests.
- Debug and optimized release native linking regressions pass in both library orders.
- Rust formatting, ShellCheck, and `git diff --check` pass.
- `cargo clippy -p walletkit-db --all-targets --locked -- -D warnings`: passes.

The local Apple linker emits a nonfatal deployment-target warning (26.5 archive versus 26.0 host). Validation ran in a separate Git worktree using the repository-pinned Rust 1.94.1 toolchain; Nix is unavailable and the Docker daemon is not running.

## Review and release

Keep draft for native storage/encryption review. Verify existing encrypted-store upgrade/downgrade behavior and real initialization/proof flows before distribution. The low-level encrypted-open checks preserve and reject plaintext stores; host-level recovery/error handling and any data migration require separate review.

The linking probes remain manual: GitHub rejected workflow edits with the available push credential. Add both commands in `SQLITE_ISOLATION_BACKPORT.md` to macOS CI with a bounded timeout before release. Cross-platform CI and a full Swift build of this revision remain to be checked.

Assign a distinct reviewed version before publishing, use a narrow internal rollout, and retain the prior SDK artifact with a tested data-preserving rollback path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes native encrypted-storage linkage and fail-closed cipher validation; mis-linking or regressions could break encryption or corrupt host SQLite behavior on iOS/macOS.
> 
> **Overview**
> Backports a **v0.21.4** fix so WalletKit’s bundled sqlite3mc no longer shares unprefixed `sqlite3_*` symbols with a host app’s SQLite. Native builds compile the amalgamation through `native_sqlite.c` with **internal linkage** and route Rust FFI through 21 **`walletkit_sqlite3_*`** wrappers; `ffi.rs` binds those symbols explicitly.
> 
> **Encrypted open** now selects and verifies **ChaCha20** via `PRAGMA cipher` before applying a key, failing closed if the wrong engine is linked (v0.21.4 previously could “open” without proving encryption).
> 
> Adds **macOS native linking regressions**: a staticlib probe (`native_link_probe`), a C host that links Apple SQLite in both orders, symbol checks with `nm`, and synthetic tests for encrypted round-trip, wrong-key rejection, and unchanged bytes on failed opens. Documents validation in `SQLITE_ISOLATION_BACKPORT.md`. Amalgamation version, cipher settings, and on-disk formats are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de9a975edbc60fa30e655577ef65b33dc565ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->