### PR TITLE
chore: bump maintenance version to 0.21.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8216,7 +8216,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "uniffi",
 ]
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "uniffi",
  "walletkit-core",
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-cli"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "alloy-core",
  "base64 0.22.1",
@@ -8478,7 +8478,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-core"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "alloy",
  "alloy-core",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-db"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "cc",
  "ciborium",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "walletkit-testkit"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "alloy",
  "alloy-core",
@@ -9254,7 +9254,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "clap",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.21.4"
+version = "0.21.5"
 license = "MIT"
 edition = "2021"
 authors = ["World Contributors"]
@@ -83,8 +83,8 @@ world-id-core = { version = "0.14", default-features = false }
 world-id-proof = { version = "0.14", default-features = false }
 
 # internal
-walletkit-core = { version = "0.21.4", path = "crates/walletkit-core", default-features = false }
-walletkit-db = { version = "0.21.4", path = "crates/walletkit-db" }
+walletkit-core = { version = "0.21.5", path = "crates/walletkit-core", default-features = false }
+walletkit-db = { version = "0.21.5", path = "crates/walletkit-db" }
 # Unpublished test helpers
 walletkit-testkit = { path = "crates/walletkit-testkit" }
 


### PR DESCRIPTION
Bump the workspace version and internal crate dependency versions from `0.21.4` to `0.21.5`, with matching workspace-package entries in `Cargo.lock`.

Targets `codex/backport-base-v0.21.4` for the maintenance release. This PR changes only `Cargo.toml` and `Cargo.lock`; it adds no fixes or workflow changes.

Validation: offline, locked Cargo metadata confirms all workspace packages are `0.21.5`; `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata update with no runtime or behavioral code changes.
> 
> **Overview**
> This PR bumps the WalletKit workspace from **0.21.4** to **0.21.5** for a maintenance release on the v0.21.4 backport line.
> 
> Changes are limited to **`Cargo.toml`** and **`Cargo.lock`**: the `[workspace.package]` version, internal path dependencies (`walletkit-core`, `walletkit-db`), and matching lockfile entries for workspace crates (`walletkit`, `walletkit-cli`, `walletkit-core`, `walletkit-db`, `walletkit-testkit`, `uniffi-bindgen`, `xtask`). No source, workflow, or dependency version changes beyond the patch release number.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2175b55c8bd14b820bb33605ba1abe34d7a5d6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->